### PR TITLE
tests: move 26 feature-heavy tests to //go:build nightly (PR CI keeps core only)

### DIFF
--- a/tests/zz_audit_test.go
+++ b/tests/zz_audit_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_auto_join_test.go
+++ b/tests/zz_auto_join_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_commands_test.go
+++ b/tests/zz_commands_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_compat_dial_test.go
+++ b/tests/zz_compat_dial_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 // End-to-end compat-mode regression test. Drives a real Daemon.Dial
 // flow from a compat-mode (WSS-only) daemon to a UDP-mode peer
 // attached to the same beacon. Verifies the SYN → SYN-ACK → ACK

--- a/tests/zz_compat_registry_tls_test.go
+++ b/tests/zz_compat_registry_tls_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 // Compat-mode TLS-registry regression test. Spins up a registry server
 // with an auto-generated self-signed cert and an in-process beacon
 // with WSS bridge, then starts a compat daemon that pins the registry

--- a/tests/zz_concurrent_test.go
+++ b/tests/zz_concurrent_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_dashboard_helper_test.go
+++ b/tests/zz_dashboard_helper_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package tests
+
+// dashRegisterNode is shared test scaffolding. Used by zz_tags_test.go
+// (default-tag) so it lives in a default-tag helper file; originally
+// defined in zz_dashboard_test.go which got tagged //go:build nightly
+// to keep the dashboard-endpoint integration suite out of PR CI.
+
+import (
+	"testing"
+
+	registryclient "github.com/TeoSlayer/pilotprotocol/pkg/registry/client"
+	icrypto "github.com/pilot-protocol/common/crypto"
+)
+
+func dashRegisterNode(t *testing.T, addr, hostname string) {
+	t.Helper()
+	ident, err := icrypto.GenerateIdentity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	rc, err := registryclient.Dial(addr)
+	if err != nil {
+		t.Fatalf("dial registry: %v", err)
+	}
+	defer rc.Close()
+
+	msg := map[string]interface{}{
+		"type":        "register",
+		"listen_addr": "127.0.0.1:4000",
+		"public_key":  icrypto.EncodePublicKey(ident.PublicKey),
+	}
+	if hostname != "" {
+		msg["hostname"] = hostname
+	}
+
+	resp, err := rc.Send(msg)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if resp["type"] != "register_ok" {
+		t.Fatalf("expected register_ok, got %v", resp["type"])
+	}
+}

--- a/tests/zz_dashboard_test.go
+++ b/tests/zz_dashboard_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (
@@ -12,42 +14,10 @@ import (
 	"testing"
 	"time"
 
-	registryclient "github.com/TeoSlayer/pilotprotocol/pkg/registry/client"
-	icrypto "github.com/pilot-protocol/common/crypto"
 	registry "github.com/pilot-protocol/rendezvous"
 )
 
-// dashRegisterNode registers a test node with the given hostname via the registry client.
-func dashRegisterNode(t *testing.T, addr, hostname string) {
-	t.Helper()
-	ident, err := icrypto.GenerateIdentity()
-	if err != nil {
-		t.Fatalf("generate identity: %v", err)
-	}
-
-	rc, err := registryclient.Dial(addr)
-	if err != nil {
-		t.Fatalf("dial registry: %v", err)
-	}
-	defer rc.Close()
-
-	msg := map[string]interface{}{
-		"type":        "register",
-		"listen_addr": "127.0.0.1:4000",
-		"public_key":  icrypto.EncodePublicKey(ident.PublicKey),
-	}
-	if hostname != "" {
-		msg["hostname"] = hostname
-	}
-
-	resp, err := rc.Send(msg)
-	if err != nil {
-		t.Fatalf("register: %v", err)
-	}
-	if resp["type"] != "register_ok" {
-		t.Fatalf("expected register_ok, got %v", resp["type"])
-	}
-}
+// dashRegisterNode lives in zz_dashboard_helper_test.go (default-tag).
 
 func TestDashboardStatsEmpty(t *testing.T) {
 	t.Parallel()

--- a/tests/zz_data_exchange_policy_test.go
+++ b/tests/zz_data_exchange_policy_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_dataexchange_test.go
+++ b/tests/zz_dataexchange_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_email_required_test.go
+++ b/tests/zz_email_required_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_enterprise_gate_test.go
+++ b/tests/zz_enterprise_gate_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_eventstream_broker_parity_test.go
+++ b/tests/zz_eventstream_broker_parity_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 // §4.6 eventstream broker parity tests. Pre-T2.2 the daemon had its

--- a/tests/zz_eventstream_test.go
+++ b/tests/zz_eventstream_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_fuzz_registry_server_test.go
+++ b/tests/zz_fuzz_registry_server_test.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 

--- a/tests/zz_hostname_privacy_test.go
+++ b/tests/zz_hostname_privacy_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_invite_acceptance_test.go
+++ b/tests/zz_invite_acceptance_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_member_tags_test.go
+++ b/tests/zz_member_tags_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_nameserver_test.go
+++ b/tests/zz_nameserver_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_nat_traversal_test.go
+++ b/tests/zz_nat_traversal_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_network_policy_test.go
+++ b/tests/zz_network_policy_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_pilotctl_network_test.go
+++ b/tests/zz_pilotctl_network_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_privacy_test.go
+++ b/tests/zz_privacy_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_rbac_test.go
+++ b/tests/zz_rbac_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_webhook_capture_replay_test.go
+++ b/tests/zz_webhook_capture_replay_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 // Webhook capture-replay (T4.1 §4.7).
 //
 // For each of the nine events listed in 04-EXTRACTION.md §T4.1, we

--- a/tests/zz_webhook_collector_helper_test.go
+++ b/tests/zz_webhook_collector_helper_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package tests
+
+// webhookCollector is shared test scaffolding for any test that needs
+// to assert on emitted webhook events. Lives in a default-tag file so
+// non-nightly consumers (zz_fin_ack_test.go, zz_eventstream_broker_parity_test.go,
+// zz_syn_trust_gate_test.go) keep resolving after the heavier
+// zz_webhook_test.go got tagged //go:build nightly.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pilot-protocol/webhook"
+)
+
+type webhookCollector struct {
+	mu     sync.Mutex
+	events []webhook.Event
+	server *httptest.Server
+}
+
+func newWebhookCollector() *webhookCollector {
+	wc := &webhookCollector{}
+	wc.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad body", 400)
+			return
+		}
+		var ev webhook.Event
+		if err := json.Unmarshal(body, &ev); err != nil {
+			http.Error(w, "bad json", 400)
+			return
+		}
+		wc.mu.Lock()
+		wc.events = append(wc.events, ev)
+		wc.mu.Unlock()
+		w.WriteHeader(200)
+	}))
+	return wc
+}
+
+func (wc *webhookCollector) URL() string {
+	return wc.server.URL
+}
+
+func (wc *webhookCollector) Close() {
+	wc.server.Close()
+}
+
+func (wc *webhookCollector) Events() []webhook.Event {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+	cp := make([]webhook.Event, len(wc.events))
+	copy(cp, wc.events)
+	return cp
+}
+
+func (wc *webhookCollector) WaitFor(eventName string, timeout time.Duration) (*webhook.Event, bool) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		wc.mu.Lock()
+		for i := range wc.events {
+			if wc.events[i].Event == eventName {
+				ev := wc.events[i]
+				wc.mu.Unlock()
+				return &ev, true
+			}
+		}
+		wc.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, false
+}
+
+func (wc *webhookCollector) CountEvent(eventName string) int {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+	n := 0
+	for _, ev := range wc.events {
+		if ev.Event == eventName {
+			n++
+		}
+	}
+	return n
+}
+
+// WaitForCount polls until at least count events with the given name are received.
+func (wc *webhookCollector) WaitForCount(eventName string, count int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if wc.CountEvent(eventName) >= count {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// EventsMatching returns all events with the given name.
+func (wc *webhookCollector) EventsMatching(eventName string) []webhook.Event {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+	var out []webhook.Event
+	for _, ev := range wc.events {
+		if ev.Event == eventName {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// Avoid unused-symbol vet warning if no test calls testing.T helpers
+// from this file directly.
+var _ = (*testing.T)(nil)

--- a/tests/zz_webhook_test.go
+++ b/tests/zz_webhook_test.go
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -18,104 +18,6 @@ import (
 	internales "github.com/pilot-protocol/eventstream"
 	"github.com/pilot-protocol/webhook"
 )
-
-// webhookCollector is a test HTTP server that records received webhook events.
-type webhookCollector struct {
-	mu     sync.Mutex
-	events []webhook.Event
-	server *httptest.Server
-}
-
-func newWebhookCollector() *webhookCollector {
-	wc := &webhookCollector{}
-	wc.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "bad body", 400)
-			return
-		}
-		var ev webhook.Event
-		if err := json.Unmarshal(body, &ev); err != nil {
-			http.Error(w, "bad json", 400)
-			return
-		}
-		wc.mu.Lock()
-		wc.events = append(wc.events, ev)
-		wc.mu.Unlock()
-		w.WriteHeader(200)
-	}))
-	return wc
-}
-
-func (wc *webhookCollector) URL() string {
-	return wc.server.URL
-}
-
-func (wc *webhookCollector) Close() {
-	wc.server.Close()
-}
-
-func (wc *webhookCollector) Events() []webhook.Event {
-	wc.mu.Lock()
-	defer wc.mu.Unlock()
-	cp := make([]webhook.Event, len(wc.events))
-	copy(cp, wc.events)
-	return cp
-}
-
-func (wc *webhookCollector) WaitFor(eventName string, timeout time.Duration) (*webhook.Event, bool) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		wc.mu.Lock()
-		for i := range wc.events {
-			if wc.events[i].Event == eventName {
-				ev := wc.events[i]
-				wc.mu.Unlock()
-				return &ev, true
-			}
-		}
-		wc.mu.Unlock()
-		time.Sleep(10 * time.Millisecond)
-	}
-	return nil, false
-}
-
-func (wc *webhookCollector) CountEvent(eventName string) int {
-	wc.mu.Lock()
-	defer wc.mu.Unlock()
-	n := 0
-	for _, ev := range wc.events {
-		if ev.Event == eventName {
-			n++
-		}
-	}
-	return n
-}
-
-// WaitForCount polls until at least count events with the given name are received.
-func (wc *webhookCollector) WaitForCount(eventName string, count int, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if wc.CountEvent(eventName) >= count {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return false
-}
-
-// EventsMatching returns all events with the given name.
-func (wc *webhookCollector) EventsMatching(eventName string) []webhook.Event {
-	wc.mu.Lock()
-	defer wc.mu.Unlock()
-	var out []webhook.Event
-	for _, ev := range wc.events {
-		if ev.Event == eventName {
-			out = append(out, ev)
-		}
-	}
-	return out
-}
 
 // --- Unit tests for WebhookClient ---
 

--- a/tests/zz_window_test.go
+++ b/tests/zz_window_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (

--- a/tests/zz_zerowindow_test.go
+++ b/tests/zz_zerowindow_test.go
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//go:build nightly
+
 package tests
 
 import (


### PR DESCRIPTION
PR CI scope: 770 → 309 tests. Heavy TestEnv-based feature/plugin tests gated nightly; full 833 still run in nightly.yml. Core daemon/transport/crypto/handshake stays on PR CI.