### PR TITLE
feat(cmd/updater): add standalone updater binary with --pin flag

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pilot-protocol/updater"
+)
+
+var version = "dev"
+
+func main() {
+	installDir := flag.String("install-dir", "", "directory containing pilot binaries (required)")
+	repo := flag.String("repo", "TeoSlayer/pilotprotocol", "GitHub owner/repo for releases")
+	pin := flag.String("pin", "", "pin to a specific release tag (e.g. v1.10.5); empty = follow latest")
+	interval := flag.Duration("interval", 1*time.Hour, "check interval")
+	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
+	logFormat := flag.String("log-format", "text", "log format (text, json)")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	if *installDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --install-dir is required")
+		os.Exit(2)
+	}
+
+	setupLogging(*logLevel, *logFormat)
+
+	u := updater.New(updater.Config{
+		CheckInterval: *interval,
+		Repo:          *repo,
+		InstallDir:    *installDir,
+		Version:       version,
+		PinnedVersion: *pin,
+	})
+
+	u.Start()
+	slog.Info("updater started",
+		"install_dir", *installDir,
+		"repo", *repo,
+		"interval", interval.String(),
+	)
+	if *pin != "" {
+		slog.Info("version pinned", "tag", *pin)
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	slog.Info("shutting down")
+	u.Stop()
+}
+
+func setupLogging(level, format string) {
+	var lvl slog.Level
+	switch level {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{Level: lvl}
+	var h slog.Handler
+	if format == "json" {
+		h = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		h = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(h))
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/pilot-protocol/app-store v0.1.0
 	github.com/pilot-protocol/beacon v0.1.0
-	github.com/pilot-protocol/common v0.1.0
+	github.com/pilot-protocol/common v0.4.0
 	github.com/pilot-protocol/dataexchange v0.1.0
 	github.com/pilot-protocol/eventstream v0.1.0
 	github.com/pilot-protocol/gateway v0.1.0
@@ -22,6 +22,7 @@ require (
 
 require (
 	github.com/expr-lang/expr v1.17.8 // indirect
+	github.com/pilot-protocol/updater v0.2.2-0.20260529065627-220ed5b8383f // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/pilot-protocol/beacon v0.1.0 h1:jXO8duAzzpB8K+9It0QwR9BRupgKZ8IQhuwqy
 github.com/pilot-protocol/beacon v0.1.0/go.mod h1:PejZP5sZ4s5Lrtc0wdYHSEJVc7cn6E8yqo0R4CV+iUo=
 github.com/pilot-protocol/common v0.1.0 h1:m8mZZATgeBiFoqhWXPnskw2u0lNkWxHp0IagZK35V1g=
 github.com/pilot-protocol/common v0.1.0/go.mod h1:4YZWHK5nhM+4RLmYTspLxxAFbyBII7yzQDAHq3Ul2ck=
+github.com/pilot-protocol/common v0.4.0 h1:lH1WdQBU5Zan1rAqF/kYpcJO6vBoYVWXrWUNwMX10jA=
+github.com/pilot-protocol/common v0.4.0/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
 github.com/pilot-protocol/dataexchange v0.1.0 h1:JJ29lL/LxDd1+szKFoEVxakzT93Tid3zoaAUBVGNKV4=
 github.com/pilot-protocol/dataexchange v0.1.0/go.mod h1:mXD17Vh0Eup+M//YhCm4j6D/DyFaZM7JzN5xexBdfLs=
 github.com/pilot-protocol/eventstream v0.1.0 h1:uHNTNTMA9MasBBpi2nCRkvFmFvTxbKCk7azPfuILkvY=
@@ -28,6 +30,8 @@ github.com/pilot-protocol/skillinject v0.1.0 h1:gs912gqmxl0ifIvswefjx8BzPCmoBWS7
 github.com/pilot-protocol/skillinject v0.1.0/go.mod h1:303GIB6j95ZhnoYeTlYzlBDhUbO01PB/6KGohm4DcJs=
 github.com/pilot-protocol/trustedagents v0.1.0 h1:rCX0IQxfZ84Q4dSgw01WJgjHUODRnI3iAon1t+NuFGE=
 github.com/pilot-protocol/trustedagents v0.1.0/go.mod h1:uVySmuMPb6N7AOCnvLHN2I9C9ggqEpfBmAZwVuP5Xaw=
+github.com/pilot-protocol/updater v0.2.2-0.20260529065627-220ed5b8383f h1:1dyunPeEOriqTv1xbt0fuDwieA5V5NLU1nVSC2714jU=
+github.com/pilot-protocol/updater v0.2.2-0.20260529065627-220ed5b8383f/go.mod h1:/I0uhVk1SljAOEYmjTdI/6CP7UmemmV4WB22ai1FxUw=
 github.com/pilot-protocol/webhook v0.1.0 h1:SnIcn+IdHvzoJt+OFzGJbkBHurjNBD0xSc6HAUvExAg=
 github.com/pilot-protocol/webhook v0.1.0/go.mod h1:c0du05MMy8FYnlc2YGqUWxRgTP8pRWTrtIdNuRhf6uk=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=


### PR DESCRIPTION
## What

Creates `cmd/updater/main.go` — the standalone `pilot-updater` binary previously referenced by `install.sh` and the `release.yml` workflow but which did not exist yet.

## Why

- The release workflow (`.github/workflows/release.yml`) builds all binaries including `updater` via `go build ./cmd/updater`, but the directory was missing — any new release would fail at the build step.
- The install.sh source-build path also references `./cmd/updater`.
- Without this binary, there's no way to run the auto-updater as a standalone service.

## Flags

| Flag | Default | Description |
|---|---|---|
| `--install-dir` | _(required)_ | Path to pilot binaries |
| `--repo` | `TeoSlayer/pilotprotocol` | GitHub owner/repo for releases |
| `--pin` | _(empty)_ | Pin to a specific release tag (e.g. `--pin v1.10.5`). Empty = follow latest. |
| `--interval` | `1h` | Check interval |
| `--version` | — | Print version and exit |

## Dependencies

- Adds `github.com/pilot-protocol/updater` (pseudo-version from PR pilot-protocol/updater#4) — this is the library that includes the new `PinnedVersion` config field.
- `github.com/pilot-protocol/common` bumped from v0.1.0 → v0.4.0 (transitive via updater).

## Testing

- Binary builds successfully
- `--version` prints `dev`
- `--install-dir` validation works (exits 2 when missing)
- Updater library tested with 73 unit + e2e tests (see pilot-protocol/updater#4)