### PR TITLE
fix(daemon): add peer reaper to idleSweepLoop (PILOT-84)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -4468,6 +4468,46 @@ func (d *Daemon) reRegister() {
 	}
 }
 
+// reapStalePeers removes tunnel peers that have no active connections
+// and haven't been contacted for peerReapIdleTimeout. Called periodically
+// from idleSweepLoop to prevent unbounded growth of per-peer maps
+// (tm.peers, routing relay/blackhole/send-err maps, keyexchange
+// pubkey/rekey state) in long-running daemons with peer churn.
+func (d *Daemon) reapStalePeers() {
+	const peerReapIdleTimeout = 5 * time.Minute
+
+	active := d.ports.ActiveNodeIDs()
+	now := time.Now()
+	peers := d.tunnels.PeerList()
+
+	for _, p := range peers {
+		if active[p.NodeID] {
+			continue // has active connection — keep
+		}
+
+		lastDirect := d.tunnels.LastDirectRecv(p.NodeID)
+		lastOutbound, ok := d.tunnels.LastOutboundSend(p.NodeID)
+
+		// Find the latest known contact.
+		latest := lastDirect
+		if ok && lastOutbound.After(latest) {
+			latest = lastOutbound
+		}
+
+		if latest.IsZero() {
+			// Never contacted — fresh peer entry, don't reap yet.
+			continue
+		}
+
+		if now.Sub(latest) > peerReapIdleTimeout {
+			slog.Debug("reaping stale peer", "node_id", p.NodeID,
+				"last_contact", latest.Round(time.Second),
+				"has_encryption", p.Encrypted)
+			d.tunnels.RemovePeer(p.NodeID)
+		}
+	}
+}
+
 // idleSweepLoop periodically sends keepalive probes and closes dead connections.
 func (d *Daemon) idleSweepLoop() {
 	ticker := time.NewTicker(DefaultIdleSweepInterval)
@@ -4510,6 +4550,11 @@ func (d *Daemon) idleSweepLoop() {
 			// epCache: stale-but-usable after EndpointCacheTTL; evict after 1 hour.
 			// resolveCache and hostnameCache: strictly TTL-gated on read; evict after 2× TTL.
 			d.reapCaches()
+
+			// Reap stale tunnel peers that have no active connections and
+			// haven't been contacted recently. Prevents unbounded growth of
+			// per-peer maps in long-running daemons with peer churn.
+			d.reapStalePeers()
 
 			// Keepalive probes + dead-peer detection. See keepaliveSweep
 			// for details. Extracted into its own method so tests can

--- a/pkg/daemon/ports.go
+++ b/pkg/daemon/ports.go
@@ -570,6 +570,24 @@ func (pm *PortManager) StaleConnections(timeWaitDur time.Duration) []*Connection
 	return stale
 }
 
+// ActiveNodeIDs returns the set of node IDs with at least one
+// non-closed, non-timewait connection. Used by the peer reaper
+// to identify stale tunnel entries that can be safely removed.
+func (pm *PortManager) ActiveNodeIDs() map[uint32]bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	nodes := make(map[uint32]bool)
+	for _, c := range pm.connections {
+		c.Mu.Lock()
+		st := c.State
+		c.Mu.Unlock()
+		if st != StateClosed && st != StateTimeWait {
+			nodes[c.RemoteAddr.Node] = true
+		}
+	}
+	return nodes
+}
+
 // IdleConnections returns connections that have been idle longer than the given duration.
 func (pm *PortManager) IdleConnections(maxIdle time.Duration) []*Connection {
 	pm.mu.RLock()

--- a/pkg/daemon/tunnel.go
+++ b/pkg/daemon/tunnel.go
@@ -1637,6 +1637,18 @@ func (tm *TunnelManager) IsEncrypted(nodeID uint32) bool {
 	return tm.envelope.IsReady(nodeID)
 }
 
+// LastDirectRecv returns the last time a direct-path packet was received
+// from the given peer (zero value if none). Thin wrapper over routing.Manager.
+func (tm *TunnelManager) LastDirectRecv(nodeID uint32) time.Time {
+	return tm.routing.LastDirectRecv(nodeID)
+}
+
+// LastOutboundSend returns the last outbound send timestamp for the
+// given peer, and whether a timestamp was ever recorded.
+func (tm *TunnelManager) LastOutboundSend(nodeID uint32) (time.Time, bool) {
+	return tm.routing.LastOutboundSend(nodeID)
+}
+
 // PeerCount returns the number of known peers.
 func (tm *TunnelManager) PeerCount() int {
 	tm.mu.RLock()


### PR DESCRIPTION
## Summary
`TunnelManager.RemovePeer()` already exists and cleans up all per-peer maps, but nothing in the production path ever calls it for stale peers. This PR adds a periodic reaper to the existing idleSweepLoop.

## What changes
- **ports.go**: Add `ActiveNodeIDs()` — returns the set of node IDs with active (non-closed, non-timewait) connections
- **tunnel.go**: Add `LastDirectRecv()` and `LastOutboundSend()` thin wrappers over routing.Manager accessors
- **daemon.go**: Add `reapStalePeers()` + call from `idleSweepLoop`

## How the reaper works
Every 15s (idleSweepInterval), it:
1. Collects node IDs with active connections (via ports)
2. Iterates tunnel peers
3. Skips peers with active connections
4. For peers without active connections, checks last contact timestamp (last direct recv or outbound send)
5. If last contact > 5 min ago, calls `RemovePeer()` which wipes:
   - `tm.peers` (address map)
   - Routing state (relayPeers, relayPinned, blackholeMissCount, directClearCount, sendErrCount, lastDirectRecv, lastOutboundSend, firstOutboundSend)
   - KeyExchange state (peerPubKeys, pendingRekey, lastInboundDecrypt, lastKeyExchangeReply, rekeyGaveUp)
   - Envelope crypto context

## Safety
- 5-minute idle TTL is conservative — a NAT-rebinding reconnect takes seconds
- Fresh peers with zero contact records are never reaped
- `RemovePeer()` is already tested (`TestRemovePeerLeavesPerPeerMetadataMapsStale`, `TestRemovePeerDropsBothPeerAndCryptoEntries`)
- Lock ordering follows the existing RemovePeer contract

Closes: PILOT-84