### PR TITLE
fix: surface malformed JSON responses as errors (PILOT-132)

### DIFF
--- a/pkg/registry/client/binary_client.go
+++ b/pkg/registry/client/binary_client.go
@@ -274,5 +274,9 @@ func (c *BinaryClient) sendJSONLocked(msg map[string]interface{}) (map[string]in
 	if errMsg, ok := resp["error"].(string); ok {
 		return resp, fmt.Errorf("registry: %s", errMsg)
 	}
+	// PILOT-132: reject valid JSON that lacks the expected "type" envelope key.
+	if _, hasType := resp["type"]; !hasType && len(resp) > 0 {
+		return resp, fmt.Errorf("registry: malformed response (missing 'type' field)")
+	}
 	return resp, nil
 }

--- a/pkg/registry/client/client.go
+++ b/pkg/registry/client/client.go
@@ -428,6 +428,12 @@ func (c *Client) sendOnEntry(entry *pooledConn, msg map[string]interface{}) (map
 	if errMsg, ok := resp["error"].(string); ok {
 		return resp, fmt.Errorf("registry: %s", errMsg)
 	}
+	// PILOT-132: reject valid JSON that lacks the expected "type" envelope key.
+	// Previously, a misconfigured server returning {"unexpected":"key"} was
+	// silently treated as success.
+	if _, hasType := resp["type"]; !hasType && len(resp) > 0 {
+		return resp, fmt.Errorf("registry: malformed response (missing 'type' field)")
+	}
 	return resp, nil
 }
 
@@ -495,6 +501,10 @@ func (c *Client) sendLocked(msg map[string]interface{}) (map[string]interface{},
 	}
 	if errMsg, ok := resp["error"].(string); ok {
 		return resp, fmt.Errorf("registry: %s", errMsg)
+	}
+	// PILOT-132: reject valid JSON that lacks the expected "type" envelope key.
+	if _, hasType := resp["type"]; !hasType && len(resp) > 0 {
+		return resp, fmt.Errorf("registry: malformed response (missing 'type' field)")
 	}
 	return resp, nil
 }

--- a/pkg/registry/client/zz_client_wire_test.go
+++ b/pkg/registry/client/zz_client_wire_test.go
@@ -606,6 +606,31 @@ func TestRotateKeyOmitsBlankSignatureAndPubKey(t *testing.T) {
 	}
 }
 
+// TestSendReturnsErrorOnMalformedResponse verifies that a valid-JSON response
+// that lacks both an "error" key and a "type" key is treated as a protocol
+// violation, not silently accepted (PILOT-132).
+func TestSendReturnsErrorOnMalformedResponse(t *testing.T) {
+	t.Parallel()
+	srv := newFakeJSONServer(t, func(_ map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{"unexpected": "key"}
+	})
+	defer srv.close()
+
+	c, err := Dial(srv.addr())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	_, err = c.Send(map[string]interface{}{"type": "ping"})
+	if err == nil {
+		t.Fatalf("expected error for malformed response (missing 'type' key)")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("error should describe malformed response: %v", err)
+	}
+}
+
 func minimalTLSConfig() *tls.Config {
 	return &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} //nolint:gosec // test-only
 }


### PR DESCRIPTION
## What

The registry client's `sendOnEntry`, `sendLocked`, and `sendJSONLocked` functions return `resp, nil` for any valid-JSON response that lacks an `"error"` key — even if the response has no recognizable envelope shape (e.g. `{"unexpected":"key"}`). This affects all 12 client API methods.

## Fix

After the existing `resp["error"]` check, add a guard: if a non-empty response lacks a `"type"` envelope key, return a `"malformed response (missing 'type' field)" error.

Three locations patched:
- `client.go` — `sendOnEntry` (per-entry pool path)
- `client.go` — `sendLocked` (single-conn path)
- `binary_client.go` — `sendJSONLocked` (binary-protocol JSON passthrough)

## Verification

- `go build ./...` — ✅ clean
- `go vet ./pkg/registry/client/` — ✅ clean
- `go test ./pkg/registry/client/ -count=1 -timeout 60s` — ✅ all tests pass, including new `TestSendReturnsErrorOnMalformedResponse`

Closes [PILOT-132](https://vulturelabs.atlassian.net/browse/PILOT-132)