### PR TITLE
fix: prefer $XDG_RUNTIME_DIR for daemon IPC socket on Linux (PILOT-151)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/TeoSlayer/pilotprotocol/pkg/config"
 	"github.com/TeoSlayer/pilotprotocol/pkg/daemon"
+	"github.com/TeoSlayer/pilotprotocol/pkg/driver"
 	"github.com/TeoSlayer/pilotprotocol/pkg/logging"
 
 	// L11 plugin imports — cmd/daemon (L12) is the only place these
@@ -47,7 +48,7 @@ func main() {
 	registryAddr := flag.String("registry", registryDefault, "registry server address (or $PILOT_REGISTRY)")
 	beaconAddr := flag.String("beacon", beaconDefault, "beacon server address (or $PILOT_BEACON)")
 	listenAddr := flag.String("listen", ":0", "UDP listen address for tunnel traffic")
-	socketPath := flag.String("socket", "/tmp/pilot.sock", "Unix socket path for IPC")
+	socketPath := flag.String("socket", driver.DefaultSocketPath(), "Unix socket path for IPC")
 	endpoint := flag.String("endpoint", "", "fixed public endpoint (host:port) — skips STUN (for cloud VMs with known IPs)")
 	encrypt := flag.Bool("encrypt", true, "enable tunnel-layer encryption (X25519 + AES-256-GCM)")
 	registryTLS := flag.Bool("registry-tls", false, "use TLS for registry connection")

--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -42,8 +42,11 @@ const (
 	defaultConfigFile = "config.json"
 	defaultPIDFile    = "pilot.pid"
 	defaultLogFile    = "pilot.log"
-	defaultSocket     = "/tmp/pilot.sock"
 )
+
+func defaultSocket() string {
+	return driver.DefaultSocketPath()
+}
 
 func configDir() string {
 	home, _ := os.UserHomeDir()
@@ -227,7 +230,7 @@ func getSocket() string {
 	if s, ok := cfg["socket"].(string); ok && s != "" {
 		return s
 	}
-	return defaultSocket
+	return defaultSocket()
 }
 
 func getRegistry() string {
@@ -1571,7 +1574,7 @@ func cmdInit(args []string) {
 	registryAddr := flagString(flags, "registry", "34.71.57.205:9000")
 	beaconAddr := flagString(flags, "beacon", "127.0.0.1:9001")
 	hostname := flagString(flags, "hostname", "")
-	socketPath := flagString(flags, "socket", defaultSocket)
+	socketPath := flagString(flags, "socket", defaultSocket())
 
 	cfg := loadConfig()
 	cfg["registry"] = registryAddr

--- a/cmd/pilotctl/zz_lifecycle_test.go
+++ b/cmd/pilotctl/zz_lifecycle_test.go
@@ -54,8 +54,8 @@ func TestGetSocketEnvPrecedence(t *testing.T) {
 
 func TestGetSocketDefault(t *testing.T) {
 	withTempHomeFull(t)
-	if got := getSocket(); got != defaultSocket {
-		t.Errorf("default = %s, want %s", got, defaultSocket)
+	if got := getSocket(); got != defaultSocket() {
+		t.Errorf("default = %s, want %s", got, defaultSocket())
 	}
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -6,12 +6,26 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/TeoSlayer/pilotprotocol/pkg/protocol"
 )
 
-const DefaultSocketPath = "/tmp/pilot.sock"
+// DefaultSocketPath returns the default Unix socket path for IPC.
+// On Linux it prefers $XDG_RUNTIME_DIR (typically /run/user/<uid>,
+// which is private to the user); falls back to /tmp/pilot.sock.
+// On macOS /tmp is already per-user via SIP, so /tmp/pilot.sock is safe.
+func DefaultSocketPath() string {
+	if runtime.GOOS == "linux" {
+		if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+			return filepath.Join(xdg, "pilot.sock")
+		}
+	}
+	return "/tmp/pilot.sock"
+}
 
 // Handshake sub-commands (must match daemon SubHandshake* constants)
 const (
@@ -47,7 +61,7 @@ type Driver struct {
 // Connect creates a new driver connected to the local daemon.
 func Connect(socketPath string) (*Driver, error) {
 	if socketPath == "" {
-		socketPath = DefaultSocketPath
+		socketPath = DefaultSocketPath()
 	}
 
 	ipc, err := newIPCClient(socketPath)


### PR DESCRIPTION
## Summary

Change the default daemon IPC socket path from hardcoded `/tmp/pilot.sock` to `$XDG_RUNTIME_DIR/pilot.sock` on Linux when XDG_RUNTIME_DIR is set.

## Problem

`/tmp/pilot.sock` is a predictable, world-accessible path on Linux. A local non-root attacker can:
- Target the socket for impersonation (if no IPC auth)
- DoS via accept storm
- Race the daemon startup (world-writable /tmp)

## Fix

- `pkg/driver/driver.go`: Replace `const DefaultSocketPath` with `func DefaultSocketPath()` that checks `$XDG_RUNTIME_DIR` on Linux
- `cmd/daemon/main.go`: Flag default uses `driver.DefaultSocketPath()`
- `cmd/pilotctl/main.go`: `defaultSocket()` wraps `driver.DefaultSocketPath()`

Socket creation already sets mode 0600 at `pkg/daemon/ipc.go:432` — this change complements that by moving the socket to a user-private directory.

## Verification

- [x] `go build ./cmd/daemon/ ./cmd/pilotctl/ ./pkg/driver/` — all pass
- [x] `go vet ./pkg/driver/ ./cmd/daemon/ ./cmd/pilotctl/` — clean
- [x] `go test ./pkg/driver/ ./pkg/daemon/ ./cmd/pilotctl/` — all pass

## Ticket

🔗 [PILOT-151](https://vulturelabs.atlassian.net/browse/PILOT-151) — Daemon socket at hardcoded /tmp/pilot.sock