### PR TITLE
ci: drop ./pkg/beacon/ from Test step paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           go test -parallel 4 -count=1 -timeout 1800s \
             -skip 'TestMultipleLargeWrites|TestConcurrentDialEncryptDecrypt|TestHTTPPrivateWithTrust|TestInviteInboxCapEnforced|TestConnectionLimits|TestRC6PeerRestartRecoveryEndToEnd|TestEndToEndRelay|TestNameserverOverwriteA|TestNameserverPersistence|TestNameserverRegisterN|TestNameserver$' \
-            ./tests/ ./pkg/beacon/
+            ./tests/
 
       - name: Coverage
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Summary

Quick follow-up to #114. pkg/beacon was extracted to pilot-protocol/beacon but the Test step in ci.yml still passed \`./pkg/beacon/\` to \`go test\`. Post-merge CI surfaces:

\`\`\`
FAIL    ./pkg/beacon [setup failed]
stat /home/runner/work/pilotprotocol/pilotprotocol/pkg/beacon: directory not found
\`\`\`

Removes the dead path; ./tests/ still runs.

## Test plan

- [x] \`ls cmd/daemon cmd/pilotctl tests\` — all present
- [x] No other workflow references pkg/beacon