### PR TITLE
tests: bump hard deadlines on 2 known flakes (TestConnectionAfterPeerRestart, TestResolveTOCTOUConcurrency)

### DIFF
--- a/tests/zz_lifecycle_test.go
+++ b/tests/zz_lifecycle_test.go
@@ -309,11 +309,17 @@ func TestConnectionAfterPeerRestart(t *testing.T) {
 	bDrv.Close()
 	bDaemon.Stop()
 
-	// Server A should eventually get an error
+	// Server A should eventually get an error.
+	// 60s budget: peer-crash detection traverses several round-trips
+	// (peer FIN/RST → connection-state transition → server Read returns
+	// error). On CI runners under -parallel 4 with many other daemons
+	// running, the 30s prior budget intermittently misses; doubling
+	// gives comfortable margin without making the test slow on the
+	// happy path (still returns in ~3s in isolation).
 	select {
 	case err := <-serverErr:
 		t.Logf("server got error after peer crash: %v", err)
-	case <-time.After(30 * time.Second):
+	case <-time.After(60 * time.Second):
 		t.Fatal("server did not detect peer crash within timeout")
 	}
 }

--- a/tests/zz_security_fixes_test.go
+++ b/tests/zz_security_fixes_test.go
@@ -507,9 +507,14 @@ func TestResolveTOCTOUConcurrency(t *testing.T) {
 		close(waitDone)
 	}()
 
+	// 60s budget: the test spins 50 revoke/report cycles + a continuous
+	// resolve loop on shared registry state. Under -parallel 4 on CI
+	// runners the 15s prior budget intermittently misses; bumping to
+	// 60s gives margin without slowing the happy path (cycles run in
+	// ~5s in isolation).
 	select {
 	case <-waitDone:
-	case <-time.After(15 * time.Second):
+	case <-time.After(60 * time.Second):
 		close(done)
 		t.Fatal("TOCTOU test timed out")
 	}


### PR DESCRIPTION
Both pass instantly in isolation; fail intermittently under -parallel 4 on CI due to tight hard-coded deadlines (30s and 15s respectively). Bumped to 60s each. No logic change.