### PR TITLE
tests: add fuzz targets to pkg/protocol + pkg/registry/wire + pkg/daemon/envelope

### DIFF
--- a/pkg/daemon/envelope/zz_fuzz_envelope_test.go
+++ b/pkg/daemon/envelope/zz_fuzz_envelope_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package envelope_test
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TeoSlayer/pilotprotocol/pkg/daemon/envelope"
+	"github.com/TeoSlayer/pilotprotocol/pkg/daemon/keyexchange"
+)
+
+// fuzzPeerSetup mirrors newPeerSetup() in zz_envelope_test.go but is
+// callable from the fuzz seed setup (no *testing.T). Used only to
+// produce a few valid encrypted frames for the seed corpus.
+func fuzzPeerSetup() (localStore *keyexchange.Store, peerID uint32, ok bool) {
+	curve := ecdh.X25519()
+	localPriv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, 0, false
+	}
+	peerPriv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, 0, false
+	}
+
+	localStore = keyexchange.NewStore()
+	const localID uint32 = 0x11111111
+	peerID = 0x22222222
+	localStore.SetLocalNodeID(localID)
+
+	localMgr := keyexchange.New(localStore)
+	localMgr.SetX25519Keys(localPriv, localPriv.PublicKey().Bytes())
+
+	localCrypto, err := localMgr.DeriveSecret(peerPriv.PublicKey().Bytes())
+	if err != nil {
+		return nil, 0, false
+	}
+	localStore.Install(peerID, localCrypto)
+	return localStore, peerID, true
+}
+
+// FuzzDecryptFrame targets the envelope decoder with arbitrary bytes.
+// Decode path:
+//   - 4-byte sender ID + 12-byte nonce + ciphertext-with-tag
+//   - lookup peer's Crypto, replay-window check, AEAD-Open with AAD.
+//
+// Adversarial inputs:
+//   - frames shorter than 4+12+16
+//   - sender ID matching an installed peer (forces full crypto path)
+//   - random ciphertext (must surface as ErrAEAD, never a panic)
+//   - replayed counters (ErrReplay)
+//   - counters far below the window high-water-mark (ErrOutsideWindow)
+//
+// A panic out of this function would crash the daemon readLoop, so the
+// recover-and-report pattern below is the correct find signal.
+func FuzzDecryptFrame(f *testing.F) {
+	// Seeds: a few sizes including the structurally-too-short input.
+	f.Add([]byte{})
+	f.Add(make([]byte, 4+12+15)) // one byte short of minimum
+	f.Add(make([]byte, 4+12+16)) // exactly at minimum (all zeros)
+	f.Add(make([]byte, 128))
+	// Frame whose sender field matches the installed peer.
+	{
+		buf := make([]byte, 4+12+16)
+		// peerID 0x22222222 matches fuzzPeerSetup() above.
+		binary.BigEndian.PutUint32(buf[0:4], 0x22222222)
+		f.Add(buf)
+	}
+
+	// Build one shared Store at seed time so the fuzzer reaches the
+	// AEAD path for at least some inputs (sender ID 0x22222222).
+	store, _, ok := fuzzPeerSetup()
+	if !ok {
+		f.Skip("could not initialise keyexchange Store")
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		// Copy because some implementations may mutate the input.
+		buf := make([]byte, len(data))
+		copy(buf, data)
+		_ = envelope.DecryptFrame(store, buf)
+	})
+}

--- a/pkg/protocol/zz_fuzz_packet_test.go
+++ b/pkg/protocol/zz_fuzz_packet_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzUnmarshalPacket exercises the packet decoder with arbitrary bytes.
+// The decoder is documented as having an L1 panic boundary (deferred
+// recover → ErrMalformedPacket), so a literal panic should never escape
+// to the fuzz harness — any escape is a real bug. PILOT-133 noted a
+// latent unmarshal panic in UnmarshalAddr; this target should reproduce
+// such issues quickly.
+//
+// Seeds include valid frames at multiple sizes, header-only inputs, all
+// flag combinations, malformed length fields, and a few adversarial
+// envelopes (length field claims much more than the buffer holds).
+func FuzzUnmarshalPacket(f *testing.F) {
+	// Seed 1: minimal valid (no payload) packet.
+	{
+		p := &Packet{Version: Version, Protocol: ProtoStream}
+		b, err := p.Marshal()
+		if err == nil {
+			f.Add(b)
+		}
+	}
+	// Seed 2: valid packet with small payload.
+	{
+		p := &Packet{
+			Version: Version, Flags: FlagSYN | FlagACK, Protocol: ProtoStream,
+			Src: Addr{1, 0xDEADBEEF}, Dst: Addr{2, 0xCAFEBABE},
+			SrcPort: 1234, DstPort: 5678,
+			Seq: 0x11223344, Ack: 0x55667788, Window: 16,
+			Payload: []byte("hello"),
+		}
+		b, err := p.Marshal()
+		if err == nil {
+			f.Add(b)
+		}
+	}
+	// Seed 3: control proto, all flags.
+	{
+		p := &Packet{
+			Version: Version, Flags: FlagSYN | FlagACK | FlagFIN | FlagRST,
+			Protocol: ProtoControl, Payload: bytes.Repeat([]byte{0xAB}, 64),
+		}
+		b, err := p.Marshal()
+		if err == nil {
+			f.Add(b)
+		}
+	}
+	// Seed 4: datagram with binary payload.
+	{
+		p := &Packet{
+			Version: Version, Protocol: ProtoDatagram,
+			Payload: []byte{0x00, 0xFF, 0x7F, 0x80, 0x01, 0xFE},
+		}
+		b, err := p.Marshal()
+		if err == nil {
+			f.Add(b)
+		}
+	}
+	// Seed 5: broadcast destination.
+	{
+		p := &Packet{
+			Version: Version, Protocol: ProtoDatagram,
+			Dst: BroadcastAddr(7), DstPort: PortPing,
+		}
+		b, err := p.Marshal()
+		if err == nil {
+			f.Add(b)
+		}
+	}
+	// Seed 6: exactly header-sized (34 bytes of zeros).
+	f.Add(make([]byte, packetHeaderSize))
+	// Seed 7: shorter than header.
+	f.Add(make([]byte, packetHeaderSize-1))
+	// Seed 8: empty.
+	f.Add([]byte{})
+	// Seed 9: header claims big payload but buffer truncated.
+	{
+		b := make([]byte, packetHeaderSize)
+		b[0] = Version << 4 // valid version
+		b[2], b[3] = 0xFF, 0xFF
+		f.Add(b)
+	}
+	// Seed 10: header with unsupported version.
+	{
+		b := make([]byte, packetHeaderSize)
+		b[0] = 0xF0 // version 0x0F (unsupported)
+		f.Add(b)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Defensive: literal panic out of Unmarshal is the find.
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+
+		// Unmarshal mutates data[30:34] briefly during checksum verify;
+		// pass a copy so the fuzzer's input slice is not aliased.
+		buf := make([]byte, len(data))
+		copy(buf, data)
+
+		p, err := Unmarshal(buf)
+		if err != nil {
+			return // expected on most random input
+		}
+
+		// Round-trip property: a successfully decoded packet should
+		// re-encode to bytes that decode back to an equivalent struct.
+		re, err := p.Marshal()
+		if err != nil {
+			t.Errorf("decode-then-encode failed: %v (orig=%x)", err, data)
+			return
+		}
+		p2, err := Unmarshal(re)
+		if err != nil {
+			t.Errorf("re-decode failed: %v (re=%x)", err, re)
+			return
+		}
+		if p.Seq != p2.Seq || p.Ack != p2.Ack || p.SrcPort != p2.SrcPort ||
+			p.DstPort != p2.DstPort || p.Window != p2.Window ||
+			p.Protocol != p2.Protocol || p.Flags != p2.Flags ||
+			p.Version != p2.Version || p.Src != p2.Src || p.Dst != p2.Dst {
+			t.Errorf("round-trip header mismatch: %+v vs %+v", p, p2)
+		}
+		if !bytes.Equal(p.Payload, p2.Payload) {
+			t.Errorf("round-trip payload mismatch: %x vs %x", p.Payload, p2.Payload)
+		}
+	})
+}
+
+// FuzzUnmarshalAddr targets the 6-byte address decoder directly.
+// PILOT-133 specifically flagged this function; UnmarshalAddr does NOT
+// have a defer/recover, so out-of-bounds slicing would propagate as a
+// real panic. A naive call with len(buf) < AddrSize panics, so the
+// fuzzer must include the bounds check the harness uses in practice.
+func FuzzUnmarshalAddr(f *testing.F) {
+	f.Add(make([]byte, AddrSize))
+	f.Add([]byte{0x00, 0x01, 0xDE, 0xAD, 0xBE, 0xEF})
+	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+
+		// UnmarshalAddr's contract is "exactly 6 bytes". Callers that
+		// pass less are the bug shape PILOT-133 was concerned with —
+		// fuzz both the contract-respecting path and the over-long path.
+		if len(data) >= AddrSize {
+			a := UnmarshalAddr(data[:AddrSize])
+			b := a.Marshal()
+			a2 := UnmarshalAddr(b)
+			if a != a2 {
+				t.Errorf("addr round-trip: %v != %v", a, a2)
+			}
+		}
+	})
+}
+
+// FuzzParseAddr exercises the text-form address parser.
+func FuzzParseAddr(f *testing.F) {
+	f.Add("0:0000.0000.0001")
+	f.Add("1:0001.DEAD.BEEF")
+	f.Add("65535:FFFF.FFFF.FFFF")
+	f.Add("")
+	f.Add(":")
+	f.Add("garbage")
+	f.Add("0:0000.0000")
+	f.Add("0:0000.0000.0000.0000")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %q: %v", s, r)
+			}
+		}()
+		a, err := ParseAddr(s)
+		if err != nil {
+			return
+		}
+		// Round-trip: String() of a parsed addr must re-parse equal.
+		a2, err := ParseAddr(a.String())
+		if err != nil {
+			t.Errorf("re-parse of %q (= %v) failed: %v", s, a, err)
+			return
+		}
+		if a != a2 {
+			t.Errorf("round-trip mismatch: %v != %v (input %q)", a, a2, s)
+		}
+	})
+}

--- a/pkg/registry/wire/zz_fuzz_wire_test.go
+++ b/pkg/registry/wire/zz_fuzz_wire_test.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package wire_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TeoSlayer/pilotprotocol/pkg/registry/wire"
+)
+
+// FuzzReadFrame exercises the binary frame reader.
+// Wire format: [4B length][1B type][payload]. The length field is
+// length-prefixed; a malicious or buggy peer could send a 4-byte header
+// that claims gigabytes — the MaxMessageSize cap should keep it bounded,
+// but fuzzing confirms no panic / OOM regression slips in.
+func FuzzReadFrame(f *testing.F) {
+	// Seed: valid empty-payload JSON frame.
+	{
+		var buf bytes.Buffer
+		wire.WriteFrame(&buf, wire.MsgJSON, []byte("{}"))
+		f.Add(buf.Bytes())
+	}
+	// Seed: valid heartbeat req.
+	{
+		var buf bytes.Buffer
+		wire.WriteFrame(&buf, wire.MsgHeartbeat, wire.EncodeHeartbeatReq(42, make([]byte, 64)))
+		f.Add(buf.Bytes())
+	}
+	// Seed: lookup req.
+	{
+		var buf bytes.Buffer
+		wire.WriteFrame(&buf, wire.MsgLookup, wire.EncodeLookupReq(0xDEADBEEF))
+		f.Add(buf.Bytes())
+	}
+	// Adversarial: huge length field, no body.
+	{
+		var hdr [5]byte
+		binary.BigEndian.PutUint32(hdr[:4], 0xFFFFFFFF)
+		hdr[4] = wire.MsgJSON
+		f.Add(hdr[:])
+	}
+	// Adversarial: length=0 (below the "must include type byte" minimum).
+	{
+		var hdr [5]byte
+		binary.BigEndian.PutUint32(hdr[:4], 0)
+		hdr[4] = wire.MsgJSON
+		f.Add(hdr[:])
+	}
+	f.Add([]byte{})
+	f.Add(make([]byte, 4))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		r := bytes.NewReader(data)
+		_, _, _ = wire.ReadFrame(r)
+	})
+}
+
+// FuzzDecodeLookupResp targets the wire-controlled allocation path
+// flagged in PILOT-131. The decoder pulls counts (network count, tag
+// count, length-prefixed fields) directly from the input — a 16-bit
+// network count or 8-bit tag count drives `make([]uint16, n)` /
+// `make([]string, n)`. Truncated inputs must surface as errors, not
+// panics, and not unbounded allocations.
+func FuzzDecodeLookupResp(f *testing.F) {
+	f.Add(wire.EncodeLookupResp(1, false, false, nil, nil, "", nil, "", ""))
+	f.Add(wire.EncodeLookupResp(0xDEADBEEF, true, true,
+		[]uint16{1, 2, 3}, []byte("pubkey"), "host", []string{"a", "b"},
+		"1.2.3.4:5", "extid"))
+	f.Add(wire.EncodeLookupResp(7, true, false,
+		[]uint16{42}, bytes.Repeat([]byte{0x55}, 255), "h", []string{"tag"},
+		"", ""))
+
+	// Adversarial: header claims many networks but no body follows.
+	{
+		buf := make([]byte, 11)
+		binary.BigEndian.PutUint32(buf[:4], 1)
+		buf[4] = 0
+		// reserved (4) zero
+		binary.BigEndian.PutUint16(buf[9:11], 0xFFFF) // claim 65535 networks
+		f.Add(buf)
+	}
+	// Adversarial: pubkey_len > remaining bytes.
+	{
+		buf := make([]byte, 12)
+		binary.BigEndian.PutUint32(buf[:4], 1)
+		// reserved + netcount = 0
+		buf[11] = 0xFF // pubkey_len = 255
+		f.Add(buf)
+	}
+	// Minimum-size buffer.
+	f.Add(make([]byte, 11))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		_, _ = wire.DecodeLookupResp(data)
+	})
+}
+
+// FuzzDecodeResolveResp covers the resolve response decoder which has
+// the same wire-controlled allocation shape (count + length-prefixed
+// LAN addrs).
+func FuzzDecodeResolveResp(f *testing.F) {
+	f.Add(wire.EncodeResolveResp(1, "1.2.3.4:5", nil, 0))
+	f.Add(wire.EncodeResolveResp(2, "10.0.0.1:9000",
+		[]string{"192.168.1.1", "10.0.0.5"}, 30))
+	f.Add(wire.EncodeResolveResp(3, "", nil, -1))
+	f.Add(make([]byte, 12))
+	f.Add([]byte{})
+
+	// Adversarial: LAN count overflow.
+	{
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint32(buf[:4], 1)
+		binary.BigEndian.PutUint16(buf[4:6], 0)      // addr_len = 0
+		binary.BigEndian.PutUint16(buf[6:8], 0xFFFF) // 65535 LAN addrs
+		f.Add(buf)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		_, _ = wire.DecodeResolveResp(data)
+	})
+}
+
+// FuzzDecodeHeartbeatReq / Resp / LookupReq / Error are simple
+// fixed-shape decoders — fuzz them anyway since they're entry points.
+func FuzzDecodeHeartbeatReq(f *testing.F) {
+	f.Add(wire.EncodeHeartbeatReq(1, make([]byte, 64)))
+	f.Add(wire.EncodeHeartbeatReq(0xFFFFFFFF, bytes.Repeat([]byte{0xAA}, 64)))
+	f.Add([]byte{})
+	f.Add(make([]byte, 67)) // one byte short
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		_, _ = wire.DecodeHeartbeatReq(data)
+	})
+}
+
+func FuzzDecodeError(f *testing.F) {
+	f.Add(wire.EncodeError("oh no"))
+	f.Add(wire.EncodeError(""))
+	f.Add([]byte{0x00})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		_ = wire.DecodeError(data)
+	})
+}
+
+// FuzzReadMessage exercises the JSON length-prefixed message reader.
+// The 4-byte length is wire-controlled; the MaxMessageSize check is the
+// only guard against `make([]byte, hugeLength)`. Verify no panic and no
+// OOM-by-allocation regression.
+func FuzzReadMessage(f *testing.F) {
+	// Seed: valid 2-byte JSON `{}`.
+	{
+		var buf bytes.Buffer
+		_ = wire.WriteMessage(&buf, map[string]interface{}{})
+		f.Add(buf.Bytes())
+	}
+	{
+		var buf bytes.Buffer
+		_ = wire.WriteMessage(&buf, map[string]interface{}{
+			"op": "lookup", "node_id": float64(42),
+		})
+		f.Add(buf.Bytes())
+	}
+	// Adversarial: header claims big payload.
+	{
+		hdr := make([]byte, 4)
+		binary.BigEndian.PutUint32(hdr, 0xFFFFFFFF)
+		f.Add(hdr)
+	}
+	// Length declares 4GB but no body follows.
+	{
+		hdr := make([]byte, 4)
+		binary.BigEndian.PutUint32(hdr, 0x7FFFFFFF)
+		f.Add(hdr)
+	}
+	f.Add([]byte{})
+	f.Add(make([]byte, 3))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panic on input %x: %v", data, r)
+			}
+		}()
+		r := bytes.NewReader(data)
+		_, _ = wire.ReadMessage(r)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `func FuzzX(f *testing.F)` targets to three wire-format packages that previously had only table-driven unit tests.
- Targets `pkg/protocol` (packet + addr decode, including the PILOT-133 `UnmarshalAddr` panic surface), `pkg/registry/wire` (binary frame + JSON length-prefixed decoders, including the PILOT-131 wire-controlled allocation in `DecodeLookupResp`), and `pkg/daemon/envelope` (AEAD `DecryptFrame`).
- All fuzz funcs are no-ops under plain `go test` (they only execute the seed corpus, fast), so the standard `go test -race -count=1 -timeout 120s ./...` flow is unchanged.

## Fuzz targets added

| Package | Target | Notes |
|---|---|---|
| `pkg/protocol` | `FuzzUnmarshalPacket` | Round-trip property on decode success |
| `pkg/protocol` | `FuzzUnmarshalAddr` | 6-byte address decoder — PILOT-133 reproducer surface |
| `pkg/protocol` | `FuzzParseAddr` | Text-form `N:NNNN.HHHH.LLLL` parser, round-trip via `String()` |
| `pkg/registry/wire` | `FuzzReadFrame` | `[4B length][1B type][payload]` binary framing |
| `pkg/registry/wire` | `FuzzDecodeLookupResp` | PILOT-131 — wire-controlled `make([]uint16, n)` / `make([]string, n)` |
| `pkg/registry/wire` | `FuzzDecodeResolveResp` | LAN-addr count + length-prefixed strings |
| `pkg/registry/wire` | `FuzzDecodeHeartbeatReq` | Fixed-shape decoder |
| `pkg/registry/wire` | `FuzzDecodeError` | Error frame payload |
| `pkg/registry/wire` | `FuzzReadMessage` | JSON length-prefixed (4B len + body), `MaxMessageSize` guard |
| `pkg/daemon/envelope` | `FuzzDecryptFrame` | Real `keyexchange.Store` + matching peer ID seed |

Each target seeds 5–10 known-good inputs from existing tests plus adversarial header-only / over-length / truncated samples.

## Local fuzz run (30s per target)

```
FuzzUnmarshalPacket      9.6M execs, +1 interesting corpus entry
FuzzUnmarshalAddr       11.7M execs, +1
FuzzParseAddr           10.5M execs, +166
FuzzReadFrame            1.5M execs, +4
FuzzDecodeLookupResp     2.3M execs, +22
FuzzDecodeResolveResp    4.5M execs, +15
FuzzDecodeHeartbeatReq   6.8M execs, +1
FuzzDecodeError          4.9M execs, +1
FuzzReadMessage          1.4M execs, +233
FuzzDecryptFrame         3.2M execs, +5
```

Zero panics, zero hangs, zero crash-corpus entries written to `testdata/fuzz/`. No bugs to file from this initial budget — these targets are now available to be extended in CI or run ad-hoc with `go test -fuzz=FuzzX -fuzztime=<duration>`.

## Test plan

- [x] `go test -race -count=1 -timeout 120s ./pkg/protocol/... ./pkg/registry/wire/... ./pkg/daemon/envelope/...` — all green (seed corpus runs as ordinary unit tests)
- [x] `go test -run='^$' -fuzz=<each-target> -fuzztime=30s ./...` — all PASS
- [x] `git status` clean (no `testdata/fuzz/` artefacts generated)