### PR TITLE
fix(pilotctl): humanDuration no longer over-strips zero components

### DIFF
--- a/cmd/pilotctl/appstore.go
+++ b/cmd/pilotctl/appstore.go
@@ -1468,28 +1468,50 @@ func validationErrSummary(errs []error) string {
 
 // humanDuration formats a Duration cleanly: "24h", "1h30m", "10m",
 // "45s". Go's Duration.String() emits "24h0m0s" which is fine for
-// machines but noisy for humans — strip trailing zero components.
+// machines but noisy for humans — drop any trailing zero components.
 // Sub-second durations stay as "Xms" / "Xµs" via the stdlib default.
+//
+// The previous implementation used strings.TrimSuffix(s, "0m") which
+// over-stripped: "1h30m0s" → "1h30m" → "1h3" and "10m0s" → "10m" → "1".
+// We now decompose the duration into h/m/s components and emit only the
+// non-zero ones (e.g. "1h30m0s" → "1h30m", "10m0s" → "10m",
+// "2h5m30s" → "2h5m30s", "1h0m0s" → "1h").
 func humanDuration(d time.Duration) string {
 	if d == 0 {
 		return "0s"
 	}
-	// Round to whole seconds for anything ≥1s so we don't render
-	// "23h29m58.948334s"; sub-second durations (e.g. test fixtures
-	// with 100ms intervals) keep their precision via the stdlib default.
-	if d >= time.Second {
-		d = d.Round(time.Second)
-	}
-	s := d.String()
-	// Collapse the two common eyesores from Duration.String():
-	//   "1h0m0s" → "1h", "1h30m0s" → "1h30m", "1m0s" → "1m".
-	s = strings.TrimSuffix(s, "0s")
-	s = strings.TrimSuffix(s, "0m")
-	if s == "" {
-		// All-zero compacted away — fall back to the raw form.
+	// Sub-second durations (e.g. test fixtures with 100ms intervals)
+	// keep their precision via the stdlib default — the h/m/s
+	// decomposition below has nothing to render.
+	if d < time.Second {
 		return d.String()
 	}
-	return s
+	// Round to whole seconds for anything ≥1s so we don't render
+	// "23h29m58.948334s".
+	d = d.Round(time.Second)
+
+	hours := int64(d / time.Hour)
+	d -= time.Duration(hours) * time.Hour
+	minutes := int64(d / time.Minute)
+	d -= time.Duration(minutes) * time.Minute
+	seconds := int64(d / time.Second)
+
+	var b strings.Builder
+	if hours > 0 {
+		fmt.Fprintf(&b, "%dh", hours)
+	}
+	if minutes > 0 {
+		fmt.Fprintf(&b, "%dm", minutes)
+	}
+	if seconds > 0 {
+		fmt.Fprintf(&b, "%ds", seconds)
+	}
+	if b.Len() == 0 {
+		// d rounded to zero — shouldn't happen given d ≥ 1s above,
+		// but fall back to the stdlib default for safety.
+		return d.String()
+	}
+	return b.String()
 }
 
 // capDecl is the local pilotctl-side projection of a manifest cap.

--- a/cmd/pilotctl/zz_appstore_helpers_test.go
+++ b/cmd/pilotctl/zz_appstore_helpers_test.go
@@ -86,12 +86,11 @@ func TestValidationErrSummary(t *testing.T) {
 
 func TestHumanDuration(t *testing.T) {
 	t.Parallel()
-	// NOTE: humanDuration has a known bug: TrimSuffix("...30m", "0m") strips
-	// the "0m" suffix from "30m" producing "...3". The comments say the intent
-	// is to strip Go's noisy zero components ("1h0m0s" → "1h") but the
-	// implementation also strips legitimate trailing zeros inside
-	// non-zero values. We pin the *current* behavior so a future fix
-	// must update this test deliberately.
+	// humanDuration decomposes the duration into h/m/s components and
+	// emits only the non-zero ones. The previous implementation used
+	// strings.TrimSuffix(s, "0m") which over-stripped — "1h30m0s" became
+	// "1h3" and "10m0s" became "1". The cases marked "fixed:" below pin
+	// the corrected behavior so the bug can't quietly come back.
 	cases := []struct {
 		in   time.Duration
 		want string
@@ -99,11 +98,13 @@ func TestHumanDuration(t *testing.T) {
 		{0, "0s"},
 		{24 * time.Hour, "24h"},
 		{time.Hour, "1h"},
-		{time.Hour + 30*time.Minute, "1h3"}, // buggy: "1h30m" → strip "0m" → "1h3"
-		{10 * time.Minute, "1"},             // buggy: "10m0s" → "10m" → "1"
+		{time.Hour + 30*time.Minute, "1h30m"}, // fixed: was "1h3"
+		{10 * time.Minute, "10m"},             // fixed: was "1"
+		{2*time.Hour + 5*time.Minute + 30*time.Second, "2h5m30s"}, // fixed: was "2h5m3"
+		{time.Hour, "1h"}, // fixed canonical: "1h0m0s" -> "1h"
 		{45 * time.Second, "45s"},
-		{time.Hour + 11*time.Minute, "1h11m"}, // last char "1m" — "0m" suffix absent → preserved
-		{5 * time.Minute, "5m"},               // "5m0s" → "5m" → no "0m" suffix → preserved
+		{time.Hour + 11*time.Minute, "1h11m"},
+		{5 * time.Minute, "5m"},
 		{2*time.Hour + 5*time.Minute + 1*time.Second, "2h5m1s"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- The previous \`humanDuration\` chained \`strings.TrimSuffix(s, "0s")\` and \`strings.TrimSuffix(s, "0m")\`, which over-stripped: \`"1h30m0s"\` became \`"1h3"\` and \`"10m0s"\` became \`"1"\`.
- Replace the suffix chase with proper h/m/s decomposition that only emits the non-zero components.
- Update \`TestHumanDuration\` to assert the corrected outputs (the previous test deliberately pinned the buggy behavior with a note that a future fix should update the expectations).

## Fixed cases

| Input | Old (buggy) | New (fixed) |
|---|---|---|
| \`1h30m0s\` | \`1h3\` | \`1h30m\` |
| \`10m0s\` | \`1\` | \`10m\` |
| \`2h5m30s\` | \`2h5m3\` | \`2h5m30s\` |
| \`1h0m0s\` | \`1h\` | \`1h\` |

## Test plan

- [x] \`go test -short -race -count=1 -timeout 60s ./cmd/pilotctl/...\` passes
- [x] \`go build ./...\` clean
- [x] All four explicit cases from the spec are pinned in the updated test