### PR TITLE
fix: distinguish zero-window from unknown-window in window-open signal (PILOT-126)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2438,7 +2438,9 @@ func (d *Daemon) handleStreamPacket(pkt *protocol.Packet) {
 		conn.RetxMu.Lock()
 		prevWin := conn.PeerRecvWin
 		conn.PeerRecvWin = int(pkt.Window) * MaxSegmentSize
-		winOpened := conn.PeerRecvWin > prevWin && conn.WindowAvailable()
+		// prevWin==-1 is the sentinel (no advertisement yet); don't signal
+		// window-opened on the first transition (unknown→zero would fire).
+		winOpened := prevWin != -1 && conn.PeerRecvWin > prevWin && conn.WindowAvailable()
 		conn.RetxMu.Unlock()
 		if winOpened && conn.WindowCh != nil {
 			select {
@@ -2524,7 +2526,7 @@ func (d *Daemon) handleStreamPacket(pkt *protocol.Packet) {
 		conn.RetxMu.Lock()
 		prevWin := conn.PeerRecvWin
 		conn.PeerRecvWin = int(pkt.Window) * MaxSegmentSize
-		winOpened := conn.PeerRecvWin > prevWin && conn.WindowAvailable()
+		winOpened := prevWin != -1 && conn.PeerRecvWin > prevWin && conn.WindowAvailable()
 		conn.RetxMu.Unlock()
 		if winOpened && conn.WindowCh != nil {
 			select {
@@ -2638,7 +2640,7 @@ func (d *Daemon) handleStreamPacket(pkt *protocol.Packet) {
 		conn.RetxMu.Lock()
 		prevPeerWin := conn.PeerRecvWin
 		conn.PeerRecvWin = int(pkt.Window) * MaxSegmentSize
-		peerWinOpened := conn.PeerRecvWin > prevPeerWin && conn.WindowAvailable()
+		peerWinOpened := prevPeerWin != -1 && conn.PeerRecvWin > prevPeerWin && conn.WindowAvailable()
 		conn.RetxMu.Unlock()
 		if peerWinOpened && conn.WindowCh != nil {
 			select {


### PR DESCRIPTION
## What

Fix a sentinel-value edge case in the daemon's window-open signal: when `PeerRecvWin` is the -1 sentinel (no window advertisement received yet) and the peer's first SYN/SYN-ACK carries `Window=0`, the condition `0 > -1` fires `winOpened=true` even though the real window is closed, not opening.

## Root cause

`PeerRecvWin` is initialized to -1 in `ports.go:426` (sentinel meaning "no advertisement received yet"). Three sites in `handleStreamPacket` computed `PeerRecvWin > prevWin` without checking whether `prevWin` was the sentinel. Transitioning from -1 → 0 is not a window-open event.

## Fix

Added `prevWin != -1` guard at all three call sites:
- SYN handler (~line 2439)
- SYN-ACK handler (~line 2525)
- Per-packet window update (~line 2639)

## Verification

- `go build ./...` ✅
- `go vet ./pkg/daemon/` ✅
- `go test -count=1 ./pkg/daemon/` ✅ (46s suite, all pass)
- `WindowAvailable()` already guards real sends — this fix makes the signal semantically correct.

## Files

| File | Δ |
|------|---|
| pkg/daemon/daemon.go | +5/-3 |

Jira: PILOT-126
Labels: daemon, p3