### PR TITLE
fix(pilotctl): cmdSkillsEnable/Disable validate args (closes PILOT-189)

### DIFF
--- a/cmd/pilotctl/skills.go
+++ b/cmd/pilotctl/skills.go
@@ -21,12 +21,12 @@ import (
 //
 // Subcommands:
 //
-//	pilotctl skills           — alias for `status`
-//	pilotctl skills status    — show per-tool install paths + state
-//	pilotctl skills paths     — print just the install paths
-//	pilotctl skills check     — run one reconcile pass right now
-//	pilotctl skills disable   — remove every file we wrote + opt out of future ticks
-//	pilotctl skills enable    — opt back in + run one reconcile pass
+//	pilotctl skills                       — alias for `status`
+//	pilotctl skills status                — show per-tool install paths + state
+//	pilotctl skills paths                 — print just the install paths
+//	pilotctl skills check                 — run one reconcile pass right now
+//	pilotctl skills disable <skill|all>   — remove every file we wrote + opt out of future ticks
+//	pilotctl skills enable  <skill|all>   — opt back in + run one reconcile pass
 func cmdSkills(args []string) {
 	sub := "status"
 	if len(args) > 0 && !strings.HasPrefix(args[0], "--") {
@@ -220,7 +220,16 @@ var _ = skillsHomeRel // reserved for future use; keeps gofmt happy
 // (pilot-protocol/, ~/.pilot/bin/, plugin install dirs) are deleted;
 // files we co-inhabit with the user (CLAUDE.md, AGENTS.md, AGENT.md,
 // SOUL.md) only have our marker block stripped — never the whole file.
-func cmdSkillsDisable(_ []string) {
+//
+// Requires an explicit skill id (or `all`) to avoid the foot-gun where a
+// stray invocation silently nukes every managed file. Pre-fix this
+// command ran unconditionally regardless of input — see PILOT-189.
+func cmdSkillsDisable(args []string) {
+	if len(args) == 0 {
+		fatalHint("invalid_argument",
+			"usage: pilotctl skills disable <skill-id|all>",
+			"skill id required")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		fatalCode("internal", "home dir: %v", err)
@@ -302,7 +311,16 @@ func cmdSkillsDisable(_ []string) {
 // cmdSkillsEnable flips the opt-out flag off and runs one reconcile
 // pass so the user sees what got installed without waiting for the
 // next 15-minute tick.
-func cmdSkillsEnable(_ []string) {
+//
+// Requires an explicit skill id (or `all`) so a stray invocation
+// can't silently re-install everything. Pre-fix this command ran
+// unconditionally regardless of input — see PILOT-189.
+func cmdSkillsEnable(args []string) {
+	if len(args) == 0 {
+		fatalHint("invalid_argument",
+			"usage: pilotctl skills enable <skill-id|all>",
+			"skill id required")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		fatalCode("internal", "home dir: %v", err)

--- a/cmd/pilotctl/zz_skills_test.go
+++ b/cmd/pilotctl/zz_skills_test.go
@@ -120,3 +120,36 @@ func TestPrintSkillInstallSummaryNoOutcomes(t *testing.T) {
 	// Quiet when no outcomes — no panic, prints nothing significant.
 	_ = captureStdout(t, printSkillInstallSummary)
 }
+
+// TestCLISkillsEnable_RejectsNoArgs pins the PILOT-189 fix: pre-fix the
+// command silently ran the global re-enable + reconcile regardless of
+// input. Now it must refuse and print a usage hint when no skill id is
+// supplied — the install/uninstall side effects belong behind an
+// explicit argument, not a typo.
+func TestCLISkillsEnable_RejectsNoArgs(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"skills", "enable"}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when no skill id supplied, got 0\nstderr=%s", stderr)
+	}
+	low := strings.ToLower(stderr)
+	if !strings.Contains(low, "usage") && !strings.Contains(low, "skill id required") {
+		t.Errorf("expected 'usage' or 'skill id required' in stderr, got: %s", stderr)
+	}
+}
+
+// TestCLISkillsDisable_RejectsNoArgs is the symmetric pin for the
+// disable path — pre-fix it would tear down every managed file on a
+// bare `pilotctl skills disable`. Now it bails out unless the caller
+// specifies what to disable.
+func TestCLISkillsDisable_RejectsNoArgs(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"skills", "disable"}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when no skill id supplied, got 0\nstderr=%s", stderr)
+	}
+	low := strings.ToLower(stderr)
+	if !strings.Contains(low, "usage") && !strings.Contains(low, "skill id required") {
+		t.Errorf("expected 'usage' or 'skill id required' in stderr, got: %s", stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- `cmdSkillsEnable` / `cmdSkillsDisable` previously discarded their args slice (`_ []string`), so a stray `pilotctl skills enable` or `pilotctl skills disable` ran the full reconcile / uninstall path regardless of input — including silently nuking every managed skill file on the disable side.
- Both commands now require an explicit `<skill-id|all>` argument and bail out via `fatalHint` with a usage hint when none is supplied.
- Added two subprocess regression tests via the existing `runCLI` harness so the validation path stays pinned.

## Test plan
- [x] `go test -short -race -count=1 -timeout 120s ./cmd/pilotctl/...` — green
- [x] `go test -short ./cmd/... ./pkg/... ./internal/...` — green (matches PR CI)
- [x] `go build ./...` — green
- [x] New tests fail on the pre-fix code (signature was `_ []string`, would have exited 0)

Closes PILOT-189.