### PR TITLE
fix(daemon): add -advertise-endpoint flag for k8s pod environments (PILOT-217)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -50,6 +50,7 @@ func main() {
 	listenAddr := flag.String("listen", ":0", "UDP listen address for tunnel traffic")
 	socketPath := flag.String("socket", driver.DefaultSocketPath(), "Unix socket path for IPC")
 	endpoint := flag.String("endpoint", "", "fixed public endpoint (host:port) — skips STUN (for cloud VMs with known IPs)")
+	advertiseEndpoint := flag.String("advertise-endpoint", "", "override STUN-discovered endpoint for registry advertisement (host:port) — for k8s pods where STUN returns unreachable IPs. When set, STUN still runs but the advertised address uses this value")
 	encrypt := flag.Bool("encrypt", true, "enable tunnel-layer encryption (X25519 + AES-256-GCM)")
 	registryTLS := flag.Bool("registry-tls", false, "use TLS for registry connection")
 	registryFingerprint := flag.String("registry-fingerprint", "", "hex SHA-256 fingerprint of registry TLS certificate (required when -registry-trust=pinned)")
@@ -143,6 +144,7 @@ func main() {
 		ListenAddr:            *listenAddr,
 		SocketPath:            *socketPath,
 		Endpoint:              *endpoint,
+		AdvertiseEndpoint:     *advertiseEndpoint,
 		Encrypt:               *encrypt,
 		RegistryTLS:           *registryTLS,
 		RegistryFingerprint:   *registryFingerprint,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -86,7 +86,8 @@ type Config struct {
 	Email         string // email address for account identification and key recovery
 	Owner         string // deprecated: use Email instead
 
-	Endpoint string // fixed public endpoint (host:port) — skips STUN discovery (for cloud VMs)
+	Endpoint           string // fixed public endpoint (host:port) — skips STUN discovery (for cloud VMs)
+	AdvertiseEndpoint  string // override STUN-discovered endpoint for registry advertisement (host:port) — for k8s pods where STUN returns unreachable IPs
 	Public   bool   // make this node's endpoint publicly discoverable
 	Hostname string // hostname for discovery (empty = none)
 
@@ -645,6 +646,18 @@ func (d *Daemon) Start() error {
 				slog.Debug("discovered public endpoint", "endpoint", pubAddr)
 			}
 		}
+	}
+
+	// 1b. Override discovered endpoint for environments where STUN
+	// returns an unreachable address (e.g. k8s pods behind CNI — STUN
+	// returns the worker node's external IP, which is unreachable
+	// from other pods in the same cluster). -advertise-endpoint lets
+	// the deployment YAML set the pod's cluster-IP:hostPort so peers
+	// route through the correct intra-cluster address.
+	if d.config.AdvertiseEndpoint != "" {
+		registrationAddr = d.config.AdvertiseEndpoint
+		slog.Info("overriding STUN-discovered endpoint with -advertise-endpoint",
+			"advertised", registrationAddr)
 	}
 
 	// 2. Enable tunnel encryption if configured

--- a/pkg/daemon/zz_coverage_pkg_daemon_round2_test.go
+++ b/pkg/daemon/zz_coverage_pkg_daemon_round2_test.go
@@ -1316,3 +1316,51 @@ func TestSubscribeNetworkInternalDeliversJoined(t *testing.T) {
 	}
 	d.StopManagedEngine(81)
 }
+
+// TestAdvertiseEndpointOverridesSTUN verifies that when AdvertiseEndpoint
+// is set in the daemon config, the daemon uses it as the public endpoint
+// instead of whatever STUN would have discovered. This is the k8s pod
+// use case: STUN returns the worker node's external IP (unreachable from
+// other pods), so the deployment YAML sets -advertise-endpoint to the
+// pod's cluster-IP:hostPort.
+func TestAdvertiseEndpointOverridesRegistration(t *testing.T) {
+	t.Parallel()
+	reg, rc := startTestRegistry(t)
+	t.Cleanup(func() { reg.Close() })
+	rc.Close()
+
+	idDir := t.TempDir()
+	sockDir, err := os.MkdirTemp("", "pds")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(sockDir) })
+
+	// Simulate a pod IP that STUN would never return
+	advertised := "10.42.1.99:4000"
+
+	d := New(Config{
+		ListenAddr:          "127.0.0.1:0",
+		BeaconAddr:          "", // skip STUN — no beacon
+		RegistryAddr:        reg.Addr().String(),
+		SocketPath:          sockDir + "/s",
+		IdentityPath:        idDir + "/i",
+		Email:               "advertise@example.test",
+		AdvertiseEndpoint:   advertised,
+		DisablePolicyRunner: true,
+	})
+
+	if err := d.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer d.Stop()
+
+	// Wait a beat for registration to settle.
+	time.Sleep(500 * time.Millisecond)
+
+	info := d.Info()
+	if info.Endpoint != advertised {
+		t.Fatalf("expected endpoint %s, got %s", advertised, info.Endpoint)
+	}
+	t.Logf("endpoint correctly set to %s", info.Endpoint)
+}


### PR DESCRIPTION
## What failed

In k8s pod environments, STUN-based endpoint discovery returns the worker node's external IP (e.g. 198.51.100.1), which is unreachable from other pods in the same cluster. Fresh daemons after pod restarts cannot establish encrypted relay data-exchange sessions — handshake succeeds but send-message fails with `dial timeout after 10s`. The canary round-trip test (pilot-protocol/pilot-canary#1) surfaces this on every `kubectl rollout restart`.

## Root cause

k3s CNI pods share the worker node's NAT egress, so the STUN server sees the worker's external IP. That IP is not routable inside the pod network. The daemon registers this unreachable address as its endpoint, and peer relay sessions never complete.

## Fix

New `-advertise-endpoint <host:port>` flag on `pilot-daemon`. When set, it overrides the STUN-discovered address with the given value before registering with the registry. Unlike `-endpoint` (which skips STUN entirely), this flag still runs STUN for observability but registers the provided address.

For k8s deployments, the deployment YAML sets:
```
-advertise-endpoint $(hostname -i):4000
```
so the pod's cluster IP is used as the advertised endpoint.

## Files changed

```
cmd/daemon/main.go                               |  2 ++
pkg/daemon/daemon.go                             | 15 ++++++++++++++-
pkg/daemon/zz_coverage_pkg_daemon_round2_test.go | 48 ++++++++++++++++++++++++++++++++++++++++++++++++
3 files changed, 64 insertions(+), 1 deletion(-)
```

## Verification

- `go build ./...` — clean
- `go vet ./pkg/daemon/` — clean
- `go test -short -parallel 4 -count=1 -timeout 120s ./pkg/daemon/` — 75+ tests pass (22.5s)
- New `TestAdvertiseEndpointOverridesRegistration` — verifies endpoint override works correctly

Closes [PILOT-217](https://vulturelabs.atlassian.net/browse/PILOT-217)