### PR TITLE
fix: start idle-ping goroutine to keep WSS connection alive (PILOT-149)

### DIFF
--- a/pkg/daemon/transport/wss/wss.go
+++ b/pkg/daemon/transport/wss/wss.go
@@ -227,6 +227,7 @@ func Dial(ctx context.Context, cfg Config) (*Transport, error) {
 	t.connMu.Unlock()
 
 	go t.supervise()
+	go t.idlePing()
 	return t, nil
 }
 
@@ -541,6 +542,37 @@ func (t *Transport) drainReads(conn *websocket.Conn) {
 		case t.recvCh <- recvItem{frame: frameCopy}:
 		case <-t.superviseDoneCh:
 			return
+		}
+	}
+}
+
+// idlePing sends websocket Ping frames at the configured IdlePingInterval
+// to keep the WSS connection alive through proxy idle timeouts. Runs until
+// Close() fires via lifetimeCtx. Skips pings while the supervisor is
+// reconnecting (conn == nil).
+func (t *Transport) idlePing() {
+	ticker := time.NewTicker(t.cfg.IdlePingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-t.lifetimeCtx.Done():
+			return
+		case <-ticker.C:
+			if t.closed.Load() {
+				return
+			}
+			t.connMu.RLock()
+			conn := t.conn
+			t.connMu.RUnlock()
+			if conn == nil {
+				continue
+			}
+			t.writeMu.Lock()
+			err := conn.Ping(t.lifetimeCtx)
+			t.writeMu.Unlock()
+			if err != nil {
+				slog.Debug("wss transport: idle ping failed", "err", err)
+			}
 		}
 	}
 }

--- a/pkg/daemon/transport/wss/zz_wss_test.go
+++ b/pkg/daemon/transport/wss/zz_wss_test.go
@@ -600,6 +600,48 @@ func TestReconnect_SurvivesFailedRedialAttempts(t *testing.T) {
 	}
 }
 
+// TestIdlePing_KeepsConnectionAlive verifies that the idle-ping
+// goroutine runs without interfering with Send/Recv. The bug was that
+// IdlePingInterval was stored but no goroutine ever sent websocket
+// Ping frames — corporate proxies would idle-timeout the WS connection
+// and the daemon would wedge on Recv forever.
+func TestIdlePing_KeepsConnectionAlive(t *testing.T) {
+	t.Parallel()
+	id := mustID(t)
+	fb := newFakeBeacon(t, 1)
+
+	tr, err := wss.Dial(context.Background(), wss.Config{
+		URL:              fb.url(),
+		TLSConfig:        fb.tlsConfig(),
+		Identity:         id,
+		NodeID:           1,
+		IdlePingInterval: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer tr.Close()
+
+	// Wait long enough for several ping cycles to fire. If the ping
+	// goroutine panics or deadlocks (e.g., holds writeMu while the
+	// transport is closed), the Send/Recv round-trip below will hang.
+	time.Sleep(200 * time.Millisecond)
+
+	// Send/Recv must still work after idle pings have fired.
+	payload := []byte("after-pings")
+	if _, err := tr.Send(payload, nil); err != nil {
+		t.Fatalf("Send after idle pings: %v", err)
+	}
+	frame, _, err := tr.Recv()
+	if err != nil {
+		t.Fatalf("Recv after idle pings: %v", err)
+	}
+	want := append([]byte("echo:"), payload...)
+	if string(frame) != string(want) {
+		t.Errorf("Recv = %q; want %q", frame, want)
+	}
+}
+
 func mustID(t *testing.T) *crypto.Identity {
 	t.Helper()
 	id, err := crypto.GenerateIdentity()


### PR DESCRIPTION
## What

Fixes PILOT-149: The WSS transport's `IdlePingInterval` config was stored but never used — no goroutine ever sent websocket Ping frames. Corporate proxies idle-timeout WS after 60-300s, causing the daemon to wedge on Recv forever without any error surfaced.

## Changes

- **`pkg/daemon/transport/wss/wss.go`**: Add `idlePing()` goroutine that sends websocket Ping frames at the configured `IdlePingInterval` (default 30s). Uses `connMu.RLock` for conn access, `writeMu.Lock` for serialization with Send. Skips pings while supervisor is reconnecting. Exits cleanly on Close via `lifetimeCtx`.
- **`pkg/daemon/transport/wss/zz_wss_test.go`**: Add `TestIdlePing_KeepsConnectionAlive` — dials with 50ms interval, waits 200ms, then verifies Send/Recv still works.

## Verification

```
go test -v -count=1 ./pkg/daemon/transport/wss/
=== RUN   TestIdlePing_KeepsConnectionAlive
--- PASS: TestIdlePing_KeepsConnectionAlive (0.21s)
...
PASS (10/10 tests, 0 failures)
```

## Scope

- 1 file modified: `wss.go` (+33/-0 lines)
- 1 file modified: `zz_wss_test.go` (+41/-0 lines)
- Total: 2 files, +74 lines

Closes PILOT-149