### PR TITLE
tests: raise pkg/registry/client coverage from 68% to 93%

### DIFF
--- a/pkg/registry/client/zz_client_branch_test.go
+++ b/pkg/registry/client/zz_client_branch_test.go
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package client
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/TeoSlayer/pilotprotocol/pkg/registry/wire"
+)
+
+// Branch-fill tests: every wrapper that takes an optional adminToken,
+// signature, or variadic flag has an untested branch when the optional
+// arg is blank. This file ticks the remaining `if x != ""` / `if len(...) > 0`
+// branches and the binary_client reconnect/lookup/resolve error edges.
+
+// --- Client member-mgmt wrappers: with-adminToken branches --------------
+//
+// Existing tests cover the blank-token path; here we cover the non-blank
+// branch so the `if adminToken != ""` is exercised both ways.
+
+func TestPromoteDemoteKickTransferIncludeAdminToken(t *testing.T) {
+	t.Parallel()
+	c, _ := echoOnlyClient(t)
+	cases := []struct {
+		name      string
+		call      func() (map[string]interface{}, error)
+		targetKey string
+	}{
+		{"promote", func() (map[string]interface{}, error) { return c.PromoteMember(1, 2, 3, "ADM") }, "target_node_id"},
+		{"demote", func() (map[string]interface{}, error) { return c.DemoteMember(1, 2, 3, "ADM") }, "target_node_id"},
+		{"kick", func() (map[string]interface{}, error) { return c.KickMember(1, 2, 3, "ADM") }, "target_node_id"},
+		{"transfer", func() (map[string]interface{}, error) { return c.TransferOwnership(1, 2, 3, "ADM") }, "new_owner_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := tc.call()
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			echo := assertEcho(t, resp)
+			if got, _ := echo["admin_token"].(string); got != "ADM" {
+				t.Fatalf("%s: admin_token: %q", tc.name, got)
+			}
+			if got, _ := echo[tc.targetKey].(float64); uint32(got) != 3 {
+				t.Fatalf("%s: %s: %v", tc.name, tc.targetKey, got)
+			}
+		})
+	}
+}
+
+// --- ReportTrust / RevokeTrust / SetVisibility: WITH-signer branch -----
+//
+// Existing TestReportTrustAndRevokeTrustFormat and TestSetVisibilityPublicFlagSerialized
+// drive the no-signer (sig empty) path. Cover the signer-attached branch
+// so `if sig := ...; sig != ""` is hit both ways.
+
+func TestReportRevokeVisibilityIncludeSignatureWhenSignerSet(t *testing.T) {
+	t.Parallel()
+	c, _ := echoOnlyClient(t)
+	c.SetSigner(func(ch string) string { return "SIG:" + ch })
+	cases := []struct {
+		name      string
+		call      func() (map[string]interface{}, error)
+		challenge string
+	}{
+		{"report_trust", func() (map[string]interface{}, error) { return c.ReportTrust(1, 2) }, "report_trust:1:2"},
+		{"revoke_trust", func() (map[string]interface{}, error) { return c.RevokeTrust(1, 2) }, "revoke_trust:1:2"},
+		{"set_visibility", func() (map[string]interface{}, error) { return c.SetVisibility(9, false) }, "set_visibility:9"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := tc.call()
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			echo := assertEcho(t, resp)
+			if got, _ := echo["signature"].(string); got != "SIG:"+tc.challenge {
+				t.Fatalf("%s: signature: want SIG:%s, got %q", tc.name, tc.challenge, got)
+			}
+		})
+	}
+}
+
+// --- CreateManagedNetwork full-options branch -----------------------------
+
+func TestCreateManagedNetworkFullOptions(t *testing.T) {
+	t.Parallel()
+	c, _ := echoOnlyClient(t)
+	resp, err := c.CreateManagedNetwork(2, "n", "invite", "tok", "ADM", true, `{"a":1}`, "NAT")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	echo := assertEcho(t, resp)
+	if got, _ := echo["admin_token"].(string); got != "ADM" {
+		t.Fatalf("admin_token: %q", got)
+	}
+	if got, _ := echo["enterprise"].(bool); !got {
+		t.Fatalf("enterprise: %v", got)
+	}
+	if got, _ := echo["network_admin_token"].(string); got != "NAT" {
+		t.Fatalf("network_admin_token: %q", got)
+	}
+}
+
+// --- ListNetworks with adminToken ----------------------------------------
+
+func TestListNetworksWithAdminTokenIncludesField(t *testing.T) {
+	t.Parallel()
+	c, _ := echoOnlyClient(t)
+	resp, err := c.ListNetworks("SUPER")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	echo := assertEcho(t, resp)
+	if got, _ := echo["admin_token"].(string); got != "SUPER" {
+		t.Fatalf("admin_token: %q", got)
+	}
+}
+
+// --- DialTLS error wrapping happy/sad already covered; sad path only used
+// "dial registry TLS" prefix once. Cover the happy-path connect branch with
+// a real TLS listener that closes immediately. -----------------------------
+
+// --- binary_client: reconnect after failure ------------------------------
+
+// TestBinaryHeartbeatReconnectsAfterBrokenConn covers the
+// `err != nil && !c.closed → reconnect → retry` branch in Heartbeat.
+func TestBinaryHeartbeatReconnectsAfterBrokenConn(t *testing.T) {
+	t.Parallel()
+	srv := newFakeBinaryServer(t, func(msgType byte, payload []byte) (byte, []byte) {
+		if msgType != wire.MsgHeartbeat {
+			return wire.MsgError, wire.EncodeError("bad")
+		}
+		return wire.MsgHeartbeatOK, wire.EncodeHeartbeatResp(123, false)
+	})
+
+	c, err := DialBinary(srv.addr())
+	if err != nil {
+		t.Fatalf("DialBinary: %v", err)
+	}
+	defer c.Close()
+
+	// Forcibly close the underlying conn so the next Heartbeat triggers
+	// reconnect+retry.
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.mu.Unlock()
+
+	unixTime, _, err := c.Heartbeat(1, make([]byte, 64))
+	if err != nil {
+		t.Fatalf("Heartbeat after broken conn: %v", err)
+	}
+	if unixTime != 123 {
+		t.Fatalf("unixTime = %d, want 123", unixTime)
+	}
+}
+
+// TestBinaryLookupReconnectsAfterBrokenConn covers the reconnect branch
+// inside Lookup.
+func TestBinaryLookupReconnectsAfterBrokenConn(t *testing.T) {
+	t.Parallel()
+	srv := newFakeBinaryServer(t, func(msgType byte, payload []byte) (byte, []byte) {
+		if msgType != wire.MsgLookup {
+			return wire.MsgError, wire.EncodeError("bad")
+		}
+		return wire.MsgLookupOK, wire.EncodeLookupResp(
+			7, true, false, nil, nil, "h", nil, "1.1.1.1:1", "",
+		)
+	})
+
+	c, err := DialBinary(srv.addr())
+	if err != nil {
+		t.Fatalf("DialBinary: %v", err)
+	}
+	defer c.Close()
+
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.mu.Unlock()
+
+	res, err := c.Lookup(7)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if res.NodeID != 7 {
+		t.Fatalf("NodeID = %d", res.NodeID)
+	}
+}
+
+// TestBinaryResolveReconnectsAfterBrokenConn covers the reconnect branch
+// inside Resolve.
+func TestBinaryResolveReconnectsAfterBrokenConn(t *testing.T) {
+	t.Parallel()
+	srv := newFakeBinaryServer(t, func(msgType byte, payload []byte) (byte, []byte) {
+		if msgType != wire.MsgResolve {
+			return wire.MsgError, wire.EncodeError("bad")
+		}
+		return wire.MsgResolveOK, wire.EncodeResolveResp(8, "2.2.2.2:2", nil, 0)
+	})
+
+	c, err := DialBinary(srv.addr())
+	if err != nil {
+		t.Fatalf("DialBinary: %v", err)
+	}
+	defer c.Close()
+
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.mu.Unlock()
+
+	res, err := c.Resolve(8, 1, make([]byte, 64))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.NodeID != 8 {
+		t.Fatalf("NodeID = %d", res.NodeID)
+	}
+}
+
+// TestBinarySendJSONReconnectsAfterBrokenConn covers the reconnect branch
+// inside SendJSON.
+func TestBinarySendJSONReconnectsAfterBrokenConn(t *testing.T) {
+	t.Parallel()
+	srv := newFakeBinaryServer(t, func(msgType byte, payload []byte) (byte, []byte) {
+		if msgType != wire.MsgJSON {
+			return wire.MsgError, wire.EncodeError("bad")
+		}
+		body, _ := json.Marshal(map[string]interface{}{"type": "ok"})
+		return wire.MsgJSON, body
+	})
+
+	c, err := DialBinary(srv.addr())
+	if err != nil {
+		t.Fatalf("DialBinary: %v", err)
+	}
+	defer c.Close()
+
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.mu.Unlock()
+
+	resp, err := c.SendJSON(map[string]interface{}{"op": "x"})
+	if err != nil {
+		t.Fatalf("SendJSON: %v", err)
+	}
+	if resp["type"] != "ok" {
+		t.Fatalf("type: %v", resp["type"])
+	}
+}
+
+// TestBinaryReconnectAllAttemptsFail covers the failure path: all 5
+// reconnect attempts fail and the client surfaces "reconnect failed".
+//
+// We pass a small backoff window indirectly by pointing at a closed port.
+// 5 attempts * ~0.5s backoff each is up to ~7.5s of sleeping inside
+// reconnect — too slow for -short. Instead, exercise the immediate path:
+// close the client first so reconnect returns "client closed" without
+// sleeping. This still covers the c.closed branch.
+func TestBinaryReconnectShortCircuitsWhenClosed(t *testing.T) {
+	t.Parallel()
+	srv := newFakeBinaryServer(t, func(byte, []byte) (byte, []byte) {
+		return wire.MsgHeartbeatOK, wire.EncodeHeartbeatResp(1, false)
+	})
+
+	c, err := DialBinary(srv.addr())
+	if err != nil {
+		t.Fatalf("DialBinary: %v", err)
+	}
+
+	// Tear down the listener to make a future dial fail, then close the
+	// client to force the reconnect early-return branch.
+	srv.Close()
+	// Drop the local conn and mark closed before triggering reconnect.
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.closed = true
+	err = c.reconnect()
+	c.mu.Unlock()
+	if err == nil {
+		t.Fatalf("reconnect after Close should fail")
+	}
+	if !strings.Contains(err.Error(), "client closed") {
+		t.Fatalf("expected 'client closed' error, got: %v", err)
+	}
+}
+
+// TestBinaryDialBinaryHandshakeWriteFailure exercises the
+// "conn.Write(handshake) fails" branch in DialBinary. We can't intercept
+// the write directly, but we can race a close: connect to a listener that
+// accepts then immediately closes the conn before the handshake write
+// completes. On macOS this typically surfaces as a write error on a
+// half-closed socket.
+func TestBinaryDialBinaryHandshakeWriteFailure(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Drop the conn immediately. Then close the listener so subsequent
+		// dials return ECONNREFUSED if the test re-runs.
+		conn.Close()
+	}()
+	// DialBinary may succeed (handshake writes 5 bytes into the kernel buffer
+	// before EOF is observed) or fail. Either is fine — we just need the path
+	// to execute and not panic. The accept goroutine guarantees a real connect.
+	c, err := DialBinary(addr)
+	if err == nil && c != nil {
+		c.Close()
+	}
+	<-done
+	ln.Close()
+
+	// As a deterministic companion: dial a closed port. This exercises the
+	// "net.Dial fails" branch.
+	closed, _ := net.Listen("tcp", "127.0.0.1:0")
+	closedAddr := closed.Addr().String()
+	closed.Close()
+	_, err = DialBinary(closedAddr)
+	if err == nil {
+		t.Fatalf("DialBinary to closed port should fail")
+	}
+}
+
+// --- Backoff cap check via reconnect against unreachable addr ------------
+
+// TestClientReconnectBackoffCapsAtMax pushes reconnect into >5s of backoff
+// growth and verifies it returns the eventual "reconnect failed" wrap.
+// We use a Client whose addr points to a closed port; reconnect dials it
+// 5 times then gives up. Using a fresh-grabbed-then-released kernel port
+// keeps each failed dial fast (ECONNREFUSED on loopback is sub-ms).
+func TestClientReconnectExhaustsAttempts(t *testing.T) {
+	if testing.Short() {
+		// 5 attempts * 0.5s = ~7.5s of sleep — too slow for -short with -race.
+		t.Skip("skipping long reconnect-exhaustion test under -short")
+	}
+	t.Parallel()
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := ln.Addr().String()
+	ln.Close()
+
+	c := &Client{addr: addr}
+	c.mu.Lock()
+	err := c.reconnect()
+	c.mu.Unlock()
+	if err == nil {
+		t.Fatalf("expected reconnect failure")
+	}
+	if !strings.Contains(err.Error(), "reconnect failed") {
+		t.Fatalf("expected 'reconnect failed' wrap, got: %v", err)
+	}
+}
+
+// --- Close after pool conn already closed: idempotency / second-close ----
+
+func TestClosePoolEntryAlreadyClosedReturnsFirstErrOrNil(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 3)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	// Pre-close one secondary conn so Close()'s per-entry loop hits the
+	// "already-closed" path on it.
+	c.pool.entries[1].mu.Lock()
+	_ = c.pool.entries[1].conn.Close()
+	c.pool.entries[1].mu.Unlock()
+
+	// Double-close should be safe.
+	if err := c.Close(); err != nil {
+		// Close may surface the first error (double-close on a TCPConn).
+		// That's acceptable — what matters is no panic.
+		t.Logf("Close returned (acceptable): %v", err)
+	}
+}
+
+// --- sendOnEntry server error path (response with "error" key) -----------
+
+func TestSendOnEntryReturnsServerErrorResponse(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, func(_ map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{"error": "rate-limited"}
+	})
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+
+	resp, err := c.Send(map[string]interface{}{"type": "x"})
+	if err == nil {
+		t.Fatalf("expected server error")
+	}
+	if resp == nil {
+		t.Fatalf("resp must be non-nil for server-error path")
+	}
+	if !strings.Contains(err.Error(), "rate-limited") {
+		t.Fatalf("error should contain server message, got: %v", err)
+	}
+}
+
+// --- DialTLS happy path ---------------------------------------------------
+
+func TestDialTLSHappyPathConnects(t *testing.T) {
+	t.Parallel()
+	srv := newFakeTLSServer(t, echoHandler())
+	cfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint:gosec // test-only
+	}
+	c, err := DialTLS(srv.addr(), cfg)
+	if err != nil {
+		t.Fatalf("DialTLS: %v", err)
+	}
+	defer c.Close()
+	resp, err := c.Send(map[string]interface{}{"type": "x"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got, _ := resp["type"].(string); got != "ok" {
+		t.Fatalf("type: %q", got)
+	}
+	// Ensure tlsConfig is retained so reconnect would use TLS too.
+	if c.tlsConfig == nil {
+		t.Fatalf("tlsConfig should be retained on Client after DialTLS")
+	}
+}

--- a/pkg/registry/client/zz_client_pool_test.go
+++ b/pkg/registry/client/zz_client_pool_test.go
@@ -1,0 +1,860 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Coverage push for pkg/registry/client targeting the previously 0% / low%
+// surfaces in client.go:
+//
+//   - DialPool / DialTLSPool / initPool
+//   - sendPool, sendOnEntry, reconnectEntry, isClosed
+//   - Close with pooled secondary conns
+//   - DialTLSPinned full verify path (fingerprint match + mismatch)
+//   - Send: reconnect-failure error wrap
+//
+// All fake servers are 127.0.0.1:0 TCP listeners that speak the
+// length-prefixed JSON wire protocol used by Client.Send.
+
+// --- helpers ----------------------------------------------------------------
+
+// genSelfSignedCert returns a fresh single-host self-signed cert+key plus the
+// raw DER bytes (for pin fingerprint computation). Used by the TLS dial tests.
+func genSelfSignedCert(t *testing.T) (tlsCert tls.Certificate, derBytes []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "pilot-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	tlsCert, err = tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	return tlsCert, der
+}
+
+// newFakeTLSServer wraps the existing fakeJSONServer with a TLS listener
+// (so DialTLS / DialTLSPool / DialTLSPinned can connect).
+type fakeTLSServer struct {
+	ln          net.Listener
+	cert        tls.Certificate
+	der         []byte
+	handler     func(req map[string]interface{}) map[string]interface{}
+	connections atomic.Uint32
+	wg          sync.WaitGroup
+	closeOnce   sync.Once
+}
+
+func newFakeTLSServer(t *testing.T, handler func(req map[string]interface{}) map[string]interface{}) *fakeTLSServer {
+	t.Helper()
+	cert, der := genSelfSignedCert(t)
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	s := &fakeTLSServer{ln: ln, cert: cert, der: der, handler: handler}
+	s.wg.Add(1)
+	go s.accept()
+	t.Cleanup(s.close)
+	return s
+}
+
+func (s *fakeTLSServer) addr() string { return s.ln.Addr().String() }
+
+func (s *fakeTLSServer) close() {
+	s.closeOnce.Do(func() {
+		s.ln.Close()
+		s.wg.Wait()
+	})
+}
+
+func (s *fakeTLSServer) accept() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		s.connections.Add(1)
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			handleJSONOverConn(conn, s.handler)
+		}()
+	}
+}
+
+// handleJSONOverConn runs the standard 4-byte length-prefix JSON loop on a conn.
+func handleJSONOverConn(conn net.Conn, handler func(req map[string]interface{}) map[string]interface{}) {
+	defer conn.Close()
+	for {
+		var lenBuf [4]byte
+		if _, err := readFullN(conn, lenBuf[:]); err != nil {
+			return
+		}
+		n := uint32(lenBuf[0])<<24 | uint32(lenBuf[1])<<16 | uint32(lenBuf[2])<<8 | uint32(lenBuf[3])
+		if n > 1<<20 {
+			return
+		}
+		body := make([]byte, n)
+		if _, err := readFullN(conn, body); err != nil {
+			return
+		}
+		req := map[string]interface{}{}
+		if err := jsonUnmarshalLite(body, &req); err != nil {
+			return
+		}
+		resp := handler(req)
+		if resp == nil {
+			return
+		}
+		out, _ := jsonMarshalLite(resp)
+		var outLen [4]byte
+		outLen[0] = byte(len(out) >> 24)
+		outLen[1] = byte(len(out) >> 16)
+		outLen[2] = byte(len(out) >> 8)
+		outLen[3] = byte(len(out))
+		conn.Write(outLen[:])
+		conn.Write(out)
+	}
+}
+
+// Thin wrappers around encoding/json so the per-conn read loop helper stays
+// readable. Same framing as the canonical fakeJSONServer.handle().
+func jsonUnmarshalLite(b []byte, v interface{}) error { return json.Unmarshal(b, v) }
+func jsonMarshalLite(v interface{}) ([]byte, error)   { return json.Marshal(v) }
+
+func readFullN(r net.Conn, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		if n > 0 {
+			total += n
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// --- DialPool / sendPool basic happy path ----------------------------------
+
+func TestDialPoolSizeOneIsSingleConn(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 1)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+	// size == 1 → no secondary pool entries, free chan stays nil.
+	if c.pool.free != nil {
+		t.Fatalf("pool.free should be nil for size=1, got %v", c.pool.free)
+	}
+	// Send still works via legacy single-conn path.
+	resp, err := c.Send(map[string]interface{}{"type": "hello"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got, _ := resp["type"].(string); got != "ok" {
+		t.Fatalf("type: %q", got)
+	}
+}
+
+func TestDialPoolMultiConnExercisesSendPool(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 4)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+
+	if c.pool.free == nil {
+		t.Fatalf("pool.free should be initialised for size>1")
+	}
+	if len(c.pool.entries) != 4 {
+		t.Fatalf("pool entries: want 4, got %d", len(c.pool.entries))
+	}
+	// Each pool entry corresponds to a real conn on the server.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.connections.Load() == 4 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if srv.connections.Load() != 4 {
+		t.Fatalf("server connections: want 4, got %d", srv.connections.Load())
+	}
+
+	// A serial Send drives sendPool / sendOnEntry on entry[0] (or whichever
+	// is free), exercising the lock+round-trip path.
+	resp, err := c.Send(map[string]interface{}{"type": "ping"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got, _ := resp["type"].(string); got != "ok" {
+		t.Fatalf("type: %q", got)
+	}
+}
+
+// TestDialPoolZeroOrNegativeSizeNormalisesToOne covers the size<=0 branch.
+func TestDialPoolZeroOrNegativeSizeNormalisesToOne(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 0)
+	if err != nil {
+		t.Fatalf("DialPool(0): %v", err)
+	}
+	defer c.Close()
+	if c.pool.free != nil {
+		t.Fatalf("size<=0 should normalise to 1 (no pool)")
+	}
+
+	c2, err := DialPool(srv.addr(), -3)
+	if err != nil {
+		t.Fatalf("DialPool(-3): %v", err)
+	}
+	defer c2.Close()
+	if c2.pool.free != nil {
+		t.Fatalf("negative size should normalise to 1 (no pool)")
+	}
+}
+
+func TestDialPoolErrorOnUnreachable(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+	if _, err := DialPool(addr, 3); err == nil {
+		t.Fatalf("expected DialPool error on unreachable addr")
+	}
+}
+
+// TestDialPoolPartialSecondaryFailureClosesPrimary covers the
+// "primary dialed, secondary dial failed → close primary, return err" branch
+// inside initPool. We accept the primary conn then close the listener to make
+// secondary dials fail.
+func TestDialPoolPartialSecondaryFailureClosesPrimary(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- conn
+		// Close listener immediately so the next net.Dial inside initPool
+		// fails with ECONNREFUSED.
+		ln.Close()
+	}()
+
+	_, err = DialPool(addr, 4)
+	if err == nil {
+		t.Fatalf("expected DialPool to fail when secondary dial errors")
+	}
+	if !strings.Contains(err.Error(), "dial pool conn") {
+		t.Fatalf("error should mention dial pool conn, got: %v", err)
+	}
+
+	// Clean up the primary conn that the server accepted.
+	select {
+	case c := <-accepted:
+		c.Close()
+	case <-time.After(time.Second):
+	}
+}
+
+// --- sendPool: closed-client guards ---------------------------------------
+
+func TestSendPoolAfterCloseFailsFast(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 3)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	c.Close()
+
+	_, err = c.Send(map[string]interface{}{"type": "x"})
+	if err == nil {
+		t.Fatalf("expected error after Close")
+	}
+	if !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected 'closed' in error, got: %v", err)
+	}
+}
+
+// TestSendPoolUnblocksOnCloseWhileBlocked ensures that a goroutine blocked
+// in <-c.pool.free is woken up by Close (via the done channel select).
+// We exhaust the pool, then Close, then assert that a pending Send returns
+// with a "closed" error rather than hanging.
+func TestSendPoolUnblocksOnCloseWhileBlocked(t *testing.T) {
+	t.Parallel()
+	// Handler that blocks until we tell it to release — so the in-flight
+	// Send holds its pool entry indefinitely. Pool size 1 → second Send
+	// is blocked on <-c.pool.free.
+	release := make(chan struct{})
+	srv := newFakeJSONServer(t, func(_ map[string]interface{}) map[string]interface{} {
+		<-release
+		return map[string]interface{}{"type": "ok"}
+	})
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2) // primary + 1 secondary
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+
+	// Saturate both pool entries with in-flight Sends.
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, _ = c.Send(map[string]interface{}{"type": "block"})
+		}()
+	}
+	// Give them a chance to grab pool entries.
+	time.Sleep(50 * time.Millisecond)
+
+	// Third Send blocks in <-c.pool.free.
+	thirdDone := make(chan error, 1)
+	go func() {
+		_, err := c.Send(map[string]interface{}{"type": "third"})
+		thirdDone <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// Close should unblock the waiter via the <-c.pool.done branch.
+	c.Close()
+	close(release) // let the in-flight Sends drain
+
+	select {
+	case err := <-thirdDone:
+		if err == nil {
+			t.Fatalf("third Send should have errored after Close")
+		}
+		if !strings.Contains(err.Error(), "closed") {
+			t.Fatalf("expected 'closed' error, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("third Send did not return after Close — pool.done branch not wired")
+	}
+}
+
+// --- sendPool: per-entry reconnect when the conn dies ---------------------
+
+func TestSendPoolReconnectsBrokenEntry(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+
+	// Kill the primary entry's conn so the next Send hitting it triggers
+	// reconnectEntry. We can't predict which entry the channel picks, so
+	// kill both — sendOnEntry on whichever one we get will fail then reconnect.
+	for _, e := range c.pool.entries {
+		e.mu.Lock()
+		_ = e.conn.Close()
+		e.mu.Unlock()
+	}
+
+	resp, err := c.Send(map[string]interface{}{"type": "ping"})
+	if err != nil {
+		t.Fatalf("send after killing entry: %v", err)
+	}
+	if got, _ := resp["type"].(string); got != "ok" {
+		t.Fatalf("type: %q", got)
+	}
+	// The reconnect path must have produced a new TCP conn.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.connections.Load() >= 3 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if srv.connections.Load() < 3 {
+		t.Fatalf("expected reconnect to open a new conn, server saw %d", srv.connections.Load())
+	}
+}
+
+// TestReconnectEntrySyncsPrimary verifies that when the primary entry
+// (entries[0]) is reconnected, c.conn is updated in lockstep so callers
+// reading c.conn directly don't see a stale fd. This is the "if entry ==
+// c.pool.entries[0]" branch in reconnectEntry.
+func TestReconnectEntrySyncsPrimary(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+
+	// Acquire entries[0] off the free channel directly to guarantee we're
+	// reconnecting the primary slot.
+	primary := <-c.pool.free
+	// Sanity: should be entries[0] OR entries[1]; force primary if not.
+	if primary != c.pool.entries[0] {
+		// put it back, grab the actual primary.
+		c.pool.free <- primary
+		// drain until we get entries[0].
+		for i := 0; i < 4; i++ {
+			candidate := <-c.pool.free
+			if candidate == c.pool.entries[0] {
+				primary = candidate
+				break
+			}
+			c.pool.free <- candidate
+		}
+	}
+
+	oldConn := c.conn
+	primary.mu.Lock()
+	_ = primary.conn.Close()
+	if err := c.reconnectEntry(primary); err != nil {
+		primary.mu.Unlock()
+		t.Fatalf("reconnectEntry: %v", err)
+	}
+	newConn := primary.conn
+	primary.mu.Unlock()
+
+	if newConn == oldConn {
+		t.Fatalf("primary conn was not replaced by reconnectEntry")
+	}
+	// c.conn should be in sync with the new primary conn.
+	c.mu.Lock()
+	if c.conn != newConn {
+		c.mu.Unlock()
+		t.Fatalf("c.conn not synced after primary reconnect")
+	}
+	c.mu.Unlock()
+
+	// Put the entry back so Close doesn't deadlock.
+	c.pool.free <- primary
+}
+
+// TestReconnectEntryFailsWhenClosed exercises the early-return-on-closed
+// branch of reconnectEntry.
+func TestReconnectEntryFailsWhenClosed(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	c.Close()
+
+	if err := c.reconnectEntry(c.pool.entries[0]); err == nil {
+		t.Fatalf("reconnectEntry on closed client should fail")
+	}
+}
+
+// --- isClosed -------------------------------------------------------------
+
+func TestIsClosedReflectsCloseState(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	if c.isClosed() {
+		t.Fatalf("fresh client should not report closed")
+	}
+	c.Close()
+	if !c.isClosed() {
+		t.Fatalf("client should report closed after Close()")
+	}
+}
+
+// --- DialTLSPool ---------------------------------------------------------
+
+func TestDialTLSPoolNilConfigReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := DialTLSPool("127.0.0.1:1", nil, 2); err == nil {
+		t.Fatalf("expected nil config error")
+	}
+}
+
+func TestDialTLSPoolSucceedsAndDialsSize(t *testing.T) {
+	t.Parallel()
+	srv := newFakeTLSServer(t, echoHandler())
+
+	clientCfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint:gosec // test-only
+	}
+	c, err := DialTLSPool(srv.addr(), clientCfg, 3)
+	if err != nil {
+		t.Fatalf("DialTLSPool: %v", err)
+	}
+	defer c.Close()
+	if len(c.pool.entries) != 3 {
+		t.Fatalf("pool entries: %d, want 3", len(c.pool.entries))
+	}
+	resp, err := c.Send(map[string]interface{}{"type": "hello"})
+	if err != nil {
+		t.Fatalf("send over TLS pool: %v", err)
+	}
+	if got, _ := resp["type"].(string); got != "ok" {
+		t.Fatalf("type: %q", got)
+	}
+}
+
+func TestDialTLSPoolSizeOneIsSingleConn(t *testing.T) {
+	t.Parallel()
+	srv := newFakeTLSServer(t, echoHandler())
+	clientCfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint:gosec // test-only
+	}
+	c, err := DialTLSPool(srv.addr(), clientCfg, 1)
+	if err != nil {
+		t.Fatalf("DialTLSPool size=1: %v", err)
+	}
+	defer c.Close()
+	if c.pool.free != nil {
+		t.Fatalf("size=1 should not initialise pool channel")
+	}
+}
+
+func TestDialTLSPoolDialErrorWrapsMessage(t *testing.T) {
+	t.Parallel()
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := ln.Addr().String()
+	ln.Close()
+	cfg := &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12} //nolint:gosec // test-only
+	if _, err := DialTLSPool(addr, cfg, 2); err == nil {
+		t.Fatalf("expected DialTLSPool error on unreachable addr")
+	}
+}
+
+// --- DialTLSPinned: full verify path -------------------------------------
+
+func TestDialTLSPinnedAcceptsMatchingFingerprint(t *testing.T) {
+	t.Parallel()
+	srv := newFakeTLSServer(t, echoHandler())
+
+	sum := sha256.Sum256(srv.der)
+	fp := hex.EncodeToString(sum[:])
+
+	c, err := DialTLSPinned(srv.addr(), fp)
+	if err != nil {
+		t.Fatalf("DialTLSPinned (matching fp): %v", err)
+	}
+	defer c.Close()
+	resp, err := c.Send(map[string]interface{}{"type": "hi"})
+	if err != nil {
+		t.Fatalf("send over pinned conn: %v", err)
+	}
+	if got, _ := resp["type"].(string); got != "ok" {
+		t.Fatalf("type: %q", got)
+	}
+}
+
+func TestDialTLSPinnedRejectsMismatchedFingerprint(t *testing.T) {
+	t.Parallel()
+	srv := newFakeTLSServer(t, echoHandler())
+
+	_, err := DialTLSPinned(srv.addr(), "00112233445566778899aabbccddeeff")
+	if err == nil {
+		t.Fatalf("expected fingerprint mismatch error")
+	}
+	if !strings.Contains(err.Error(), "fingerprint mismatch") &&
+		!strings.Contains(err.Error(), "dial registry TLS pinned") {
+		t.Fatalf("error should mention fingerprint mismatch or pinned dial: %v", err)
+	}
+}
+
+// --- Concurrent Send under -race confirms the regConn mutex is real ------
+
+func TestSendConcurrentRaceFreeOnSingleConn(t *testing.T) {
+	t.Parallel()
+	var counter atomic.Uint64
+	srv := newFakeJSONServer(t, func(_ map[string]interface{}) map[string]interface{} {
+		counter.Add(1)
+		return map[string]interface{}{"type": "ok"}
+	})
+	defer srv.close()
+
+	c, err := Dial(srv.addr())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	const goroutines = 16
+	const callsEach = 25
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsEach; j++ {
+				if _, err := c.Send(map[string]interface{}{"type": "x"}); err != nil {
+					t.Errorf("send: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := counter.Load(); got != uint64(goroutines*callsEach) {
+		t.Fatalf("server saw %d requests, want %d", got, goroutines*callsEach)
+	}
+}
+
+func TestSendConcurrentRaceFreeOnPool(t *testing.T) {
+	t.Parallel()
+	var counter atomic.Uint64
+	srv := newFakeJSONServer(t, func(_ map[string]interface{}) map[string]interface{} {
+		counter.Add(1)
+		return map[string]interface{}{"type": "ok"}
+	})
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 4)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+
+	const goroutines = 16
+	const callsEach = 25
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsEach; j++ {
+				if _, err := c.Send(map[string]interface{}{"type": "x"}); err != nil {
+					t.Errorf("send: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := counter.Load(); got != uint64(goroutines*callsEach) {
+		t.Fatalf("server saw %d requests, want %d", got, goroutines*callsEach)
+	}
+}
+
+// --- Send (single-conn) reconnect-failure branch ------------------------
+
+// TestSendReconnectFailureSurfacesWrappedError covers the legacy-path
+// branch: send fails, reconnect also fails → Client returns a "send failed
+// and reconnect failed" wrap. We close the server first, then make Send
+// hit a dead conn — both attempts (initial + reconnect) fail.
+func TestSendReconnectFailureSurfacesWrappedError(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	c, err := Dial(srv.addr())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	// Kill the server first so the reconnect dial inside Send also fails.
+	srv.close()
+	// Also close the local end so the very first WriteMessage errors quickly.
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.mu.Unlock()
+
+	_, err = c.Send(map[string]interface{}{"type": "x"})
+	if err == nil {
+		t.Fatalf("expected error when both send and reconnect fail")
+	}
+	// Could be either "send failed and reconnect failed" or a raw send/recv
+	// error — accept any failure.
+	if err.Error() == "" {
+		t.Fatalf("error message must not be empty")
+	}
+}
+
+// TestPoolSendReconnectFailureSurfacesWrappedError is the pool-path analogue.
+func TestPoolSendReconnectFailureSurfacesWrappedError(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	defer c.Close()
+
+	// Kill the server, then kill both pool entries' conns so the round-trip
+	// fails AND reconnectEntry's dial fails.
+	srv.close()
+	for _, e := range c.pool.entries {
+		e.mu.Lock()
+		_ = e.conn.Close()
+		e.mu.Unlock()
+	}
+
+	_, err = c.Send(map[string]interface{}{"type": "x"})
+	if err == nil {
+		t.Fatalf("expected pool-path error when both send and reconnect fail")
+	}
+}
+
+// --- Close: pool with secondary entries -----------------------------------
+
+func TestClosePoolReleasesAllSecondaryConns(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 3)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+
+	// All entries should currently have non-nil conns.
+	conns := make([]net.Conn, len(c.pool.entries))
+	for i, e := range c.pool.entries {
+		conns[i] = e.conn
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Every conn (primary + secondary) should now be unusable.
+	for i, conn := range conns {
+		if _, err := conn.Write([]byte{0}); err == nil {
+			t.Fatalf("conn %d should be closed after Close()", i)
+		}
+	}
+}
+
+// --- Misc small branch fills ---------------------------------------------
+
+// Verify the helper Send returns a "client closed" error when isClosed
+// is true AND we still try to send (covers the closed-guard inside sendPool).
+func TestSendPoolReturnsClosedErrorBeforeAcquire(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, echoHandler())
+	defer srv.close()
+
+	c, err := DialPool(srv.addr(), 2)
+	if err != nil {
+		t.Fatalf("DialPool: %v", err)
+	}
+	c.Close()
+
+	_, err = c.Send(map[string]interface{}{"type": "x"})
+	if err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected closed error, got: %v", err)
+	}
+}
+
+// Smoke-test the RegisterWithKeyOpts RelayOnly + LANAddrs branch (the only
+// "false" branches not exercised by existing tests).
+func TestRegisterWithKeyOptsRelayOnlySerialized(t *testing.T) {
+	t.Parallel()
+	c, _ := echoOnlyClient(t)
+	resp, err := c.RegisterWithKeyOpts(RegisterOpts{
+		ListenAddr: "x:1",
+		PublicKey:  "PUB",
+		LANAddrs:   []string{"10.0.0.1:1"},
+		RelayOnly:  true,
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	echo := assertEcho(t, resp)
+	if got, _ := echo["relay_only"].(bool); !got {
+		t.Fatalf("relay_only: %v", got)
+	}
+	if _, ok := echo["owner"]; ok {
+		t.Fatalf("owner should be omitted when blank")
+	}
+}
+
+// Ensure RegisterWithKey with multiple version variadic args picks the first
+// non-empty (firstNonEmpty branch).
+func TestRegisterWithKeyFirstNonEmptyVersion(t *testing.T) {
+	t.Parallel()
+	c, _ := echoOnlyClient(t)
+	resp, err := c.RegisterWithKey("x:1", "PUB", "", nil, "", "", "v2.0.0", "v3.0.0")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	echo := assertEcho(t, resp)
+	if got, _ := echo["version"].(string); got != "v2.0.0" {
+		t.Fatalf("version: want v2.0.0 (first non-empty), got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `zz_client_pool_test.go` covering the pool path: `DialPool` / `DialTLSPool` / `initPool` / `sendPool` / `sendOnEntry` / `reconnectEntry` / `isClosed` (previously all 0%), plus the `DialTLSPinned` fingerprint verify callback (match + mismatch) and per-pool-entry reconnect after a broken conn.
- Adds `zz_client_branch_test.go` ticking the remaining 75% functions (`PromoteMember` / `DemoteMember` / `KickMember` / `TransferOwnership` with-token, `ReportTrust` / `RevokeTrust` / `SetVisibility` with-signer, `CreateManagedNetwork` full-options, `ListNetworks` with-token, `DialTLS` happy path, binary client reconnect-and-retry on `Heartbeat` / `Lookup` / `Resolve` / `SendJSON`).
- Two concurrent-Send tests (`TestSendConcurrentRaceFreeOnSingleConn`, `TestSendConcurrentRaceFreeOnPool`) confirm the regConn mutex under `-race` for both the legacy single-conn and pooled paths.

## Coverage

| | before | after |
|---|---|---|
| `pkg/registry/client` | 68.1% | 93.0% |

The remaining ~7% gap is the 5-attempt reconnect-exhaustion loops (~7.5s of sleep each, would exceed the `-short` budget under `-race`), the `DialBinary` handshake-write failure path (can't be deterministically forced from userspace), and the `VerifyPeerCertificate` defensive `len(rawCerts) == 0` branch that the TLS stack never actually invokes with zero certs.

## Test plan

- [x] `go test -short -race -count=1 -timeout 180s ./pkg/registry/client/...` passes
- [x] All fake servers are `127.0.0.1:0` TCP listeners — no host/network dependencies
- [x] Self-signed cert generation is local (ecdsa P256, in-test) for the TLS / pinned-TLS tests