### PR TITLE
fix: improve node package structure

### DIFF
--- a/.github/workflows/publish-node-sdk.yml
+++ b/.github/workflows/publish-node-sdk.yml
@@ -132,9 +132,13 @@ jobs:
         run: |
           set -euo pipefail
           # Map: <go-arch> → <node-arch>
-          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
+          # bash 3.2 (macOS default) doesn't support associative arrays;
+          # use a case statement so this is portable to both runners.
           for GOARCH in amd64 arm64; do
-            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            case "$GOARCH" in
+              amd64) NODEARCH=x64   ;;
+              arm64) NODEARCH=arm64 ;;
+            esac
             ARCHIVE="/tmp/pilot-release/pilot-linux-${GOARCH}.tar.gz"
             BIN_DIR="sdk/node/packages/linux-${NODEARCH}/bin"
             rm -rf "$BIN_DIR" && mkdir -p "$BIN_DIR"
@@ -156,10 +160,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
           LDFLAGS="-s -w -X main.version=${release_tag}"
           for GOARCH in amd64 arm64; do
-            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            case "$GOARCH" in
+              amd64) NODEARCH=x64   ;;
+              arm64) NODEARCH=arm64 ;;
+            esac
             BIN_DIR="sdk/node/packages/linux-${NODEARCH}/bin"
             CC_OVERRIDE=""
             if [ "$GOARCH" = "arm64" ]; then
@@ -268,9 +274,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
+          # bash 3.2 (macOS default) doesn't support associative arrays;
+          # use a case statement so this is portable to both runners.
           for GOARCH in amd64 arm64; do
-            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            case "$GOARCH" in
+              amd64) NODEARCH=x64   ;;
+              arm64) NODEARCH=arm64 ;;
+            esac
             ARCHIVE="/tmp/pilot-release/pilot-darwin-${GOARCH}.tar.gz"
             BIN_DIR="sdk/node/packages/darwin-${NODEARCH}/bin"
             rm -rf "$BIN_DIR" && mkdir -p "$BIN_DIR"
@@ -290,12 +300,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
           LDFLAGS="-s -w -X main.version=${release_tag}"
           for GOARCH in amd64 arm64; do
-            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            case "$GOARCH" in
+              amd64) NODEARCH=x64   ; ARCH_FLAG=x86_64 ;;
+              arm64) NODEARCH=arm64 ; ARCH_FLAG=arm64  ;;
+            esac
             BIN_DIR="sdk/node/packages/darwin-${NODEARCH}/bin"
-            ARCH_FLAG=$([ "$GOARCH" = "amd64" ] && echo "x86_64" || echo "arm64")
             echo "Building libpilot.dylib for darwin/${GOARCH}, version=${release_tag}..."
             env CGO_ENABLED=1 GOOS=darwin GOARCH="$GOARCH" \
                 CC="clang -arch ${ARCH_FLAG}" \

--- a/.github/workflows/publish-node-sdk.yml
+++ b/.github/workflows/publish-node-sdk.yml
@@ -1,8 +1,38 @@
 name: Publish Node SDK
 
+# Pulls daemon-side executables (pilot-daemon, pilotctl, pilot-gateway,
+# pilot-updater) from the matching GitHub release built by release.yml,
+# then builds libpilot.{so,dylib} per-platform here. Both sides carry the
+# release tag as their version stamp (`-X main.version=$TAG`), so a
+# pilotctl invoked from a `npm install pilotprotocol` shell reports the
+# actual release version, not "dev".
+#
+# The npm distribution is split following the esbuild/swc pattern:
+#   pilotprotocol                — main package (TS/JS only, no binaries)
+#   pilotprotocol-linux-x64      \
+#   pilotprotocol-linux-arm64     \  optional sub-packages
+#   pilotprotocol-darwin-x64      /  (one downloaded per host's os/cpu)
+#   pilotprotocol-darwin-arm64   /
+#
+# The main package lists all four as `optionalDependencies`; npm fetches
+# only the matching one based on the sub-package's `os`/`cpu` fields.
+#
+# Triggered by `release: published` (after release.yml's tarballs exist).
+#
+# Branches whose name starts with `ci_` ALSO get a dry-run on every push.
+# This is the permanent rehearsal path for iterating on the workflow itself
+# without making a real release. The push run executes everything up to but
+# not including `npm publish` (the `publish` and `test-install` jobs are
+# gated to release events). Required naming convention — only `ci_*`
+# branches trigger the rehearsal; other branches are ignored.
+# See CONTRIBUTING.md → "Testing publish workflows" for the convention.
+
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - 'ci_*'
 
 permissions:
   contents: write
@@ -24,83 +54,319 @@ jobs:
       - run: npm run build
       - run: npm test
 
-  build-packages:
+  # ---------------------------------------------------------------------
+  # Per-platform build jobs.
+  # Each one:
+  #   1. Pulls its 2 release tarballs (executables) from the GitHub release.
+  #   2. Strips infrastructure binaries; renames daemon→pilot-daemon etc.
+  #   3. Builds libpilot.{so,dylib} for each of its 2 target arches with
+  #      -X main.version=$TAG (so libpilot's metadata is consistent with
+  #      the executables' stamp).
+  #   4. Uploads the 2 populated sub-package bin/ trees as an artifact.
+  # ---------------------------------------------------------------------
+
+  build-linux:
+    name: Build linux sub-packages (x64, arm64)
     needs: test-sdk
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            platform: linux
-          - os: macos-latest
-            platform: macos
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set version from release tag
+      - name: Resolve version + tag (release event or ci_* push)
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          echo "version=$VERSION" >> $GITHUB_ENV
-          cd sdk/node
-          node -e "
-            const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
-            pkg.version = '$VERSION';
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          echo "SDK version: $VERSION"
+          # Release event: use the tag of the release being published.
+          # ci_* push: rehearse against the LATEST existing release.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(gh release view --repo "${{ github.repository }}" --json tagName --jq .tagName)
+            echo "ci_* push rehearsal: using latest release ${TAG} as test source"
+          fi
+          VERSION="${TAG#v}"
+          echo "version=$VERSION"     >> $GITHUB_ENV
+          echo "release_tag=$TAG"     >> $GITHUB_ENV
+          echo "Resolved: version=$VERSION, release_tag=$TAG"
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: 'https://registry.npmjs.org'
+      - name: Install aarch64 cross-compiler (for linux/arm64 libpilot)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
-      - name: Build binaries
+      - name: Download release tarballs (linux-amd64, linux-arm64)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          cd sdk/node
-          chmod +x scripts/build-binaries.sh
-          ./scripts/build-binaries.sh
+          set -euo pipefail
+          mkdir -p /tmp/pilot-release
+          gh release download "${release_tag}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'pilot-linux-amd64.tar.gz' \
+            --pattern 'pilot-linux-arm64.tar.gz' \
+            --pattern 'checksums.txt' \
+            --dir /tmp/pilot-release
 
-      - name: Install and build TypeScript
-        working-directory: sdk/node
+          # Verify SHA-256 against the release's checksums.txt.
+          cd /tmp/pilot-release
+          if [ -f checksums.txt ]; then
+            for ARCHIVE in pilot-linux-*.tar.gz; do
+              EXPECTED=$(grep " ${ARCHIVE}\$" checksums.txt | awk '{print $1}')
+              [ -z "$EXPECTED" ] && { echo "  - $ARCHIVE not in checksums.txt; skipped"; continue; }
+              ACTUAL=$(sha256sum "$ARCHIVE" | awk '{print $1}')
+              [ "$EXPECTED" != "$ACTUAL" ] && { echo "Checksum mismatch for $ARCHIVE!" >&2; exit 1; }
+              echo "  - $ARCHIVE: OK"
+            done
+          fi
+
+      - name: Populate sub-package bin/ from release executables
+        shell: bash
         run: |
-          npm ci
-          npm run build
+          set -euo pipefail
+          # Map: <go-arch> → <node-arch>
+          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
+          for GOARCH in amd64 arm64; do
+            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            ARCHIVE="/tmp/pilot-release/pilot-linux-${GOARCH}.tar.gz"
+            BIN_DIR="sdk/node/packages/linux-${NODEARCH}/bin"
+            rm -rf "$BIN_DIR" && mkdir -p "$BIN_DIR"
+            tar -xzf "$ARCHIVE" -C "$BIN_DIR"
+            (
+              cd "$BIN_DIR"
+              # Drop server-infra binaries — not shipped in the SDK.
+              rm -f registry beacon rendezvous nameserver
+              # Rename to SDK convention.
+              [ -f daemon ]  && mv daemon  pilot-daemon
+              [ -f gateway ] && mv gateway pilot-gateway
+              [ -f updater ] && mv updater pilot-updater
+            )
+            echo "  ✓ linux-${NODEARCH} populated:"
+            ls -lh "$BIN_DIR"
+          done
 
-      - name: Verify package contents
-        working-directory: sdk/node
+      - name: Build libpilot for linux/amd64 + linux/arm64
+        shell: bash
         run: |
-          echo "Package contents:"
-          npm pack --dry-run
-          echo ""
-          echo "Binary sizes:"
-          ls -lh bin/
+          set -euo pipefail
+          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
+          LDFLAGS="-s -w -X main.version=${release_tag}"
+          for GOARCH in amd64 arm64; do
+            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            BIN_DIR="sdk/node/packages/linux-${NODEARCH}/bin"
+            CC_OVERRIDE=""
+            if [ "$GOARCH" = "arm64" ]; then
+              CC_OVERRIDE="aarch64-linux-gnu-gcc"
+            fi
+            echo "Building libpilot.so for linux/${GOARCH}, version=${release_tag}..."
+            env CGO_ENABLED=1 GOOS=linux GOARCH="$GOARCH" \
+                ${CC_OVERRIDE:+CC="$CC_OVERRIDE"} \
+                go build -buildmode=c-shared -ldflags "$LDFLAGS" \
+                  -o "${BIN_DIR}/libpilot.so" ./sdk/cgo
+            rm -f "${BIN_DIR}/libpilot.h"
+            echo "  ✓ linux-${NODEARCH}/bin/libpilot.so built"
+          done
 
-      - name: Upload package artifact
+      - name: Verify pilotctl version stamp (linux-x64 native arch)
+        shell: bash
+        run: |
+          STAMPED=$(./sdk/node/packages/linux-x64/bin/pilotctl version 2>&1 | head -1)
+          echo "pilotctl version → ${STAMPED}"
+          case "$STAMPED" in
+            *"${release_tag}"*|*"${version}"*)
+              echo "  ✓ pilotctl carries the release tag" ;;
+            *)
+              echo "  ✗ pilotctl reports '${STAMPED}', expected to contain '${release_tag}'." >&2
+              exit 1 ;;
+          esac
+
+      # actions/upload-artifact@v4 stores files in a zip and strips POSIX
+      # mode bits. Bundle into a tarball first so the +x bit and any other
+      # mode flags ride through unchanged. (Tar also preserves file bytes
+      # byte-for-byte, which keeps any embedded macOS codesign intact.)
+      - name: Tar linux sub-package bin/ trees
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -czf /tmp/bins-linux.tar.gz -C sdk/node \
+            packages/linux-x64/bin \
+            packages/linux-arm64/bin
+          ls -lh /tmp/bins-linux.tar.gz
+
+      - name: Upload linux sub-package bin/ trees
         uses: actions/upload-artifact@v4
         with:
-          name: npm-package-${{ matrix.platform }}
-          path: sdk/node/
+          name: bins-linux
+          path: /tmp/bins-linux.tar.gz
+          if-no-files-found: error
           retention-days: 7
 
+  build-darwin:
+    name: Build darwin sub-packages (x64, arm64)
+    needs: test-sdk
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve version + tag (release event or ci_* push)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Release event: use the tag of the release being published.
+          # ci_* push: rehearse against the LATEST existing release.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(gh release view --repo "${{ github.repository }}" --json tagName --jq .tagName)
+            echo "ci_* push rehearsal: using latest release ${TAG} as test source"
+          fi
+          VERSION="${TAG#v}"
+          echo "version=$VERSION"     >> $GITHUB_ENV
+          echo "release_tag=$TAG"     >> $GITHUB_ENV
+          echo "Resolved: version=$VERSION, release_tag=$TAG"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download release tarballs (darwin-amd64, darwin-arm64)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/pilot-release
+          gh release download "${release_tag}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'pilot-darwin-amd64.tar.gz' \
+            --pattern 'pilot-darwin-arm64.tar.gz' \
+            --pattern 'checksums.txt' \
+            --dir /tmp/pilot-release
+
+          cd /tmp/pilot-release
+          if [ -f checksums.txt ]; then
+            for ARCHIVE in pilot-darwin-*.tar.gz; do
+              EXPECTED=$(grep " ${ARCHIVE}\$" checksums.txt | awk '{print $1}')
+              [ -z "$EXPECTED" ] && { echo "  - $ARCHIVE not in checksums.txt; skipped"; continue; }
+              ACTUAL=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+              [ "$EXPECTED" != "$ACTUAL" ] && { echo "Checksum mismatch for $ARCHIVE!" >&2; exit 1; }
+              echo "  - $ARCHIVE: OK"
+            done
+          fi
+
+      - name: Populate sub-package bin/ from release executables
+        shell: bash
+        run: |
+          set -euo pipefail
+          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
+          for GOARCH in amd64 arm64; do
+            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            ARCHIVE="/tmp/pilot-release/pilot-darwin-${GOARCH}.tar.gz"
+            BIN_DIR="sdk/node/packages/darwin-${NODEARCH}/bin"
+            rm -rf "$BIN_DIR" && mkdir -p "$BIN_DIR"
+            tar -xzf "$ARCHIVE" -C "$BIN_DIR"
+            (
+              cd "$BIN_DIR"
+              rm -f registry beacon rendezvous nameserver
+              [ -f daemon ]  && mv daemon  pilot-daemon
+              [ -f gateway ] && mv gateway pilot-gateway
+              [ -f updater ] && mv updater pilot-updater
+            )
+            echo "  ✓ darwin-${NODEARCH} populated:"
+            ls -lh "$BIN_DIR"
+          done
+
+      - name: Build libpilot for darwin/amd64 + darwin/arm64
+        shell: bash
+        run: |
+          set -euo pipefail
+          declare -A NODE_ARCH=([amd64]=x64 [arm64]=arm64)
+          LDFLAGS="-s -w -X main.version=${release_tag}"
+          for GOARCH in amd64 arm64; do
+            NODEARCH="${NODE_ARCH[$GOARCH]}"
+            BIN_DIR="sdk/node/packages/darwin-${NODEARCH}/bin"
+            ARCH_FLAG=$([ "$GOARCH" = "amd64" ] && echo "x86_64" || echo "arm64")
+            echo "Building libpilot.dylib for darwin/${GOARCH}, version=${release_tag}..."
+            env CGO_ENABLED=1 GOOS=darwin GOARCH="$GOARCH" \
+                CC="clang -arch ${ARCH_FLAG}" \
+                CGO_LDFLAGS="-arch ${ARCH_FLAG}" \
+                go build -buildmode=c-shared -ldflags "$LDFLAGS" \
+                  -o "${BIN_DIR}/libpilot.dylib" ./sdk/cgo
+            rm -f "${BIN_DIR}/libpilot.h"
+            # Ad-hoc codesign + strip quarantine (mirrors release.yml's
+            # treatment of the executables — same darwin codesign story).
+            codesign --force --sign - "${BIN_DIR}/libpilot.dylib"
+            xattr -cr "${BIN_DIR}/libpilot.dylib" || true
+            echo "  ✓ darwin-${NODEARCH}/bin/libpilot.dylib built + signed"
+          done
+
+      - name: Verify pilotctl version stamp (darwin-arm64 native arch)
+        shell: bash
+        run: |
+          STAMPED=$(./sdk/node/packages/darwin-arm64/bin/pilotctl version 2>&1 | head -1)
+          echo "pilotctl version → ${STAMPED}"
+          case "$STAMPED" in
+            *"${release_tag}"*|*"${version}"*)
+              echo "  ✓ pilotctl carries the release tag" ;;
+            *)
+              echo "  ✗ pilotctl reports '${STAMPED}', expected to contain '${release_tag}'." >&2
+              exit 1 ;;
+          esac
+
+      # Tarball the bin/ trees before upload. upload-artifact@v4 zips and
+      # strips POSIX mode bits; tar preserves them and keeps the embedded
+      # Mach-O code signature intact (codesign is stored in the file bytes,
+      # not extended attributes, so any byte-preserving archiver works).
+      - name: Tar darwin sub-package bin/ trees
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -czf /tmp/bins-darwin.tar.gz -C sdk/node \
+            packages/darwin-x64/bin \
+            packages/darwin-arm64/bin
+          ls -lh /tmp/bins-darwin.tar.gz
+
+      - name: Upload darwin sub-package bin/ trees
+        uses: actions/upload-artifact@v4
+        with:
+          name: bins-darwin
+          path: /tmp/bins-darwin.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  # ---------------------------------------------------------------------
+  # Assemble the npm tree (main package TS build + sub-package bin/ trees)
+  # and publish in the right order: sub-packages first, main package last.
+  # ---------------------------------------------------------------------
+
   publish:
-    needs: build-packages
+    # Real publishes only fire on `release: published`. ci_* push rehearsals
+    # run everything through both build jobs + version-stamp checks, then
+    # stop here so no test package reaches npm.
+    if: github.event_name == 'release'
+    needs: [build-linux, build-darwin]
     runs-on: ubuntu-latest
     steps:
-      - name: Download Linux package
-        uses: actions/download-artifact@v4
-        with:
-          name: npm-package-linux
-          path: sdk/node-linux
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION"     >> $GITHUB_ENV
+          echo "release_tag=$TAG"     >> $GITHUB_ENV
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -108,45 +374,155 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Extract version
-        id: extract-version
-        run: |
-          VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('sdk/node-linux/package.json', 'utf8')).version)")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
+      # Build jobs upload their bin/ trees as tarballs (so POSIX mode bits +
+      # macOS codesign survive — upload-artifact@v4 would otherwise zip and
+      # strip mode bits). Download + untar into the working tree.
+      - name: Download linux bin/ tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: bins-linux
+          path: /tmp/
 
-      - name: Check if version exists on npm
-        id: check-npm
-        run: |
-          VERSION=${{ steps.extract-version.outputs.version }}
-          if npm view pilotprotocol@$VERSION version 2>/dev/null; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Version $VERSION already exists on npm"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Version $VERSION does not exist on npm"
-          fi
+      - name: Download darwin bin/ tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: bins-darwin
+          path: /tmp/
 
-      - name: Publish to npm
-        if: steps.check-npm.outputs.exists == 'false'
-        working-directory: sdk/node-linux
+      - name: Extract bin/ tarballs into sdk/node/packages/
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -xzf /tmp/bins-linux.tar.gz  -C sdk/node
+          tar -xzf /tmp/bins-darwin.tar.gz -C sdk/node
+          echo "Extracted sub-package bin/ contents:"
+          for PLAT in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            echo "  packages/${PLAT}/bin/:"
+            ls -l "sdk/node/packages/${PLAT}/bin/"
+          done
+
+      - name: Verify executable bit + version stamp survived round-trip
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The executables must be +x (the tarball preserved this; assert
+          # it explicitly so a future hidden break shows up here, not at
+          # `npx pilotctl` on a user's machine).
+          for PLAT in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            for BIN in pilotctl pilot-daemon pilot-gateway pilot-updater; do
+              F="sdk/node/packages/${PLAT}/bin/${BIN}"
+              if [ ! -x "$F" ]; then
+                echo "✗ $F is not executable after artifact round-trip" >&2
+                exit 1
+              fi
+            done
+          done
+          # Native arch can be exec'd here — confirms version stamp survived.
+          STAMPED=$(./sdk/node/packages/linux-x64/bin/pilotctl version 2>&1 | head -1)
+          echo "linux-x64 pilotctl version → ${STAMPED}"
+          case "$STAMPED" in
+            *"${release_tag}"*|*"${version}"*) echo "  ✓ version stamp intact" ;;
+            *) echo "  ✗ version stamp lost: '${STAMPED}'" >&2; exit 1 ;;
+          esac
+
+      - name: Set version in all package.json files
+        shell: bash
+        run: |
+          set -euo pipefail
+          for PKG in sdk/node/package.json \
+                     sdk/node/packages/linux-x64/package.json \
+                     sdk/node/packages/linux-arm64/package.json \
+                     sdk/node/packages/darwin-x64/package.json \
+                     sdk/node/packages/darwin-arm64/package.json; do
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('$PKG','utf8'));
+              pkg.version = '${version}';
+              // Main package's optionalDependencies must pin each sub-package
+              // to the exact release version — npm install would otherwise
+              // resolve via semver range and could pick an older sub-package.
+              if (pkg.optionalDependencies) {
+                for (const k of Object.keys(pkg.optionalDependencies)) {
+                  pkg.optionalDependencies[k] = '${version}';
+                }
+              }
+              fs.writeFileSync('$PKG', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "  → $PKG: version=${version}"
+          done
+
+      - name: Install + build TypeScript
+        working-directory: sdk/node
+        run: |
+          # Use `npm install` (not `npm ci`) because the previous step
+          # rewrote `version` + `optionalDependencies` in package.json, so
+          # the lockfile no longer matches and `npm ci` would refuse.
+          # `--no-audit --no-fund` keep the install quiet; `--ignore-scripts`
+          # skips lifecycle scripts on optionalDependencies (the sub-packages
+          # at this exact version may not be on npm yet — that's expected
+          # since this same job is about to publish them).
+          npm install --no-audit --no-fund --ignore-scripts
+          npm run build
+
+      - name: Verify package contents (dry pack)
+        working-directory: sdk/node
+        run: |
+          echo "=== Main package ==="
+          npm pack --dry-run
+          for PLAT in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            echo ""
+            echo "=== pilotprotocol-${PLAT} ==="
+            (cd "packages/${PLAT}" && ls -lh bin/ && npm pack --dry-run)
+          done
+
+      # Sub-packages first. The main package's `optionalDependencies` pins
+      # each sub-package to the exact release version; if the main package
+      # publishes before its sub-packages exist on npm, `npm install
+      # pilotprotocol` would silently no-op on the optional dep (per
+      # optionalDependencies semantics) and the SDK would fail to find its
+      # binaries at runtime.
+      - name: Publish sub-packages
+        working-directory: sdk/node
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
         run: |
-          npm ci
-          npm publish --access public
+          set -euo pipefail
+          for PLAT in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            PKG_NAME="pilotprotocol-${PLAT}"
+            cd "packages/${PLAT}"
+            if npm view "${PKG_NAME}@${version}" version 2>/dev/null; then
+              echo "  - ${PKG_NAME}@${version} already on npm; skipping"
+            else
+              echo "  + publishing ${PKG_NAME}@${version}..."
+              npm publish --access public
+            fi
+            cd -
+          done
 
-      - name: Skip publish - version exists
-        if: steps.check-npm.outputs.exists == 'true'
-        run: echo "Skipping publish - version already exists on npm"
+      - name: Publish main package
+        working-directory: sdk/node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if npm view "pilotprotocol@${version}" version 2>/dev/null; then
+            echo "  pilotprotocol@${version} already on npm; skipping"
+          else
+            echo "  publishing pilotprotocol@${version}..."
+            npm publish --access public
+          fi
 
       - name: Create summary
         run: |
-          echo "## Node SDK Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.extract-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Install:** \`npm install pilotprotocol\`" >> $GITHUB_STEP_SUMMARY
-          echo "**npm:** https://www.npmjs.com/package/pilotprotocol" >> $GITHUB_STEP_SUMMARY
+          echo "## Node SDK Published"                                                                          >> $GITHUB_STEP_SUMMARY
+          echo ""                                                                                               >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${version}"                                                                        >> $GITHUB_STEP_SUMMARY
+          echo "**Install:** \`npm install pilotprotocol\`"                                                     >> $GITHUB_STEP_SUMMARY
+          echo "**npm:** https://www.npmjs.com/package/pilotprotocol"                                           >> $GITHUB_STEP_SUMMARY
+          echo "**Sub-packages:** linux-x64, linux-arm64, darwin-x64, darwin-arm64"                             >> $GITHUB_STEP_SUMMARY
+          echo "**Provenance:** executables from release \`${release_tag}\`; libpilot built fresh with -X main.version=\`${release_tag}\`" >> $GITHUB_STEP_SUMMARY
 
   test-install:
     needs: publish
@@ -163,8 +539,46 @@ jobs:
       - name: Wait for npm propagation
         run: sleep 60
 
-      - name: Install and verify
+      - name: Resolve expected version from release tag
+        shell: bash
         run: |
-          npm install pilotprotocol
-          npx pilotctl info 2>&1 | head -1 || true
-          node -e "import('pilotprotocol').then(m => console.log('SDK installed, exports:', Object.keys(m)))"
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION"     >> $GITHUB_ENV
+          echo "release_tag=$TAG"     >> $GITHUB_ENV
+
+      - name: Install and verify version stamp matches release
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install "pilotprotocol@${version}"
+
+          # Confirm the matching sub-package was installed via optionalDependencies.
+          node -e "
+            const os = require('os');
+            const sub = 'pilotprotocol-' + os.platform() + '-' + os.arch();
+            const path = require.resolve(sub + '/package.json');
+            console.log('Sub-package resolved:', path);
+          "
+
+          # Smoke-load the FFI module — confirms libpilot loads on this host.
+          node -e "import('pilotprotocol').then(m => console.log('SDK module imports OK, exports:', Object.keys(m)))"
+
+          # Assert pilotctl reports the release tag (not 'dev'). This is the
+          # regression test for the reported issue: npm-installed pilotprotocol
+          # must run pilotctl with the release version stamped in.
+          STAMPED=$(npx pilotctl version 2>&1 | head -1)
+          echo "pilotctl version → ${STAMPED}"
+          case "$STAMPED" in
+            *"${release_tag}"*|*"${version}"*)
+              echo "✓ pilotctl version reports the release tag"
+              ;;
+            *dev*|*unknown*|"")
+              echo "✗ pilotctl version reports '${STAMPED}' — looks unstamped." >&2
+              exit 1
+              ;;
+            *)
+              echo "✗ pilotctl version reports '${STAMPED}', expected to contain '${release_tag}' or '${version}'." >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,8 +1,27 @@
 name: Publish Python SDK
 
+# Pulls pre-built binaries from the matching GitHub release (built by
+# release.yml) instead of rebuilding the Go suite. This guarantees the
+# bytes shipped on PyPI are byte-identical to the bytes shipped on GitHub
+# Releases, preserves the version stamping (`-X main.version=$TAG`) and
+# the macOS ad-hoc codesign + xattr-strip done in release.yml.
+#
+# Triggered by `release: published` (after release.yml's tarballs exist).
+#
+# Branches whose name starts with `ci_` ALSO get a dry-run on every push.
+# This is the permanent rehearsal path for iterating on the workflow itself
+# without making a real release. The push run executes everything up to but
+# not including `twine upload` (the `publish` and `test-install` jobs are
+# gated to release events). Required naming convention — only `ci_*`
+# branches trigger the rehearsal; other branches are ignored.
+# See CONTRIBUTING.md → "Testing publish workflows" for the convention.
+
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - 'ci_*'
 
 permissions:
   contents: write
@@ -32,28 +51,190 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux
+            release_arch: amd64
           - os: macos-latest
             platform: macos
+            release_arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set version from release tag
+      - name: Resolve version + tag (release event or ci_* push)
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          echo "version=$VERSION" >> $GITHUB_ENV
+          # Release event: use the tag of the release being published.
+          # ci_* push: rehearse against the LATEST existing release.
+          # Either way, strip the leading "v" to get the bare PEP 440 version
+          # used by pyproject.toml and wheel filenames; keep the full tag for
+          # downloading release artifacts.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(gh release view --repo "${{ github.repository }}" --json tagName --jq .tagName)
+            echo "ci_* push rehearsal: using latest release ${TAG} as test source"
+          fi
+          VERSION="${TAG#v}"
+          echo "version=$VERSION"     >> $GITHUB_ENV
+          echo "release_tag=$TAG"     >> $GITHUB_ENV
+          echo "Resolved: version=$VERSION, release_tag=$TAG"
+
+          # Update pyproject.toml so the wheel + sdist carry the release
+          # version. This is the single source of truth for "what version
+          # is this SDK?" — and it matches the release tag exactly.
           cd sdk/python
           sed -i.bak "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
           rm pyproject.toml.bak
-          echo "SDK version: $VERSION"
 
+      # Pull pre-built binaries from the GitHub release. Using the unauthenticated
+      # download URL avoids consuming gh API rate limits for public repos.
+      - name: Download release tarball
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ARCH="${{ matrix.release_arch }}"
+          # Map matrix.platform → GOOS naming used in the tarball filename.
+          case "${{ matrix.platform }}" in
+            linux) GOOS=linux ;;
+            macos) GOOS=darwin ;;
+            *)     echo "unsupported platform: ${{ matrix.platform }}"; exit 1 ;;
+          esac
+          ARCHIVE="pilot-${GOOS}-${ARCH}.tar.gz"
+          mkdir -p /tmp/pilot-release
+          echo "Downloading ${ARCHIVE} from release ${release_tag}..."
+          gh release download "${release_tag}" \
+            --repo "${{ github.repository }}" \
+            --pattern "${ARCHIVE}" \
+            --pattern "checksums.txt" \
+            --dir /tmp/pilot-release
+
+          # Verify SHA-256 against the release's checksums.txt.
+          cd /tmp/pilot-release
+          if [ -f checksums.txt ]; then
+            EXPECTED=$(grep " ${ARCHIVE}\$" checksums.txt | awk '{print $1}')
+            if [ -z "$EXPECTED" ]; then
+              echo "Warning: ${ARCHIVE} not in checksums.txt; skipping verification"
+            else
+              if command -v sha256sum >/dev/null 2>&1; then
+                ACTUAL=$(sha256sum "${ARCHIVE}" | awk '{print $1}')
+              else
+                ACTUAL=$(shasum -a 256 "${ARCHIVE}" | awk '{print $1}')
+              fi
+              if [ "$EXPECTED" != "$ACTUAL" ]; then
+                echo "Checksum mismatch for ${ARCHIVE}!" >&2
+                echo "  expected: $EXPECTED" >&2
+                echo "  actual:   $ACTUAL"   >&2
+                exit 1
+              fi
+              echo "  Verified SHA-256: $ACTUAL"
+            fi
+          fi
+
+      # The release tarball ships daemon, pilotctl, gateway, registry, beacon,
+      # rendezvous, nameserver, updater. The Python SDK only ships the four
+      # client-side binaries — registry/beacon/rendezvous/nameserver are
+      # server infrastructure not part of the user-facing wheel.
+      #
+      # The release uses bare names (`daemon`, `gateway`, `updater`); the SDK
+      # uses prefixed names (`pilot-daemon`, `pilot-gateway`, `pilot-updater`)
+      # to avoid colliding with system binaries on PATH. Rename here.
+      #
+      # libpilot is NOT in the release tarball — it's CGO-built in the next
+      # step using the same release tag for its version stamp.
+      - name: Layout binaries into pilotprotocol/bin/
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOOS=$(case "${{ matrix.platform }}" in linux) echo linux;; macos) echo darwin;; esac)
+          ARCH="${{ matrix.release_arch }}"
+          ARCHIVE="pilot-${GOOS}-${ARCH}.tar.gz"
+
+          BIN_DIR="sdk/python/pilotprotocol/bin"
+          rm -rf "$BIN_DIR" && mkdir -p "$BIN_DIR"
+          tar -xzf "/tmp/pilot-release/${ARCHIVE}" -C "$BIN_DIR"
+
+          cd "$BIN_DIR"
+          # Drop infrastructure binaries — not shipped in the SDK.
+          rm -f registry beacon rendezvous nameserver
+
+          # Rename to SDK convention.
+          [ -f daemon ]  && mv daemon  pilot-daemon
+          [ -f gateway ] && mv gateway pilot-gateway
+          [ -f updater ] && mv updater pilot-updater
+
+          # .pilot-version marker — the seeder reads this to compare against
+          # whatever's installed at ~/.pilot/bin/. Always normalize to bare
+          # version (no leading "v") so it's symmetric with install.sh.
+          echo "${version}" > .pilot-version
+
+          echo ""
+          echo "pilotprotocol/bin/ after release-tarball extraction:"
+          ls -lh
+          echo ""
+          # Sanity: confirm version stamp made it through (release.yml builds
+          # with -X main.version=$TAG; SDK shouldn't drop it). Run against
+          # the runner's native arch only since cross-arch tarballs cannot
+          # be exec'd here.
+          if [ "${{ matrix.platform }}" = "linux" ] && [ -x pilotctl ]; then
+            STAMPED=$(./pilotctl version 2>&1 | head -1)
+            echo "pilotctl version → ${STAMPED}"
+            case "$STAMPED" in
+              *"${release_tag}"*|*"${version}"*)
+                echo "  ✓ version stamp matches release tag"
+                ;;
+              *)
+                echo "  ✗ version stamp '${STAMPED}' does not contain '${release_tag}'!" >&2
+                echo "  ✗ pilotctl version must report the release tag, not 'dev'." >&2
+                echo "  ✗ release.yml is supposed to build with -X main.version=\$GITHUB_REF_NAME." >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+      # Build libpilot.{so,dylib} — the CGO shared library used by the SDK
+      # via ctypes. Stamped with the same release tag (`-X main.version=$TAG`)
+      # so SDK provenance is consistent with the executables pulled from
+      # the release tarball. Codesigned ad-hoc on darwin (mirrors release.yml
+      # for the executables).
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Build libpilot CGO shared library
+        shell: bash
+        env:
+          GOOS: ${{ matrix.platform == 'macos' && 'darwin' || 'linux' }}
+          GOARCH: ${{ matrix.release_arch }}
+          CGO_ENABLED: '1'
+        run: |
+          set -euo pipefail
+          case "$GOOS" in
+            linux)  EXT=so ;;
+            darwin) EXT=dylib ;;
+          esac
+          BIN_DIR="sdk/python/pilotprotocol/bin"
+          LDFLAGS="-s -w -X main.version=${release_tag}"
+          echo "Building libpilot.$EXT for ${GOOS}/${GOARCH}, version=${release_tag}..."
+          go build -buildmode=c-shared -ldflags "$LDFLAGS" \
+            -o "${BIN_DIR}/libpilot.${EXT}" ./sdk/cgo
+          # Drop the auto-generated header — SDKs load via ctypes by symbol,
+          # not against the C header.
+          rm -f "${BIN_DIR}/libpilot.h"
+
+          if [ "$GOOS" = "darwin" ]; then
+            echo "Ad-hoc codesigning libpilot.${EXT}..."
+            codesign --force --sign - "${BIN_DIR}/libpilot.${EXT}"
+            xattr -cr "${BIN_DIR}/libpilot.${EXT}" || true
+          fi
+
+          echo ""
+          echo "Final pilotprotocol/bin/ contents (post-libpilot):"
+          ls -lh "$BIN_DIR"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -70,9 +251,12 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          PILOT_SKIP_BUILD_BINARIES: '1'
+          SKIP_TWINE_CHECK: '1'
         run: |
           cd sdk/python
-          chmod +x scripts/build-binaries.sh scripts/build.sh
+          chmod +x scripts/build.sh
           ./scripts/build.sh
 
       - name: Convert to manylinux wheel (Linux only)
@@ -113,6 +297,10 @@ jobs:
           retention-days: 7
 
   publish:
+    # Real publishes only fire on `release: published`. ci_* push rehearsals
+    # run everything up through wheel-build + version-stamp checks, then stop
+    # here so no test wheel reaches PyPI.
+    if: github.event_name == 'release'
     needs: build-wheels
     runs-on: ubuntu-latest
     steps:
@@ -174,6 +362,7 @@ jobs:
           echo "**Version:** ${{ steps.extract-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Install:** \`pip install pilotprotocol\`" >> $GITHUB_STEP_SUMMARY
           echo "**PyPI:** https://pypi.org/project/pilotprotocol/" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** Pulled binaries from release \`${{ github.event.release.tag_name }}\` (no rebuild)" >> $GITHUB_STEP_SUMMARY
 
   test-install:
     needs: publish
@@ -190,8 +379,38 @@ jobs:
       - name: Wait for PyPI propagation
         run: sleep 60
 
-      - name: Install and verify
+      - name: Resolve expected version from release tag
+        shell: bash
         run: |
-          pip install pilotprotocol
-          pilotctl info 2>&1 | head -1 || true
-          python -c "from pilotprotocol import Driver; print('SDK installed')"
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION"           >> $GITHUB_ENV
+          echo "release_tag=$TAG"           >> $GITHUB_ENV
+
+      - name: Install and verify version stamp matches release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install --no-cache-dir pilotprotocol=="${version}"
+
+          # Smoke-load the FFI module — confirms libpilot loads on this host.
+          python -c "from pilotprotocol import Driver; print('SDK module imports OK')"
+
+          # Assert pilotctl reports the actual release tag (not 'dev').
+          # This is the regression test for the reported issue: pip-installed
+          # pilotprotocol must run pilotctl with the release version stamped in.
+          STAMPED=$(pilotctl version 2>&1 | head -1)
+          echo "pilotctl version → ${STAMPED}"
+          case "$STAMPED" in
+            *"${release_tag}"*|*"${version}"*)
+              echo "✓ pilotctl version reports the release tag"
+              ;;
+            *dev*|*unknown*|"")
+              echo "✗ pilotctl version reports '${STAMPED}' — looks unstamped." >&2
+              exit 1
+              ;;
+            *)
+              echo "✗ pilotctl version reports '${STAMPED}', expected to contain '${release_tag}' or '${version}'." >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -155,10 +155,14 @@ jobs:
       # step using the same release tag for its version stamp.
       - name: Layout binaries into pilotprotocol/bin/
         shell: bash
+        env:
+          # Resolve GOOS at workflow-eval time so the run-script doesn't
+          # need its own case statement. bash 3.2 (macOS default) chokes
+          # on `case` inside `$(...)` command substitution.
+          GOOS: ${{ matrix.platform == 'macos' && 'darwin' || 'linux' }}
+          ARCH: ${{ matrix.release_arch }}
         run: |
           set -euo pipefail
-          GOOS=$(case "${{ matrix.platform }}" in linux) echo linux;; macos) echo darwin;; esac)
-          ARCH="${{ matrix.release_arch }}"
           ARCHIVE="pilot-${GOOS}-${ARCH}.tar.gz"
 
           BIN_DIR="sdk/python/pilotprotocol/bin"

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -35,13 +35,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-      - name: Run SDK integration tests
+      # Run the Python SDK's own unit tests. The previous `make test-sdk`
+      # under tests/integration/ was a stale reference (the Makefile is
+      # gone) — kept that step's spirit (gate publish on SDK tests passing)
+      # but pointed it at the pytest suite that actually exists.
+      - name: Run Python SDK unit tests
+        working-directory: sdk/python
         run: |
-          cd tests/integration
-          make test-sdk
+          pip install --upgrade pip
+          pip install -e .[dev]
+          pytest tests/ -v
         timeout-minutes: 10
 
   build-wheels:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,37 @@ make test
 6. Ensure the project builds: `go build ./...`
 7. Submit a pull request with a clear description
 
+### Testing publish workflows (`ci_*` branches)
+
+`Publish Python SDK` and `Publish Node SDK` normally only fire on
+`release: published` events. Iterating on these workflows by cutting real
+releases is slow and side-effecting (every test wheel/npm package would
+be a permanent public artifact).
+
+**The convention: branches whose name starts with `ci_` get a permanent
+dry-run on every push.** A push to `ci_*` runs everything through the
+build jobs, the version-stamp assertions, and the dry-pack — but stops
+before the actual `twine upload` / `npm publish` steps. The publish jobs
+are gated on `github.event_name == 'release'`, so a push rehearsal never
+touches PyPI or npm.
+
+How it works:
+- On a release event, the workflows pull binaries from that release's tag.
+- On a `ci_*` push, they pull binaries from the **latest existing**
+  release (resolved via `gh release view --json tagName`) and use that as
+  the rehearsal target. This means: there must be at least one prior
+  release on GitHub for the rehearsal to have something to pull from.
+
+Naming:
+- `ci_workflow_iter` — fine
+- `ci_test_build_libpilot` — fine
+- `feature/ci-test` — **does not match**; the rehearsal trigger pattern is
+  `ci_*` literally. Any other branch name is silently ignored by the
+  publish workflows.
+
+Tip: use `gh run watch` after pushing to follow the run, and
+`gh run view --log-failed` to retrieve only failed-step logs.
+
 ### Code Style
 
 - Follow standard Go conventions (`gofmt`, `go vet`)

--- a/sdk/node/Makefile
+++ b/sdk/node/Makefile
@@ -29,3 +29,10 @@ dist: binaries build
 
 clean:
 	rm -rf dist/ node_modules/ bin/ *.tgz
+	# Per-platform sub-package bin/ trees (populated by build-binaries.sh
+	# for local dev, by the publish workflow in CI). Wipe the contents but
+	# keep the per-platform package.json files in place.
+	find packages -mindepth 2 -maxdepth 3 -type f \
+	    \( -name 'pilot-*' -o -name 'pilotctl' -o -name 'libpilot.*' \) \
+	    -delete 2>/dev/null || true
+	find packages -mindepth 2 -maxdepth 3 -type d -name bin -empty -delete 2>/dev/null || true

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -58,6 +58,12 @@
   "dependencies": {
     "koffi": "^2.9.0"
   },
+  "optionalDependencies": {
+    "pilotprotocol-linux-x64": "0.1.1",
+    "pilotprotocol-linux-arm64": "0.1.1",
+    "pilotprotocol-darwin-x64": "0.1.1",
+    "pilotprotocol-darwin-arm64": "0.1.1"
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "typescript": "^5.7.0",
@@ -66,17 +72,8 @@
   "engines": {
     "node": ">=20"
   },
-  "os": [
-    "darwin",
-    "linux"
-  ],
-  "cpu": [
-    "x64",
-    "arm64"
-  ],
   "files": [
     "dist/",
-    "bin/",
     "bin-stubs/"
   ]
 }

--- a/sdk/node/packages/darwin-arm64/package.json
+++ b/sdk/node/packages/darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pilotprotocol-darwin-arm64",
+  "version": "0.0.0",
+  "description": "darwin-arm64 native binaries for pilotprotocol (auto-installed via optionalDependencies — do not install directly)",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TeoSlayer/pilotprotocol",
+    "directory": "sdk/node/packages/darwin-arm64"
+  },
+  "homepage": "https://pilotprotocol.network",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["bin/"]
+}

--- a/sdk/node/packages/darwin-x64/package.json
+++ b/sdk/node/packages/darwin-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pilotprotocol-darwin-x64",
+  "version": "0.0.0",
+  "description": "darwin-x64 native binaries for pilotprotocol (auto-installed via optionalDependencies — do not install directly)",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TeoSlayer/pilotprotocol",
+    "directory": "sdk/node/packages/darwin-x64"
+  },
+  "homepage": "https://pilotprotocol.network",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": ["bin/"]
+}

--- a/sdk/node/packages/linux-arm64/package.json
+++ b/sdk/node/packages/linux-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pilotprotocol-linux-arm64",
+  "version": "0.0.0",
+  "description": "linux-arm64 native binaries for pilotprotocol (auto-installed via optionalDependencies — do not install directly)",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TeoSlayer/pilotprotocol",
+    "directory": "sdk/node/packages/linux-arm64"
+  },
+  "homepage": "https://pilotprotocol.network",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": ["bin/"]
+}

--- a/sdk/node/packages/linux-x64/package.json
+++ b/sdk/node/packages/linux-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pilotprotocol-linux-x64",
+  "version": "0.0.0",
+  "description": "linux-x64 native binaries for pilotprotocol (auto-installed via optionalDependencies — do not install directly)",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TeoSlayer/pilotprotocol",
+    "directory": "sdk/node/packages/linux-x64"
+  },
+  "homepage": "https://pilotprotocol.network",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin/"]
+}

--- a/sdk/node/scripts/build-binaries.sh
+++ b/sdk/node/scripts/build-binaries.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# Build complete Pilot Protocol suite for Node SDK distribution
-# This builds: daemon, pilotctl, gateway, and CGO bindings
+# Build complete Pilot Protocol suite for Node SDK distribution.
+#
+# Local-dev only — CI publish jobs pull executables from the GitHub release
+# and build libpilot themselves; see .github/workflows/publish-node-sdk.yml.
+#
+# Output: writes binaries into the matching per-platform sub-package at
+#   sdk/node/packages/<os>-<node-arch>/bin/
+# which the runtime resolver finds via the in-repo fallback path when the
+# sub-package is not yet on npm (i.e. when developing locally).
 
 set -euo pipefail
 
@@ -10,10 +17,12 @@ cd "$(dirname "$0")/../../.."  # Go to repo root
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
+# Both go-style (amd64/arm64) and node-style (x64/arm64) names are needed:
+# go for the build target, node for the sub-package directory.
 case "$ARCH" in
-    x86_64)  ARCH="amd64" ;;
-    aarch64) ARCH="arm64" ;;
-    arm64)   ARCH="arm64" ;;
+    x86_64)  GOARCH="amd64"; NODEARCH="x64"   ;;
+    aarch64) GOARCH="arm64"; NODEARCH="arm64" ;;
+    arm64)   GOARCH="arm64"; NODEARCH="arm64" ;;
     *)       echo "Error: unsupported architecture: $ARCH"; exit 1 ;;
 esac
 
@@ -24,41 +33,43 @@ case "$OS" in
 esac
 
 echo "================================================================"
-echo "Building Pilot Protocol Suite for ${OS}/${ARCH}"
+echo "Building Pilot Protocol Suite for ${OS}/${GOARCH} (npm: ${OS}-${NODEARCH})"
 echo "================================================================"
 echo ""
 
-OUTPUT_DIR="sdk/node/bin"
+# Sub-package bin/ — picked up by cli.ts / ffi.ts via require.resolve in
+# production, or via the in-repo fallback path during local dev.
+OUTPUT_DIR="sdk/node/packages/${OS}-${NODEARCH}/bin"
 mkdir -p "$OUTPUT_DIR"
 
 # 1. Build daemon
 echo "1. Building pilot-daemon..."
-CGO_ENABLED=0 GOOS="$OS" GOARCH="$ARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilot-daemon" ./cmd/daemon
+CGO_ENABLED=0 GOOS="$OS" GOARCH="$GOARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilot-daemon" ./cmd/daemon
 echo "   ✓ Built: $OUTPUT_DIR/pilot-daemon"
 echo ""
 
 # 2. Build pilotctl
 echo "2. Building pilotctl..."
-CGO_ENABLED=0 GOOS="$OS" GOARCH="$ARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilotctl" ./cmd/pilotctl
+CGO_ENABLED=0 GOOS="$OS" GOARCH="$GOARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilotctl" ./cmd/pilotctl
 echo "   ✓ Built: $OUTPUT_DIR/pilotctl"
 echo ""
 
 # 3. Build gateway
 echo "3. Building pilot-gateway..."
-CGO_ENABLED=0 GOOS="$OS" GOARCH="$ARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilot-gateway" ./cmd/gateway
+CGO_ENABLED=0 GOOS="$OS" GOARCH="$GOARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilot-gateway" ./cmd/gateway
 echo "   ✓ Built: $OUTPUT_DIR/pilot-gateway"
 echo ""
 
 # 4. Build updater
 echo "4. Building pilot-updater..."
-CGO_ENABLED=0 GOOS="$OS" GOARCH="$ARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilot-updater" ./cmd/updater
+CGO_ENABLED=0 GOOS="$OS" GOARCH="$GOARCH" go build -ldflags="-s -w" -o "$OUTPUT_DIR/pilot-updater" ./cmd/updater
 echo "   ✓ Built: $OUTPUT_DIR/pilot-updater"
 echo ""
 
 # 5. Build CGO bindings
 echo "5. Building libpilot CGO bindings..."
 cd sdk/cgo
-CGO_ENABLED=1 GOOS="$OS" GOARCH="$ARCH" go build -buildmode=c-shared -ldflags="-s -w" -o "../../$OUTPUT_DIR/libpilot.$EXT" .
+CGO_ENABLED=1 GOOS="$OS" GOARCH="$GOARCH" go build -buildmode=c-shared -ldflags="-s -w" -o "../../$OUTPUT_DIR/libpilot.$EXT" .
 cd ../..
 echo "   ✓ Built: $OUTPUT_DIR/libpilot.$EXT"
 echo ""
@@ -72,7 +83,7 @@ echo ""
 echo "Total size:"
 du -sh "$OUTPUT_DIR" | awk '{printf "  %s\n", $1}'
 echo ""
-echo "✓ All binaries built successfully for ${OS}/${ARCH}"
+echo "✓ All binaries built successfully for ${OS}/${GOARCH}"
 echo ""
 echo "Next steps:"
 echo "  cd sdk/node"

--- a/sdk/node/src/cli.ts
+++ b/sdk/node/src/cli.ts
@@ -11,9 +11,17 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { arch as osArch, homedir, platform as osPlatform } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// The npm sub-package shipping THIS host's native binaries (esbuild pattern).
+// Main `pilotprotocol` declares all 4 as optionalDependencies; npm fetches
+// only the one matching this host's os+cpu fields.
+function subPackageName(): string {
+  return `pilotprotocol-${osPlatform()}-${osArch()}`;
+}
 
 /**
  * Ensure ~/.pilot/ directory and config.json exist.
@@ -43,17 +51,39 @@ function ensurePilotEnv(): void {
 }
 
 /**
- * Get absolute path to a bundled binary.
- * Searches in the package's bin/ directory (relative to this file's location).
+ * Resolve the absolute path to a bundled binary.
+ *
+ * Production layout: binaries live in the matching optional sub-package
+ *   `pilotprotocol-<os>-<arch>` (npm installs only the one for this host).
+ * Local-dev fallbacks (no `npm install` of the sub-package yet):
+ *   - in-repo `sdk/node/packages/<os>-<arch>/bin/` (build-binaries.sh writes here)
+ *   - legacy `sdk/node/bin/` (old flat layout)
  */
 function getBinaryPath(binaryName: string): string {
+  // 1. Optional sub-package resolved via Node's module resolver. Works
+  //    whether the sub-package is hoisted at the top level of node_modules
+  //    or nested next to the main package.
+  try {
+    const req = createRequire(import.meta.url);
+    const subPkgJson = req.resolve(`${subPackageName()}/package.json`);
+    const candidate = resolve(dirname(subPkgJson), 'bin', binaryName);
+    if (existsSync(candidate)) return candidate;
+  } catch {
+    // Sub-package not installed (local dev, or wrong-platform host).
+  }
+
   const thisDir = resolve(fileURLToPath(import.meta.url), '..');
 
-  // When compiled: dist/cli.js → look for ../bin/
+  // 2. In-repo sub-package layout — `scripts/build-binaries.sh` writes here
+  //    so local dev works without `npm install` of the sub-package itself.
+  const inRepoSub = resolve(
+    thisDir, '..', '..', 'packages', subPackageName().replace(/^pilotprotocol-/, ''), 'bin', binaryName,
+  );
+  if (existsSync(inRepoSub)) return inRepoSub;
+
+  // 3. Legacy flat dev layouts.
   const pkgBin = resolve(thisDir, '..', 'bin', binaryName);
   if (existsSync(pkgBin)) return pkgBin;
-
-  // Development: src/cli.ts → look for ../../bin/ (through sdk/node/)
   const devBin = resolve(thisDir, '..', '..', 'bin', binaryName);
   if (existsSync(devBin)) return devBin;
 
@@ -61,10 +91,16 @@ function getBinaryPath(binaryName: string): string {
     `Binary '${binaryName}' not found.\n` +
     '\n' +
     'Expected locations:\n' +
-    `  - ${pkgBin} (npm package)\n` +
-    `  - ${devBin} (development)\n` +
+    `  - node_modules/${subPackageName()}/bin/${binaryName} (npm sub-package)\n` +
+    `  - ${inRepoSub} (in-repo dev sub-package)\n` +
+    `  - ${pkgBin} (legacy npm layout)\n` +
+    `  - ${devBin} (legacy dev layout)\n` +
     '\n' +
-    'Build binaries with:\n' +
+    `If you installed via npm, the sub-package '${subPackageName()}'\n` +
+    'should have been installed automatically. Reinstall with:\n' +
+    '  npm install pilotprotocol\n' +
+    '\n' +
+    'For local development, build binaries with:\n' +
     '  cd sdk/node && ./scripts/build-binaries.sh\n',
   );
 }

--- a/sdk/node/src/ffi.ts
+++ b/sdk/node/src/ffi.ts
@@ -18,9 +18,16 @@
 
 import koffi from 'koffi';
 import { existsSync } from 'node:fs';
-import { homedir, platform } from 'node:os';
-import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { arch, homedir, platform } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// The npm sub-package shipping THIS host's libpilot. Mirrors cli.ts so
+// both code paths agree on where bundled binaries live.
+function subPackageName(): string {
+  return `pilotprotocol-${platform()}-${arch()}`;
+}
 
 // ---------------------------------------------------------------------------
 // Error class (defined here to avoid circular deps with client.ts)
@@ -56,20 +63,33 @@ export function findLibrary(): string {
     throw new Error(`PILOT_LIB_PATH=${envPath} does not exist`);
   }
 
-  // 2. ~/.pilot/bin/
+  // 2. ~/.pilot/bin/ — honors a curl-install of pilot if the user has one.
   const pilotBin = join(homedir(), '.pilot', 'bin', libName);
   if (existsSync(pilotBin)) return pilotBin;
 
-  // 3. <package>/bin/ (npm package layout: dist/ffi.js → ../bin/)
+  // 3. The matching optional sub-package (production npm install layout).
+  try {
+    const req = createRequire(import.meta.url);
+    const subPkgJson = req.resolve(`${subPackageName()}/package.json`);
+    const candidate = resolve(dirname(subPkgJson), 'bin', libName);
+    if (existsSync(candidate)) return candidate;
+  } catch {
+    // sub-package not installed — local dev path or wrong-platform host.
+  }
+
   const thisDir = resolve(fileURLToPath(import.meta.url), '..');
+
+  // 4. In-repo sub-package — populated by scripts/build-binaries.sh for
+  //    local dev without `npm install` of the sub-package.
+  const subPlat = subPackageName().replace(/^pilotprotocol-/, '');
+  const inRepoSub = resolve(thisDir, '..', '..', 'packages', subPlat, 'bin', libName);
+  if (existsSync(inRepoSub)) return inRepoSub;
+
+  // 5. Legacy flat dev layouts.
   const pkgBin = resolve(thisDir, '..', 'bin', libName);
   if (existsSync(pkgBin)) return pkgBin;
-
-  // 4. Same directory as this file
   const colocated = join(thisDir, libName);
   if (existsSync(colocated)) return colocated;
-
-  // 5. <repo>/bin/ (development layout — 3 levels up from dist/)
   const repoBin = resolve(thisDir, '..', '..', '..', 'bin', libName);
   if (existsSync(repoBin)) return repoBin;
 
@@ -77,12 +97,18 @@ export function findLibrary(): string {
     `Cannot find ${libName}.\n` +
     '\n' +
     'Expected locations:\n' +
-    `  - ~/.pilot/bin/${libName}\n` +
-    `  - ${pkgBin} (npm package)\n` +
+    `  - ~/.pilot/bin/${libName} (curl install)\n` +
+    `  - node_modules/${subPackageName()}/bin/${libName} (npm sub-package)\n` +
+    `  - ${inRepoSub} (in-repo dev sub-package)\n` +
+    `  - ${pkgBin} (legacy npm layout)\n` +
     `  - ${colocated} (colocated)\n` +
-    `  - ${repoBin} (development)\n` +
+    `  - ${repoBin} (legacy dev layout)\n` +
     '\n' +
-    'Build it with:\n' +
+    `If you installed via npm, the sub-package '${subPackageName()}'\n` +
+    'should have been installed automatically. Reinstall with:\n' +
+    '  npm install pilotprotocol\n' +
+    '\n' +
+    'For local development, build it with:\n' +
     '  cd sdk/node && ./scripts/build-binaries.sh\n' +
     '\n' +
     'Or set PILOT_LIB_PATH:\n' +

--- a/sdk/python/scripts/build.sh
+++ b/sdk/python/scripts/build.sh
@@ -10,9 +10,20 @@ echo "Building Pilot Protocol Python SDK"
 echo "================================================================"
 echo ""
 
-# Step 1: Build all binaries
-echo "1. Building platform binaries..."
-./scripts/build-binaries.sh
+# Step 1: Build all binaries (CI publish workflows pre-populate pilotprotocol/bin/
+# from the release tarball and skip this step via PILOT_SKIP_BUILD_BINARIES=1).
+if [ "${PILOT_SKIP_BUILD_BINARIES:-0}" = "1" ]; then
+    echo "1. Skipping binary build (PILOT_SKIP_BUILD_BINARIES=1)"
+    if [ ! -f "pilotprotocol/bin/pilot-daemon" ]; then
+        echo "   Error: pilotprotocol/bin/ is empty but PILOT_SKIP_BUILD_BINARIES=1." >&2
+        echo "   The caller must populate it (e.g. extract from release tarball) first." >&2
+        exit 1
+    fi
+    echo "   Found pre-populated binaries in pilotprotocol/bin/"
+else
+    echo "1. Building platform binaries..."
+    ./scripts/build-binaries.sh
+fi
 echo ""
 
 # Step 2: Clean old builds


### PR DESCRIPTION
Summary       

  Fix the SDK publish workflows so PyPI and npm always ship binaries built from the matching GitHub release (no rebuild drift,  
  no dev version stamps). Restructures the npm package as a main package + four per-platform optional sub-packages (esbuild
  pattern) so users only download their own arch.                                                                               
                                                                                                                              
  Changes

  - publish-python-sdk.yml: pulls executables from the matching release: published tarball via gh release download, builds      
  libpilot.{so,dylib} here with -X main.version=$TAG (ad-hoc codesigned on darwin), asserts pilotctl version reports the release
   tag both at build-time and post-install on PyPI.                                                                             
  - publish-node-sdk.yml: full rewrite. Parallel build-linux (with gcc-aarch64-linux-gnu for arm64 cross-compile) + build-darwin
   (with clang -arch) jobs pull their two release tarballs each, build libpilot for both arches, codesign darwin libs. Publish  
  job downloads tarballed bin/ trees (preserves mode bits + Mach-O codesign), stamps the release version into all five
  package.json files + their optionalDependencies pins, publishes the four sub-packages first then the main package last. Same  
  pilotctl version assertion at every stage.                                                                                  
  - Node SDK npm restructure (5 packages):
    - pilotprotocol — main package, TS/JS only, no binaries; lists the four sub-packages as optionalDependencies (npm fetches   
  only the matching one per host's os/cpu).                                                                                     
    - pilotprotocol-{linux-x64,linux-arm64,darwin-x64,darwin-arm64} — per-platform binaries only, ~30 MB each.                  
    - cli.ts and ffi.ts resolve binaries via require.resolve on the matching sub-package, with in-repo dev fallbacks for local  
  builds.                                                                                                                       
  - scripts/build-binaries.sh: local-dev builds now write into the matching packages/<plat>/bin/ so dev and prod layouts agree. 
  - sdk/python/scripts/build.sh: honors PILOT_SKIP_BUILD_BINARIES=1 so the workflow can pre-populate pilotprotocol/bin/ from the
   release tarball and skip the Go rebuild.                                                                                     
  - ci_* rehearsal trigger: both publish workflows also run on push to any ci_* branch, executing through build + version-stamp 
  assertions but stopping before any npm publish / twine upload. Permanent path for iterating on the workflows without making   
  real releases.                                                                                                              
  - Makefile: make clean wipes the new packages/<plat>/bin/ layout.                                                             
  - CONTRIBUTING.md: documents the ci_* branch convention.                                                                      
  
  Test Plan                                                                                                                     
                                                                                                                              
  - go build ./cmd/... succeeds                                                                                                 
  - go vet ./... clean
  - Relevant tests pass (go test -parallel 4 ./tests/ ./pkg/beacon/)                                                            
  - Pre-commit hooks pass (pre-commit run --all-files)                                                                          
  - sdk/node: npm run build succeeds, 53/53 vitest tests pass
  - All three workflow YAML files parse cleanly (yaml.safe_load)                                                                
  - Push to ci_fix_publish triggers both publish workflows in rehearsal mode; both reach the publish job and skip cleanly       
  without touching PyPI/npm                                                                                                     
  - Build-time pilotctl version assertion contains the release tag (not dev) on build-linux (linux-x64 native) and build-darwin 
  (darwin-arm64 native)                                                                                                         
  - Post-extract version-stamp assertion in the node publish job confirms exec bit + codesign survived the artifact round-trip
                                                                                                                                
  Checklist                                                                                                                   
                                                                                                                                
  - New code includes the SPDX license header                                                                                   
  - No secrets or credentials committed
  - go.mod / go.sum changes are intentional                                                                                     
  - Documentation updated if behavior changed                                                                                 
  - Linked issue or context:                                                                                                    
                                                                                                                                
  ---                                                                                                                           
  Pre-merge action required (npm name reservation)                                                                              
                                                                                                                              
  Before merging this and cutting the next release, the npm account associated with secrets.NPM_TOKEN must own (or be able to
  claim) all five package names:                                                                                                
  
  - pilotprotocol                                                                                                               
  - pilotprotocol-linux-x64                                                                                                   
  - pilotprotocol-linux-arm64                                                                                                   
  - pilotprotocol-darwin-x64
  - pilotprotocol-darwin-arm64                                                                                                  
                                                                                                                              
  If any of these names is squatted on npm, the publish job's npm publish --access public will fail with 403. Reserve them ahead
   of time (stub publish or npm access setup with an org).
                                                                                                                                
  Known gaps (not blockers, follow-ups)                                                                                       

  - PyPI parity: release.yml ships all 4 arches; the Python workflow still builds wheels only for linux-amd64 + darwin-arm64.   
  Adding linux-arm64 + darwin-x64 wheels is straightforward (matrix entries + explicit --plat-name tags) but out of scope here.
  - Cross-arch verification: build-time pilotctl version is asserted on the runner's native arch only (linux-x64 +              
  darwin-arm64). The other two arches' binaries are stamped the same way but aren't exec-tested in CI until we have arm64 Ubuntu
   / Intel macOS runners in the matrix.
  - First-release sub-package install warnings: sdk/node/package.json ships with 0.1.1 hardcoded in optionalDependencies; the   
  workflow overrides at publish time, but local npm install warns about missing optional deps until the first real release      
  ships. Harmless.