### PR TITLE
fix(daemon): use overlap instead of containment in ProcessSACK (PILOT-125)

### DIFF
--- a/pkg/daemon/ports.go
+++ b/pkg/daemon/ports.go
@@ -1327,7 +1327,9 @@ func (c *Connection) ProcessSACK(blocks []SACKBlock) {
 	for _, e := range c.Unacked {
 		segEnd := e.seq + uint32(len(e.data))
 		for _, b := range blocks {
-			if seqAfterOrEqual(e.seq, b.Left) && seqAfterOrEqual(b.Right, segEnd) {
+			// RFC 2018 §3: a SACK block covers any segment that overlaps
+			// it, not just segments fully contained within the block.
+			if !seqAfterOrEqual(e.seq, b.Right) && !seqAfterOrEqual(b.Left, segEnd) {
 				e.sacked = true
 				break
 			}

--- a/pkg/daemon/zz_helpers_test.go
+++ b/pkg/daemon/zz_helpers_test.go
@@ -399,6 +399,45 @@ func TestProcessSACKMarksEntries(t *testing.T) {
 	}
 }
 
+func TestProcessSACKPartialOverlap(t *testing.T) {
+	t.Parallel()
+	// RFC 2018 §3: SACK blocks may partially cover a segment.
+	// A segment at [200, 205) should be marked sacked even when
+	// the SACK block only partially overlaps (e.g. [195, 203)).
+	c := &Connection{}
+	c.TrackSend(100, []byte("hello"))  // [100, 105)
+	c.TrackSend(200, []byte("world"))  // [200, 205)
+	c.TrackSend(300, []byte("!!!"))    // [300, 303)
+
+	// SACK block partially overlaps [200, 205) from the left
+	c.ProcessSACK([]SACKBlock{{Left: 195, Right: 203}})
+	if !c.Unacked[1].sacked {
+		t.Error("segment [200,205) should be sacked when SACK block [195,203) partially overlaps")
+	}
+	if c.Unacked[0].sacked {
+		t.Error("segment [100,105) should not be sacked — no overlap with [195,203)")
+	}
+
+	// Reset and test right-side partial overlap
+	c2 := &Connection{}
+	c2.TrackSend(100, []byte("hello")) // [100, 105)
+	c2.TrackSend(200, []byte("world")) // [200, 205)
+	c2.TrackSend(300, []byte("!!!"))   // [300, 303)
+	c2.ProcessSACK([]SACKBlock{{Left: 202, Right: 210}})
+	if !c2.Unacked[1].sacked {
+		t.Error("segment [200,205) should be sacked when SACK block [202,210) partially overlaps")
+	}
+
+	// Reset and test segment fully containing the SACK block
+	c3 := &Connection{}
+	c3.TrackSend(100, []byte("hello")) // [100, 105)
+	c3.TrackSend(200, []byte("world")) // [200, 205)
+	c3.ProcessSACK([]SACKBlock{{Left: 201, Right: 204}})
+	if !c3.Unacked[1].sacked {
+		t.Error("segment [200,205) should be sacked when it fully contains SACK block [201,204)")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CloseRecvBuf + DeliverInOrder basic paths
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What failed

ProcessSACK at `pkg/daemon/ports.go:1330` required a SACK block to **fully contain** a segment before marking it sacked. RFC 2018 §3 specifies that any overlap between a SACK block and a segment is sufficient — partial overlap also means the peer has those bytes.

The bug caused unnecessary retransmissions of segments that were partially acknowledged via SACK, degrading throughput on lossy links.

## Why this fix

Changed the containment check:
```go
// Before (bug — containment only):
seqAfterOrEqual(e.seq, b.Left) && seqAfterOrEqual(b.Right, segEnd)

// After (fix — overlap):
!seqAfterOrEqual(e.seq, b.Right) && !seqAfterOrEqual(b.Left, segEnd)
```

This correctly matches when the segment and SACK block overlap in sequence space.

## Verification

- `go build ./...` — clean
- `go vet ./pkg/daemon/` — clean
- `go test -run 'SACK|ProcessSACK' -v -count=1 ./pkg/daemon/` — all 28 SACK tests pass, including new `TestProcessSACKPartialOverlap` (3 sub-cases)
- New test covers left-side partial, right-side partial, and segment-fully-contains-block overlap scenarios

## Scope

1 file (`pkg/daemon/ports.go`), +3/-1 lines (plus test: +39 lines in `zz_helpers_test.go`).

Closes [PILOT-125](https://vulturelabs.atlassian.net/browse/PILOT-125)