### PR TITLE
tests: extend cmd/pilotctl coverage round 2

### DIFF
--- a/cmd/pilotctl/zz_cmds_daemon_test.go
+++ b/cmd/pilotctl/zz_cmds_daemon_test.go
@@ -1,0 +1,806 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Each test follows the same shape:
+//   d := newFakeDaemon(t)
+//   d.useDaemon(t)            // sets PILOT_SOCKET + HOME to a tmp dir
+//   d.onJSON(req, replyOK, …) // queues canned reply
+//   captureStdout(...)        // exercises the cmd, asserts the human/JSON output
+//
+// All happy-path coverage — fatal/error paths live in subprocess tests
+// because fatalCode calls os.Exit.
+
+// --- info / health / peers / connections ---
+
+func TestCmdInfoHumanOutput(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	body := `{
+		"node_id": 42, "address": "0:0000.0000.002A", "hostname": "host-x",
+		"uptime_secs": 3725, "connections": 3, "ports": 1, "peers": 2,
+		"bytes_sent": 1024, "bytes_recv": 2048, "pkts_sent": 4, "pkts_recv": 5,
+		"encrypt": true, "encrypted_peers": 2, "authenticated_peers": 2,
+		"relay_peer_count": 1, "handshake_pending_count": 0,
+		"beacon_addr": "b.example:9001", "identity": true,
+		"public_key": "deadbeefcafef00d12345678",
+		"version": "test-v1"
+	}`
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, body)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdInfo(nil) })
+
+	for _, want := range []string{
+		"Pilot Protocol Daemon", "host-x", "Node ID:     42",
+		"Address:     0:0000.0000.002A", "Beacon:      b.example:9001",
+		"Identity:    persistent",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestCmdInfoJSONOutput(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 7, "address": "0:0000.0000.0007", "uptime_secs": 0,
+		"connections": 0, "ports": 0, "peers": 0,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdInfo(nil) })
+
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["node_id"].(float64) != 7 {
+		t.Errorf("node_id = %v", data["node_id"])
+	}
+}
+
+func TestCmdHealthHumanOutput(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHealth, tdCmdHealthOK, `{
+		"status": "ok", "uptime_seconds": 60, "connections": 1, "peers": 2,
+		"encrypted_peers": 2, "relay_peer_count": 0,
+		"handshake_pending_count": 0, "bytes_sent": 100, "bytes_recv": 200
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdHealth() })
+
+	for _, want := range []string{"Daemon Health", "Status:      ok", "Connections: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in: %s", want, out)
+		}
+	}
+}
+
+func TestCmdHealthJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHealth, tdCmdHealthOK, `{
+		"status": "ok", "uptime_seconds": 1, "connections": 0, "peers": 0,
+		"bytes_sent": 0, "bytes_recv": 0
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdHealth() })
+
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["status"] != "ok" {
+		t.Errorf("status = %v", data["status"])
+	}
+}
+
+func TestCmdPeersEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 1, "address": "0:0000.0000.0001",
+		"uptime_secs": 0, "connections": 0, "ports": 0, "peers": 0,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0,
+		"peer_list": []
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdPeers(nil) })
+	if !strings.Contains(out, "no peers connected") {
+		t.Errorf("expected 'no peers connected', got: %s", out)
+	}
+}
+
+func TestCmdPeersWithData(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 1, "address": "0:0000.0000.0001",
+		"uptime_secs": 0, "connections": 0, "ports": 0, "peers": 1,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0,
+		"peer_list": [
+			{"node_id": 99, "encrypted": true, "authenticated": true, "relay": false}
+		]
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdPeers(nil) })
+
+	for _, want := range []string{"NODE ID", "99", "yes (AES-256-GCM)", "yes (Ed25519)", "direct"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in: %s", want, out)
+		}
+	}
+}
+
+func TestCmdPeersJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 1, "address": "0:0000.0000.0001",
+		"uptime_secs": 0, "connections": 0, "ports": 0, "peers": 1,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0,
+		"peer_list": [
+			{"node_id": 42, "encrypted": false, "authenticated": false, "relay": true,
+			 "endpoint": "1.2.3.4:5", "real_addr": "leakme"}
+		]
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdPeers(nil) })
+	// Endpoint must NOT leak through peers output even in JSON mode.
+	if strings.Contains(out, "1.2.3.4") || strings.Contains(out, "leakme") {
+		t.Errorf("peer endpoint leaked into output: %s", out)
+	}
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["total"].(float64) != 1 {
+		t.Errorf("total = %v", data["total"])
+	}
+}
+
+func TestCmdPeersSearchFiltersOut(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 1, "address": "0:0000.0000.0001",
+		"uptime_secs": 0, "connections": 0, "ports": 0, "peers": 1,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0,
+		"peer_list": [
+			{"node_id": 100, "encrypted": false, "authenticated": false, "relay": false}
+		]
+	}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdPeers([]string{"--search", "999"}) })
+	if !strings.Contains(out, "no peers matching") {
+		t.Errorf("expected 'no peers matching', got: %s", out)
+	}
+}
+
+func TestCmdConnectionsEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 1, "address": "0:0000.0000.0001",
+		"uptime_secs": 0, "connections": 0, "ports": 0, "peers": 0,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0,
+		"conn_list": []
+	}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdConnections() })
+	if !strings.Contains(out, "no active connections") {
+		t.Errorf("expected 'no active connections', got: %s", out)
+	}
+}
+
+func TestCmdConnectionsJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdInfo, tdCmdInfoOK, `{
+		"node_id": 1, "address": "0:0000.0000.0001",
+		"uptime_secs": 0, "connections": 0, "ports": 0, "peers": 0,
+		"bytes_sent": 0, "bytes_recv": 0, "pkts_sent": 0, "pkts_recv": 0,
+		"conn_list": []
+	}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdConnections() })
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["total"].(float64) != 0 {
+		t.Errorf("total = %v", data["total"])
+	}
+}
+
+// --- registration / identity ---
+
+func TestCmdRotateKey(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdRotateKey, tdCmdRotateKeyOK, `{"public_key": "newkey"}`)
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdRotateKey(nil) })
+	if !strings.Contains(out, "newkey") {
+		t.Errorf("missing newkey: %s", out)
+	}
+}
+
+func TestCmdSetPublic(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetVisibility, tdCmdSetVisibilityOK, `{"public": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdSetPublic(nil) })
+	if !strings.Contains(out, "true") {
+		t.Errorf("expected true in: %s", out)
+	}
+}
+
+func TestCmdSetPrivate(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetVisibility, tdCmdSetVisibilityOK, `{"public": false}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdSetPrivate(nil) })
+	if !strings.Contains(out, "false") {
+		t.Errorf("expected false in: %s", out)
+	}
+}
+
+func TestCmdDeregister(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdDeregister, tdCmdDeregisterOK, `{"deregistered": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdDeregister(nil) })
+	if !strings.Contains(out, "deregistered") {
+		t.Errorf("expected deregistered in: %s", out)
+	}
+}
+
+func TestCmdSetHostname(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetHostname, tdCmdSetHostnameOK, `{"hostname": "agent-x", "node_id": 7}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdSetHostname([]string{"agent-x"}) })
+	if !strings.Contains(out, "hostname set") || !strings.Contains(out, "agent-x") {
+		t.Errorf("missing hostname set: %s", out)
+	}
+}
+
+func TestCmdSetHostnameJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetHostname, tdCmdSetHostnameOK, `{"hostname": "agent-x", "node_id": 7}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdSetHostname([]string{"agent-x"}) })
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["hostname"] != "agent-x" {
+		t.Errorf("hostname = %v", data["hostname"])
+	}
+}
+
+func TestCmdClearHostname(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetHostname, tdCmdSetHostnameOK, `{"hostname": ""}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdClearHostname() })
+	if !strings.Contains(out, "hostname cleared") {
+		t.Errorf("missing 'hostname cleared': %s", out)
+	}
+}
+
+func TestCmdSetTagsHuman(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetTags, tdCmdSetTagsOK, `{"node_id": 1, "tags": ["alpha","beta"]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdSetTags([]string{"alpha", "beta"}) })
+	for _, want := range []string{"tags set", "#alpha", "#beta"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdClearTags(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetTags, tdCmdSetTagsOK, `{"tags": []}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdClearTags() })
+	if !strings.Contains(out, "tags cleared") {
+		t.Errorf("missing 'tags cleared': %s", out)
+	}
+}
+
+// --- webhook ---
+
+func TestCmdSetWebhookPersistsConfigEvenWithoutDaemon(t *testing.T) {
+	// No daemon stub — the cmd still persists to config and reports
+	// "will take effect on next daemon start".
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("PILOT_SOCKET", "/tmp/no-such-pilot.sock")
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdSetWebhook([]string{"https://example.com/hook"})
+	})
+	if !strings.Contains(out, "webhook set") {
+		t.Errorf("missing 'webhook set': %s", out)
+	}
+	if !strings.Contains(out, "next daemon start") {
+		t.Errorf("missing follow-up: %s", out)
+	}
+	// Config must be written.
+	cfg := loadConfig()
+	if cfg["webhook"] != "https://example.com/hook" {
+		t.Errorf("config not persisted: %v", cfg)
+	}
+}
+
+func TestCmdSetWebhookAppliesToDaemon(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdSetWebhook, tdCmdSetWebhookOK, `{"webhook": "https://x/h"}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdSetWebhook([]string{"https://x/h"}) })
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["applied"] != true {
+		t.Errorf("applied = %v, want true", data["applied"])
+	}
+}
+
+func TestCmdClearWebhookPersistsConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("PILOT_SOCKET", "/tmp/no-such-pilot.sock")
+	// Seed an existing webhook.
+	_ = saveConfig(map[string]interface{}{"webhook": "https://old/hook"})
+
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdClearWebhook() })
+	if !strings.Contains(out, "webhook cleared") {
+		t.Errorf("missing 'webhook cleared': %s", out)
+	}
+	cfg := loadConfig()
+	if _, ok := cfg["webhook"]; ok {
+		t.Errorf("webhook should be removed from config: %v", cfg)
+	}
+}
+
+// --- trust / handshake ---
+
+func TestCmdHandshakeNumeric(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"status": "sent"}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStderr(t, func() {
+		_ = captureStdout(t, func() { cmdHandshake([]string{"42", "test reason"}) })
+	})
+	if !strings.Contains(out, "handshake") {
+		t.Errorf("missing handshake msg in stderr: %s", out)
+	}
+}
+
+func TestCmdHandshakeJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"status": "sent"}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdHandshake([]string{"42"}) })
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["node_id"].(float64) != 42 {
+		t.Errorf("node_id = %v", data["node_id"])
+	}
+}
+
+func TestCmdHandshakeAlreadyTrusted(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"status": "already_trusted"}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdHandshake([]string{"5"}) })
+	if !strings.Contains(out, "already trusted") {
+		t.Errorf("missing 'already trusted': %s", out)
+	}
+}
+
+func TestCmdApprove(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"status": "approved"}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdApprove([]string{"77"}) })
+	if !strings.Contains(out, "trust established") {
+		t.Errorf("missing 'trust established': %s", out)
+	}
+}
+
+func TestCmdReject(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"status": "rejected"}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdReject([]string{"77", "no reason"}) })
+	if !strings.Contains(out, "rejected") {
+		t.Errorf("missing 'rejected': %s", out)
+	}
+}
+
+func TestCmdUntrust(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"revoked": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdUntrust([]string{"77"}) })
+	if !strings.Contains(out, "node_id") {
+		t.Errorf("expected node_id in output: %s", out)
+	}
+}
+
+func TestCmdPendingEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"pending": []}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdPending() })
+	if !strings.Contains(out, "no pending handshake") {
+		t.Errorf("missing 'no pending handshake': %s", out)
+	}
+}
+
+func TestCmdPendingHasOne(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK,
+		`{"pending": [{"node_id": 7, "justification": "hi", "received_at": 0}]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdPending() })
+	if !strings.Contains(out, "NODE ID") || !strings.Contains(out, "hi") {
+		t.Errorf("missing pending row: %s", out)
+	}
+}
+
+func TestCmdTrustEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK, `{"trusted": []}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdTrust() })
+	if !strings.Contains(out, "no trusted peers") {
+		t.Errorf("missing 'no trusted peers': %s", out)
+	}
+}
+
+func TestCmdTrustHasEntries(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdHandshake, tdCmdHandshakeOK,
+		`{"trusted": [{"node_id": 9, "mutual": true, "network": 1, "approved_at": 0}]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdTrust() })
+	for _, want := range []string{"NODE ID", "MUTUAL", "9", "yes"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+// --- find / disconnect ---
+
+func TestCmdFindHuman(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdResolveHostname, tdCmdResolveHostnameOK,
+		`{"node_id": 42, "address": "0:0000.0000.002A", "public": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdFind([]string{"agent-x"}) })
+	for _, want := range []string{"Hostname:  agent-x", "Node ID:   42", "Visible:   public"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdFindJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdResolveHostname, tdCmdResolveHostnameOK,
+		`{"node_id": 42, "address": "0:0000.0000.002A", "public": false}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdFind([]string{"agent-x"}) })
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["hostname"] != "agent-x" {
+		t.Errorf("hostname = %v", data["hostname"])
+	}
+	if data["public"].(bool) {
+		t.Errorf("public should be false")
+	}
+}
+
+func TestCmdDisconnect(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	// Disconnect is fire-and-forget; the daemon needs no reply for the
+	// driver to return — d.Disconnect just calls ipc.send.
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdDisconnect([]string{"42"}) })
+	if !strings.Contains(out, "conn_id") || !strings.Contains(out, "42") {
+		t.Errorf("expected conn_id 42 in: %s", out)
+	}
+}
+
+// --- network commands ---
+
+func TestCmdNetworkListEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"networks": []}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkList() })
+	if !strings.Contains(out, "no networks") {
+		t.Errorf("missing 'no networks': %s", out)
+	}
+}
+
+func TestCmdNetworkListWithEntries(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"networks": [
+		{"id": 1, "name": "alpha", "join_rule": "open"},
+		{"id": 2, "name": "beta", "join_rule": "token", "members": 5}
+	]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkList() })
+	for _, want := range []string{"ID", "alpha", "beta", "open", "token", "5"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdNetworkJoinDaemonPath(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"network_id": 5}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkJoin([]string{"5"}) })
+	if !strings.Contains(out, "joined network 5") {
+		t.Errorf("missing 'joined network 5': %s", out)
+	}
+}
+
+func TestCmdNetworkLeaveDaemonPath(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"network_id": 5}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkLeave([]string{"5"}) })
+	if !strings.Contains(out, "left network 5") {
+		t.Errorf("missing 'left network 5': %s", out)
+	}
+}
+
+func TestCmdNetworkMembersEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"nodes": []}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkMembers([]string{"5"}) })
+	if !strings.Contains(out, "no members") {
+		t.Errorf("missing 'no members': %s", out)
+	}
+}
+
+func TestCmdNetworkMembersWithRows(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"nodes": [
+		{"node_id": 100, "hostname": "a", "version": "v1", "public": true},
+		{"node_id": 200, "hostname": "", "version": "", "public": false}
+	]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkMembers([]string{"5"}) })
+	for _, want := range []string{"NODE ID", "100", "200", "v1", "public", "private"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdNetworkInvitesEmpty(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"invites": []}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkInvites() })
+	if !strings.Contains(out, "no pending invites") {
+		t.Errorf("missing 'no pending invites': %s", out)
+	}
+}
+
+func TestCmdNetworkInvitesPopulated(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"invites": [
+		{"network_id": 9, "inviter_id": 42, "timestamp": "2026-01-01T00:00:00Z"}
+	]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkInvites() })
+	for _, want := range []string{"NETWORK", "9", "42"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdNetworkAccept(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"network_id": 9, "accepted": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkAccept([]string{"9"}) })
+	if !strings.Contains(out, "accepted invite to network 9") {
+		t.Errorf("missing accept msg: %s", out)
+	}
+}
+
+func TestCmdNetworkReject(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"network_id": 9, "accepted": false}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkReject([]string{"9"}) })
+	if !strings.Contains(out, "rejected invite to network 9") {
+		t.Errorf("missing reject msg: %s", out)
+	}
+}
+
+func TestCmdNetworkInviteWithNumericTarget(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	// cmdNetworkInvite calls resolveToNodeID — numeric path needs no daemon.
+	// But the cmd opens a driver connection (defer d.Close), so the daemon
+	// must accept the connection. Then it sends the invite frame.
+	d.onJSON(tdCmdNetwork, tdCmdNetworkOK, `{"network_id": 1, "node_id": 7}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() { cmdNetworkInvite([]string{"1", "7"}) })
+	if !strings.Contains(out, "invited node 7 to network 1") {
+		t.Errorf("missing invite msg: %s", out)
+	}
+}

--- a/cmd/pilotctl/zz_cmds_policy_test.go
+++ b/cmd/pilotctl/zz_cmds_policy_test.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// IPC sub-command bytes for managed/policy — re-declared local so tests
+// don't reach into pkg/driver's unexported identifiers. Must match
+// pkg/driver/ipc.go.
+const (
+	tdCmdManaged   byte = 0x23
+	tdCmdManagedOK byte = 0x24
+)
+
+// --- managed ---
+
+func TestCmdManagedStatusJSON(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{"network_id": 5, "peers": 3, "active": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdManagedStatus([]string{"--net", "5"}) })
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["network_id"].(float64) != 5 {
+		t.Errorf("network_id = %v", data["network_id"])
+	}
+}
+
+func TestCmdManagedCycleHuman(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{"pruned": 2, "filled": 4, "peers": 5}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdManagedCycle([]string{"--net", "5", "--force"})
+	})
+	for _, want := range []string{"cycle complete", "pruned=2", "filled=4", "peers=5"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdManagedReconcileHuman(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{"network_id": 5, "peers": 7}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdManagedReconcile([]string{"--net", "5"})
+	})
+	if !strings.Contains(out, "reconciled") || !strings.Contains(out, "peers=7") {
+		t.Errorf("missing reconciled/peers: %s", out)
+	}
+}
+
+// --- policy ---
+
+func TestCmdPolicyGet(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{"network_id": 7, "policy": {"version": "1"}}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() { cmdPolicyGet([]string{"--net", "7"}) })
+	if !strings.Contains(out, "policy") {
+		t.Errorf("expected policy in: %s", out)
+	}
+}
+
+func TestCmdPolicyValidateInlineHuman(t *testing.T) {
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	policy := `{
+		"version": 1,
+		"rules": [
+			{"name": "demo", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	out := captureStdout(t, func() {
+		cmdPolicyValidate([]string{"--inline", policy})
+	})
+	if !strings.Contains(out, "valid policy") {
+		t.Errorf("expected 'valid policy' in: %s", out)
+	}
+}
+
+func TestCmdPolicyValidateInlineJSON(t *testing.T) {
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	policy := `{
+		"version": 1,
+		"rules": [
+			{"name": "demo", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	out := captureStdout(t, func() {
+		cmdPolicyValidate([]string{"--inline", policy})
+	})
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["valid"] != true {
+		t.Errorf("valid = %v", data["valid"])
+	}
+}
+
+func TestCmdPolicyValidateFromFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "pol.json")
+	policy := `{
+		"version": 1,
+		"rules": [
+			{"name": "demo", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdPolicyValidate([]string{"--file", path})
+	})
+	if !strings.Contains(out, "valid policy") {
+		t.Errorf("expected 'valid policy' in: %s", out)
+	}
+}
+
+func TestCmdPolicyTestEvalEvent(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "pol.json")
+	policy := `{
+		"version": 1,
+		"rules": [
+			{"name": "allow-all", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdPolicyTest([]string{
+			"--file", path,
+			"--event", `{"type":"connect","peer":1}`,
+		})
+	})
+	if !strings.Contains(out, "event type: connect") {
+		t.Errorf("expected event report in: %s", out)
+	}
+}
+
+func TestCmdPolicyTestJSON(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "pol.json")
+	policy := `{
+		"version": 1,
+		"rules": [
+			{"name": "allow-all", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() {
+		cmdPolicyTest([]string{
+			"--file", path,
+			"--event", `{"type":"connect"}`,
+		})
+	})
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	data := env["data"].(map[string]interface{})
+	if _, ok := data["directives"]; !ok {
+		t.Errorf("directives missing: %s", out)
+	}
+}
+
+// --- member-tags ---
+
+func TestCmdMemberTagsGetSingleNode(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{"tags": ["alpha","beta"]}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdMemberTagsGet([]string{"--net", "5", "--node", "42"})
+	})
+	for _, want := range []string{"Node 42 in network 5", "alpha", "beta"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestCmdMemberTagsGetNoTagsForNode(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdMemberTagsGet([]string{"--net", "5", "--node", "42"})
+	})
+	if !strings.Contains(out, "(no tags)") {
+		t.Errorf("expected '(no tags)' in: %s", out)
+	}
+}
+
+func TestCmdMemberTagsGetAllMembers(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK,
+		`{"members": {"7": ["alpha"], "8": ["beta"]}}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdMemberTagsGet([]string{"--net", "5"})
+	})
+	if !strings.Contains(out, "node 7") || !strings.Contains(out, "node 8") {
+		t.Errorf("expected per-node lines: %s", out)
+	}
+}
+
+func TestCmdMemberTagsSetDaemonPath(t *testing.T) {
+	d := newFakeDaemon(t)
+	d.useDaemon(t)
+	d.onJSON(tdCmdManaged, tdCmdManagedOK, `{"ok": true}`)
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = false
+	out := captureStdout(t, func() {
+		cmdMemberTagsSet([]string{"--net", "5", "--node", "42", "--tags", "alpha,beta"})
+	})
+	if !strings.Contains(out, "Member tags set for node 42 in network 5") {
+		t.Errorf("missing confirmation: %s", out)
+	}
+}
+
+// --- helpers ---
+
+func TestCountEventTypesFromCompiledPolicy(t *testing.T) {
+	// Compile a tiny policy with one connect rule so countEventTypes has
+	// at least one populated entry. Going through cmdPolicyValidate keeps
+	// the test honest — countEventTypes panics on a nil CompiledPolicy.
+	pol := `{
+		"version": 1,
+		"rules": [
+			{"name": "demo", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	prev := jsonOutput
+	defer func() { jsonOutput = prev }()
+	jsonOutput = true
+	out := captureStdout(t, func() {
+		cmdPolicyValidate([]string{"--inline", pol})
+	})
+	if !strings.Contains(out, "connect") {
+		t.Errorf("expected connect event surfaced, got: %s", out)
+	}
+}
+
+func TestDirectiveTypeNameUnknown(t *testing.T) {
+	if got := directiveTypeName(99); got != "unknown" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestResolveNetworkNodeArgNumeric(t *testing.T) {
+	if got := resolveNetworkNodeArg("12345"); got != 12345 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestResolveNetworkNodeArgAddress(t *testing.T) {
+	if got := resolveNetworkNodeArg("0:0000.0000.000F"); got != 0xF {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestParseNodeIDHappy(t *testing.T) {
+	if got := parseNodeID("100"); got != 100 {
+		t.Errorf("got %d", got)
+	}
+	if got := parseNodeID("0"); got != 0 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestParseUint16Happy(t *testing.T) {
+	if got := parseUint16("1234", "port"); got != 1234 {
+		t.Errorf("got %d", got)
+	}
+	if got := parseUint16("65535", "port"); got != 65535 {
+		t.Errorf("got %d", got)
+	}
+}

--- a/cmd/pilotctl/zz_fake_daemon_test.go
+++ b/cmd/pilotctl/zz_fake_daemon_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/TeoSlayer/pilotprotocol/internal/ipcutil"
+)
+
+// IPC cmd codes — must match pkg/driver/ipc.go and cmd/daemon/ipc.go.
+// Re-declared here as package-local constants so tests don't reach
+// into pkg/driver's unexported identifiers.
+const (
+	tdCmdBind              byte = 0x01
+	tdCmdBindOK            byte = 0x02
+	tdCmdDial              byte = 0x03
+	tdCmdDialOK            byte = 0x04
+	tdCmdSend              byte = 0x06
+	tdCmdRecv              byte = 0x07
+	tdCmdClose             byte = 0x08
+	tdCmdCloseOK           byte = 0x09
+	tdCmdError             byte = 0x0A
+	tdCmdSendTo            byte = 0x0B
+	tdCmdInfo              byte = 0x0D
+	tdCmdInfoOK            byte = 0x0E
+	tdCmdHandshake         byte = 0x0F
+	tdCmdHandshakeOK       byte = 0x10
+	tdCmdResolveHostname   byte = 0x11
+	tdCmdResolveHostnameOK byte = 0x12
+	tdCmdSetHostname       byte = 0x13
+	tdCmdSetHostnameOK     byte = 0x14
+	tdCmdSetVisibility     byte = 0x15
+	tdCmdSetVisibilityOK   byte = 0x16
+	tdCmdDeregister        byte = 0x17
+	tdCmdDeregisterOK      byte = 0x18
+	tdCmdSetTags           byte = 0x19
+	tdCmdSetTagsOK         byte = 0x1A
+	tdCmdSetWebhook        byte = 0x1B
+	tdCmdSetWebhookOK      byte = 0x1C
+	tdCmdNetwork           byte = 0x1F
+	tdCmdNetworkOK         byte = 0x20
+	tdCmdHealth            byte = 0x21
+	tdCmdHealthOK          byte = 0x22
+	tdCmdRotateKey         byte = 0x25
+	tdCmdRotateKeyOK       byte = 0x26
+	tdCmdBroadcast         byte = 0x29
+	tdCmdBroadcastOK       byte = 0x2A
+)
+
+// shortSock returns a /tmp/ps-XXX.sock path short enough for macOS's
+// 104-char unix socket name limit.
+func shortSock(t *testing.T) string {
+	t.Helper()
+	var b [6]byte
+	_, _ = rand.Read(b[:])
+	p := filepath.Join("/tmp", "ps-"+hex.EncodeToString(b[:])+".sock")
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// fakeDaemon implements just enough of the daemon IPC for cmdXxx tests.
+// Pattern: register per-cmd handlers, then point PILOT_SOCKET at d.path
+// and call cmdXxx directly.
+type fakeDaemon struct {
+	t        *testing.T
+	ln       net.Listener
+	path     string
+	mu       sync.Mutex
+	conn     net.Conn
+	connSet  chan struct{}
+	received [][]byte
+	handlers map[byte]func(frame []byte) [][]byte
+}
+
+func newFakeDaemon(t *testing.T) *fakeDaemon {
+	t.Helper()
+	path := shortSock(t)
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen unix %q: %v", path, err)
+	}
+	d := &fakeDaemon{
+		t:        t,
+		ln:       ln,
+		path:     path,
+		connSet:  make(chan struct{}),
+		handlers: map[byte]func(frame []byte) [][]byte{},
+	}
+	go d.acceptLoop()
+	t.Cleanup(d.close)
+	return d
+}
+
+func (d *fakeDaemon) acceptLoop() {
+	conn, err := d.ln.Accept()
+	if err != nil {
+		return
+	}
+	d.mu.Lock()
+	d.conn = conn
+	d.mu.Unlock()
+	close(d.connSet)
+
+	for {
+		frame, err := ipcutil.Read(conn)
+		if err != nil {
+			return
+		}
+		if len(frame) < 1 {
+			continue
+		}
+		cmd := frame[0]
+		d.mu.Lock()
+		d.received = append(d.received, frame)
+		h := d.handlers[cmd]
+		d.mu.Unlock()
+		if h == nil {
+			continue
+		}
+		for _, r := range h(frame) {
+			_ = ipcutil.Write(conn, r)
+		}
+	}
+}
+
+// on registers a handler that returns one or more frames for cmd.
+// Each returned frame should start with the reply cmd byte (e.g.
+// tdCmdHealthOK) followed by the JSON payload.
+func (d *fakeDaemon) on(cmd byte, h func(frame []byte) [][]byte) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.handlers[cmd] = h
+}
+
+// onJSON is a convenience: respond to cmd with a single
+// [replyCmd][json] frame.
+func (d *fakeDaemon) onJSON(cmd, replyCmd byte, jsonBody string) {
+	d.on(cmd, func(_ []byte) [][]byte {
+		out := make([]byte, 1+len(jsonBody))
+		out[0] = replyCmd
+		copy(out[1:], jsonBody)
+		return [][]byte{out}
+	})
+}
+
+func (d *fakeDaemon) close() {
+	_ = d.ln.Close()
+	select {
+	case <-d.connSet:
+	case <-time.After(100 * time.Millisecond):
+	}
+	d.mu.Lock()
+	c := d.conn
+	d.mu.Unlock()
+	if c != nil {
+		_ = c.Close()
+	}
+}
+
+// useDaemon points PILOT_SOCKET at d.path for the rest of the test
+// and isolates HOME so config writes are sandboxed. Returns the tmp
+// home path for tests that want to seed config files.
+func (d *fakeDaemon) useDaemon(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("PILOT_SOCKET", d.path)
+	return tmp
+}

--- a/cmd/pilotctl/zz_subprocess_round2_test.go
+++ b/cmd/pilotctl/zz_subprocess_round2_test.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Round-2 subprocess tests target the fatalCode/fatalHint paths in cmd
+// dispatch + per-cmd usage validation. Each test re-execs the binary
+// via runCLI so os.Exit doesn't take down the test runner.
+
+// --- gateway ---
+
+func TestCLIGatewayStopHints(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "gateway", "stop"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (gateway stop is unsupported)")
+	}
+	if !strings.Contains(stderr, "pilot-gateway") {
+		t.Errorf("expected pilot-gateway hint, got: %s", stderr)
+	}
+}
+
+func TestCLIGatewayUnmapHints(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "gateway", "unmap", "10.4.0.5"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (gateway unmap is unsupported)")
+	}
+	if !strings.Contains(stderr, "pilot-gateway") {
+		t.Errorf("expected pilot-gateway hint: %s", stderr)
+	}
+}
+
+func TestCLIGatewayMapMissingArgs(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "gateway", "map"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (missing pilot-addr)")
+	}
+	if !strings.Contains(stderr, "usage") && !strings.Contains(stderr, "pilot-addr") {
+		t.Errorf("expected usage error: %s", stderr)
+	}
+}
+
+func TestCLIGatewayUnmapMissingArgs(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "gateway", "unmap"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (missing local-ip)")
+	}
+	if !strings.Contains(stderr, "usage") && !strings.Contains(stderr, "local-ip") {
+		t.Errorf("expected usage error: %s", stderr)
+	}
+}
+
+func TestCLIGatewayListEmpty(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runCLI(t, []string{"--json", "extras", "gateway", "list"}, nil)
+	if code != 0 {
+		t.Errorf("exit=%d", code)
+	}
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["total"].(float64) != 0 {
+		t.Errorf("total = %v", data["total"])
+	}
+}
+
+// --- usage errors on cmds that require args ---
+
+func TestCLISetHostnameMissingArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "set-hostname"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit for missing hostname")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLISetTagsMissingArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "set-tags"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLISetTagsTooMany(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{
+		"extras", "set-tags", "a", "b", "c", "d",
+	}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (too many tags)")
+	}
+	if !strings.Contains(stderr, "maximum 3") {
+		t.Errorf("expected 'maximum 3' hint: %s", stderr)
+	}
+}
+
+func TestCLISetWebhookInvalidScheme(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"extras", "set-webhook", "ftp://bad/scheme"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (bad scheme)")
+	}
+	if !strings.Contains(stderr, "http") {
+		t.Errorf("expected scheme error: %s", stderr)
+	}
+}
+
+func TestCLINetworkLeaveMissingArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"network", "leave"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLINetworkMembersMissingArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"network", "members"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLINetworkInviteMissingArgs(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"network", "invite"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLINetworkAcceptMissingArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"network", "accept"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLINetworkRejectMissingArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"network", "reject"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLINetworkCreateMissingName(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"network", "create"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "name") && !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLIPolicyValidateInline(t *testing.T) {
+	t.Parallel()
+	pol := `{
+		"version": 1,
+		"rules": [
+			{"name": "demo", "on": "connect", "match": "true", "actions": [{"type": "allow"}]}
+		]
+	}`
+	stdout, stderr, code := runCLI(t, []string{
+		"--json", "policy", "validate", "--inline", pol,
+	}, nil)
+	if code != 0 {
+		t.Errorf("exit=%d stderr=%s", code, stderr)
+	}
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("json: %v\nstdout=%s", err, stdout)
+	}
+	data := env["data"].(map[string]interface{})
+	if data["valid"] != true {
+		t.Errorf("valid = %v", data["valid"])
+	}
+}
+
+func TestCLIPolicyValidateNoFlags(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"policy", "validate"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (no --file or --inline)")
+	}
+	if !strings.Contains(stderr, "file") && !strings.Contains(stderr, "inline") {
+		t.Errorf("expected --file/--inline hint: %s", stderr)
+	}
+}
+
+func TestCLIPolicyTestMissingFlags(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"policy", "test"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLIPolicyGetMissingNet(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"policy", "get"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "--net") && !strings.Contains(stderr, "usage") {
+		t.Errorf("expected --net hint: %s", stderr)
+	}
+}
+
+func TestCLIManagedReconcileMissingNet(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"managed", "reconcile"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "--net") && !strings.Contains(stderr, "usage") {
+		t.Errorf("expected --net hint: %s", stderr)
+	}
+}
+
+func TestCLIManagedCycleNoForce(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"managed", "cycle"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit (missing --force)")
+	}
+	if !strings.Contains(stderr, "--force") {
+		t.Errorf("expected --force hint: %s", stderr)
+	}
+}
+
+func TestCLIMemberTagsSetMissingArgs(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"member-tags", "set"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("expected usage hint: %s", stderr)
+	}
+}
+
+func TestCLIMemberTagsGetMissingNet(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"member-tags", "get"}, nil)
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "--net") && !strings.Contains(stderr, "usage") {
+		t.Errorf("expected --net hint: %s", stderr)
+	}
+}
+
+// --- daemon error path: daemon offline ---
+
+func TestCLIInfoNoDaemon(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	_, stderr, code := runCLI(t, []string{"info"}, map[string]string{
+		"PILOT_SOCKET": filepath.Join(tmp, "nope.sock"),
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit (daemon offline)")
+	}
+	if !strings.Contains(stderr, "daemon") {
+		t.Errorf("expected 'daemon' in stderr: %s", stderr)
+	}
+}
+
+func TestCLIHealthNoDaemon(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	_, stderr, code := runCLI(t, []string{"health"}, map[string]string{
+		"PILOT_SOCKET": filepath.Join(tmp, "nope.sock"),
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "daemon") {
+		t.Errorf("expected 'daemon' in stderr: %s", stderr)
+	}
+}
+
+func TestCLITrustNoDaemon(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	_, stderr, code := runCLI(t, []string{"trust"}, map[string]string{
+		"PILOT_SOCKET": filepath.Join(tmp, "nope.sock"),
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "daemon") {
+		t.Errorf("expected 'daemon' in stderr: %s", stderr)
+	}
+}
+
+func TestCLIPendingNoDaemon(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	_, stderr, code := runCLI(t, []string{"pending"}, map[string]string{
+		"PILOT_SOCKET": filepath.Join(tmp, "nope.sock"),
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "daemon") {
+		t.Errorf("expected 'daemon' in stderr: %s", stderr)
+	}
+}
+
+func TestCLIPeersNoDaemon(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	_, stderr, code := runCLI(t, []string{"peers"}, map[string]string{
+		"PILOT_SOCKET": filepath.Join(tmp, "nope.sock"),
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "daemon") {
+		t.Errorf("expected 'daemon' in stderr: %s", stderr)
+	}
+}
+
+func TestCLIConnectionsNoDaemon(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	_, stderr, code := runCLI(t, []string{"connections"}, map[string]string{
+		"PILOT_SOCKET": filepath.Join(tmp, "nope.sock"),
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit")
+	}
+	if !strings.Contains(stderr, "daemon") {
+		t.Errorf("expected 'daemon' in stderr: %s", stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `fakeDaemon` IPC harness in `package main` so cmd handlers can be exercised directly against a unix socket stub.
- Covers happy paths for ~28 daemon-backed commands: info, health, peers, connections, rotate-key, set/clear hostname & tags, set-public/private, deregister, set-webhook, handshake/approve/reject/untrust/pending/trust, find, disconnect, network list/join/leave/members/invites/accept/reject/invite.
- Covers managed (status/cycle/reconcile), policy (get/validate/test, file + inline), member-tags (set/get single-node/all-members), plus small pure helpers (directiveTypeName, resolveNetworkNodeArg, parseNodeID, parseUint16).
- Adds subprocess tests for fatalCode/fatalHint paths: gateway extras stop/unmap/map-missing, set-hostname/set-tags/set-webhook usage errors, network leave/members/invite/accept/reject/create usage, policy validate/test/get missing flags, managed reconcile/cycle missing flags, member-tags missing flags, and offline-daemon paths for info/health/trust/pending/peers/connections.

`go test -short -race ./cmd/pilotctl/` rises from **30.0% → 47.0%** (+17pp).

## Test plan
- [x] `go test -short -race ./cmd/pilotctl/` passes locally
- [x] coverage delta confirmed via `go test -coverprofile`
- [ ] CI green