### PR TITLE
fix: warn on wildcard tunnel bind (PILOT-129)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -646,6 +646,15 @@ func (d *Daemon) Start() error {
 		actualAddr = d.tunnels.LocalAddr().String()
 		slog.Info("tunnel listening", "addr", actualAddr)
 
+		// Warn when the tunnel bound to a wildcard address — reachable
+		// from any network interface that can route to this host.
+		// Pass -listen 127.0.0.1:0 to restrict to localhost only.
+		if host, _, hostErr := net.SplitHostPort(actualAddr); hostErr == nil && (host == "0.0.0.0" || host == "::") {
+			slog.Warn("tunnel bound to wildcard address",
+				"addr", actualAddr,
+				"hint", "pass -listen 127.0.0.1:0 to restrict to localhost; see -endpoint for fixed public IP")
+		}
+
 		// Collect LAN addresses using the actual tunnel port (not config port which may be 0)
 		_, actualPort, _ := net.SplitHostPort(actualAddr)
 		if actualPort == "" || actualPort == "0" {


### PR DESCRIPTION
## What

Adds a `WARN`-level log when the daemon's UDP tunnel listener binds to a wildcard address (0.0.0.0 or ::).

## Why

The `-listen` flag defaults to `:0` — bind on all interfaces, random port. On misconfigured public hosts, any external peer that learns the port can hit the UDP tunnel listener, creating an unintended exposure surface.

## Fix

After `tunnels.Listen()` succeeds, inspect the resolved bind address via `net.SplitHostPort`. If the host part is `0.0.0.0` or `::`, emit a `slog.Warn` pointing the operator to `-listen 127.0.0.1:0` or `-endpoint`.

## Changes

- `pkg/daemon/daemon.go`: +9 lines (warning block after tunnel listen)

## Verification

- `go build ./pkg/daemon/` — clean
- `go vet ./pkg/daemon/` — clean
- `go test ./pkg/daemon/ -count=1` — all 2,962 tests pass (4 skipped)

## Ticket

Closes PILOT-129