### PR TITLE
fix: cap wire-controlled list allocations in DecodeLookupResp (PILOT-131)

### DIFF
--- a/pkg/registry/wire/wire.go
+++ b/pkg/registry/wire/wire.go
@@ -17,6 +17,13 @@ import (
 	"time"
 )
 
+// maxCount caps wire-controlled list lengths to prevent a malicious
+// peer from triggering large allocations (e.g. netCount=65535 →
+// 130 KB make()). All frames are bounded by MaxMessageSize (64 MiB)
+// but per-field allocations without caps can cause memory pressure
+// before the overall frame limit is reached.
+const maxCount = 1024
+
 // WriteMessageDeadline bounds how long a single JSON response write can
 // take. If a client is slow to drain (overloaded host, kernel buffer
 // pressure) we'd otherwise hold the request goroutine + response payload
@@ -376,6 +383,9 @@ func DecodeLookupResp(payload []byte) (LookupResult, error) {
 	}
 	netCount := int(binary.BigEndian.Uint16(payload[off : off+2]))
 	off += 2
+	if netCount > maxCount {
+		return r, fmt.Errorf("network count %d exceeds cap %d", netCount, maxCount)
+	}
 	r.Networks = make([]uint16, netCount)
 	for i := 0; i < netCount; i++ {
 		if off+2 > len(payload) {
@@ -415,6 +425,9 @@ func DecodeLookupResp(payload []byte) (LookupResult, error) {
 	}
 	tagCount := int(payload[off])
 	off++
+	if tagCount > maxCount {
+		return r, fmt.Errorf("tag count %d exceeds cap %d", tagCount, maxCount)
+	}
 	r.Tags = make([]string, tagCount)
 	for i := 0; i < tagCount; i++ {
 		if off >= len(payload) {
@@ -490,6 +503,9 @@ func DecodeResolveResp(payload []byte) (ResolveResult, error) {
 	}
 	lanCount := int(binary.BigEndian.Uint16(payload[off : off+2]))
 	off += 2
+	if lanCount > maxCount {
+		return r, fmt.Errorf("lan_addrs count %d exceeds cap %d", lanCount, maxCount)
+	}
 	r.LANAddrs = make([]string, lanCount)
 	for i := 0; i < lanCount; i++ {
 		if off+2 > len(payload) {


### PR DESCRIPTION
## What failed

`DecodeLookupResp` in `pkg/registry/wire/wire.go` read `netCount`, `tagCount`, and `lanCount` directly from the wire and used them as `make()` sizes without any upper bound. A malicious peer could send `netCount=65535` (130 KB allocation per frame) or `lanCount=65535` (unbounded list of LAN addresses). While the overall frame is bounded by `MaxMessageSize` (64 MiB), repeated per-field allocations without caps can cause memory pressure before the frame limit is reached.

## What this PR does

Adds a `maxCount = 1024` constant applied to all three list-length reads in `DecodeLookupResp`. A count exceeding the cap now returns a decode error (`"network count N exceeds cap 1024"`) before the allocation.

- **1 file**, 16 lines added, 0 removed
- No behavioral change for valid frames (legitimate counts are well below 1024)

## Verification

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./pkg/registry/wire/...` — all pass
- [x] `go test ./pkg/registry/...` — all pass (wire + client suites)
- [x] Existing fuzz targets (`FuzzDecodeLookupResp`, etc.) — no regressions

Closes [PILOT-131](https://vulturelabs.atlassian.net/browse/PILOT-131)