### PR TITLE
fix(pilotctl): poll handshake trust on public-peer first contact (PILOT-220)

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -565,6 +565,48 @@ func maybeAutoHandshake(d *driver.Driver, addr protocol.Addr, skip bool) {
 			if !jsonOutput {
 				fmt.Fprintf(os.Stderr, "auto-handshake established trust with public peer %s\n", addr)
 			}
+			return
+		}
+		// PILOT-220: on fresh daemon starts the handshake ACK path
+		// may not be fully routed within the initial 5 s window.
+		// When the local trust gate drops the reply SYN because
+		// trust isn't finalised, send-message --wait times out.
+		// Poll WaitForTrust while a pending handshake exists (up
+		// to 16 s extra) so trust finalises before the first user
+		// query hits the wire.
+	} else {
+		// WaitForTrust not supported (old daemon); proceed best-effort.
+		return
+	}
+	for poll := 0; poll < 8; poll++ {
+		time.Sleep(2 * time.Second)
+		pending, err := d.PendingHandshakes()
+		if err != nil {
+			break
+		}
+		hasPending := false
+		if list, ok := pending["pending"].([]interface{}); ok {
+			for _, item := range list {
+				m, okMap := item.(map[string]interface{})
+				if !okMap {
+					continue
+				}
+				if nid, okNid := m["node_id"].(float64); okNid && uint32(nid) == addr.Node {
+					hasPending = true
+					break
+				}
+			}
+		}
+		if !hasPending {
+			break // handshake resolved (accepted or rejected); stop polling
+		}
+		if resp, err := d.WaitForTrust(addr.Node, 0); err == nil {
+			if trusted, _ := resp["trusted"].(bool); trusted {
+				if !jsonOutput {
+					fmt.Fprintf(os.Stderr, "auto-handshake established trust with public peer %s\n", addr)
+				}
+				break
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What's broken

**PILOT-220**: First-time weather specialist queries time out on fresh nodes (requires daemon restart).

On a freshly installed node, the first `pilotctl send-message --wait` to a weather specialist times out at 30s. The send itself succeeds, but the weather agent's reply SYN is silently dropped by the local trust gate because the handshake hasn't finalised yet.

## Root cause

In `maybeAutoHandshake` (branch 3 — public peer), after sending a handshake request we call `WaitForTrust` with a 5s timeout. For auto-approve peers this normally finalises in ~700–2400ms, but on fresh daemon starts the route/punch path runs in parallel and the handshake ACK can take longer. When the 5s elapses without trust, the code falls through silently. The data send then succeeds (public peers accept all SYNs), but the **reply SYN from the service agent is rejected by the local trust gate** (`daemon.go:2389` — `SYN rejected: untrusted source`) because the peer still isn't in the trusted set.

## Fix

After the initial `WaitForTrust(5s)` returns without trust, poll whether the target peer still has a pending handshake. If a pending entry exists, poll `WaitForTrust` at 2s intervals (up to 16s extra) so trust finalises before the first user query hits the wire.

**Gated on real pending handshake**: the polling loop checks `PendingHandshakes()` on each iteration. If the handshake resolved (accepted or rejected), we stop polling immediately, adding no unnecessary latency to non-handshake paths.

## Verification

- `go build ./cmd/pilotctl/...` ✅
- `go vet ./cmd/pilotctl/...` ✅
- `go test ./cmd/pilotctl/...` ✅ (8.3s, all pass)
- `go build ./...` ✅ (full build)

## Diff

```
cmd/pilotctl/main.go | 42 insertions
```

Closes [PILOT-220](https://vulturelabs.atlassian.net/browse/PILOT-220)