### PR TITLE
fix(protocol): add bounds check to UnmarshalAddr (PILOT-133)

### DIFF
--- a/pkg/protocol/address.go
+++ b/pkg/protocol/address.go
@@ -58,7 +58,12 @@ func (a Addr) MarshalTo(buf []byte, offset int) {
 }
 
 // UnmarshalAddr reads a 6-byte address from buf.
+// Returns a zero address if buf is shorter than AddrSize (6 bytes),
+// rather than panicking on the out-of-bounds slice (PILOT-133).
 func UnmarshalAddr(buf []byte) Addr {
+	if len(buf) < AddrSize {
+		return Addr{}
+	}
 	return Addr{
 		Network: binary.BigEndian.Uint16(buf[0:2]),
 		Node:    binary.BigEndian.Uint32(buf[2:6]),

--- a/pkg/protocol/zz_protocol_test.go
+++ b/pkg/protocol/zz_protocol_test.go
@@ -86,6 +86,58 @@ func TestAddrMarshalToOffset(t *testing.T) {
 	}
 }
 
+func TestUnmarshalAddrShortBuffer(t *testing.T) {
+	t.Parallel()
+	// PILOT-133: UnmarshalAddr must not panic on short buffers.
+	// It should return a zero address instead of indexing out of bounds.
+
+	// 0 bytes
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("UnmarshalAddr panicked on 0-byte buffer: %v", r)
+			}
+		}()
+		a := UnmarshalAddr([]byte{})
+		if !a.IsZero() {
+			t.Errorf("expected zero addr for empty buffer, got %+v", a)
+		}
+	}()
+
+	// 3 bytes
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("UnmarshalAddr panicked on 3-byte buffer: %v", r)
+			}
+		}()
+		a := UnmarshalAddr([]byte{0x00, 0x01, 0x02})
+		if !a.IsZero() {
+			t.Errorf("expected zero addr for short buffer, got %+v", a)
+		}
+	}()
+
+	// 5 bytes (one short)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("UnmarshalAddr panicked on 5-byte buffer: %v", r)
+			}
+		}()
+		a := UnmarshalAddr([]byte{0x00, 0x01, 0xDE, 0xAD, 0xBE})
+		if !a.IsZero() {
+			t.Errorf("expected zero addr for 5-byte buffer, got %+v", a)
+		}
+	}()
+
+	// 6 bytes (valid, should work normally)
+	a := UnmarshalAddr([]byte{0x00, 0x01, 0xDE, 0xAD, 0xBE, 0xEF})
+	want := Addr{Network: 0x0001, Node: 0xDEADBEEF}
+	if a != want {
+		t.Errorf("valid 6-byte buffer: got %+v, want %+v", a, want)
+	}
+}
+
 func TestAddrStringFormat(t *testing.T) {
 	t.Parallel()
 	a := Addr{Network: 0x00A3, Node: 0xF2910004}


### PR DESCRIPTION
## What failed

`UnmarshalAddr` (pkg/protocol/address.go:61-66) indexed `buf[0:2]` and `buf[2:6]` without checking that `len(buf) >= AddrSize` (6 bytes). Current callers in `Unmarshal` are safe thanks to the 34-byte header guard, but the exported function has no internal guard. A future refactor passing a short slice would panic with a slice-bounds runtime error.

## Why this fix

Added a `len(buf) < AddrSize` guard at the top of `UnmarshalAddr` that returns a zero address (`Addr{}`) instead of panicking. This matches the defensive-hygiene posture described in PILOT-133.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./pkg/protocol/ -count=1` — all pass, including new `TestUnmarshalAddrShortBuffer` that exercises 0, 3, 5, and 6-byte inputs
- New test reproduces the panic on main (3/3 short-buffer cases), then passes with the fix

## Files changed

- `pkg/protocol/address.go` (+5 lines)
- `pkg/protocol/zz_protocol_test.go` (+52 lines, new test)

Closes [PILOT-133](https://vulturelabs.atlassian.net/browse/PILOT-133)