### PR TITLE
fix(install): add tar fallback for macOS bsdtar incompatibility (PILOT-221)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -232,7 +232,18 @@ if [ -n "$TAG" ]; then
                 [ -n "$ACTUAL" ] && echo "  Verified SHA-256"
             fi
         fi
-        tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
+        # macOS bsdtar can fail silently on GitHub gzip archives.
+        # Try tar -xzf first; fall back to gunzip|tar on failure.
+        if ! tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" 2>/dev/null || [ ! -f "$TMPDIR/pilotctl" ]; then
+            echo "  tar -xzf failed or produced no output; trying gunzip fallback..."
+            gunzip -c "$TMPDIR/$ARCHIVE" | tar -x -C "$TMPDIR"
+        fi
+        if [ ! -f "$TMPDIR/pilotctl" ]; then
+            echo "Error: failed to extract binaries from ${ARCHIVE}"
+            echo "Try downloading manually from:"
+            echo "  ${URL}"
+            exit 1
+        fi
     else
         TAG=""
     fi


### PR DESCRIPTION
## What failed

macOS ships bsdtar which can silently fail to extract GitHub gzip tarballs — `tar -xzf` produces no output files and exits zero. Users (e.g. Mira in PILOT-36) were forced to fall back to manual GitHub release downloads.

## Why this fix

The `install.sh` script had no error checking after `tar -xzf`. This PR adds:

1. **Exit-code + existence check** after `tar -xzf`
2. **Fallback to `gunzip | tar -x`** when `tar -xzf` fails or produces no output (covers the macOS bsdtar edge case)
3. **Final guard** that exits with a clear error + manual download link if `pilotctl` is still missing after both extraction paths

## Verification

- `bash -n install.sh` — syntax OK
- `go build ./...` — clean (no Go changes, install.sh is shell-only)
- Diff: +12/-1, 1 file (small tier)

Closes [PILOT-221](https://vulturelabs.atlassian.net/browse/PILOT-221)