### PR TITLE
tests: fix flag.Parse pollution causing CI panic on go1.25.10

### DIFF
--- a/tests/zz_config_test.go
+++ b/tests/zz_config_test.go
@@ -39,7 +39,11 @@ func TestConfigLoadAndApply(t *testing.T) {
 	addr := flag.String("addr", ":9000", "")
 	logLevel := flag.String("log-level", "info", "")
 	encrypt := flag.Bool("encrypt", false, "")
-	flag.Parse() // no args, nothing explicitly set
+	// Use the swapped-in FlagSet's Parse with an explicit empty arg
+	// slice. flag.Parse() reads os.Args[1:] which under `go test`
+	// includes -test.paniconexit0 etc; the fresh FlagSet doesn't
+	// know those flags and errors out.
+	flag.CommandLine.Parse([]string{})
 
 	config.ApplyToFlags(cfg)
 
@@ -93,7 +97,7 @@ func TestConfigUnderscoreVariant(t *testing.T) {
 	defer func() { flag.CommandLine = oldCommandLine }()
 
 	logLevel := flag.String("log-level", "info", "")
-	flag.Parse()
+	flag.CommandLine.Parse([]string{}) // same reason as TestConfigLoadAndApply
 
 	config.ApplyToFlags(cfg)
 


### PR DESCRIPTION
Fixes the `flag provided but not defined: -test.paniconexit0` panic cascading 20+ failures across TestDriver*, TestWebhook_*, TestSlidingWindowLargeTransfer etc.

Root cause in tests/zz_config_test.go: two tests swap flag.CommandLine then call package-level flag.Parse() which reads os.Args[1:] (containing -test.paniconexit0 added by go test on 1.25.x). Sister test on line 72 already shows the right pattern.

Verified locally: `GOTOOLCHAIN=go1.25.10 go test -run TestConfig ./tests/` passes.