### PR TITLE
fix(install.sh): verify checksums.txt SLSA attestation before trusting digests (PILOT-76)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -223,6 +223,22 @@ if [ -n "$TAG" ]; then
     if curl -fsSL "$URL" -o "$TMPDIR/$ARCHIVE" 2>/dev/null; then
         # Verify SHA-256 against release checksums.txt when available
         if curl -fsSL "$CHECKSUMS_URL" -o "$TMPDIR/checksums.txt" 2>/dev/null; then
+            # Verify checksums.txt provenance via GitHub SLSA attestation.
+            # The release workflow (release.yml) attests checksums.txt via
+            # actions/attest-build-provenance@v2 (PILOT-120, PR #166).
+            # If gh CLI is available, verify before trusting any digest.
+            if command -v gh >/dev/null 2>&1; then
+                if gh attestation verify "$TMPDIR/checksums.txt" --repo "$REPO" 2>/dev/null; then
+                    echo "  Verified checksums.txt attestation"
+                else
+                    echo "Error: checksums.txt attestation verification failed"
+                    echo "  The file may have been tampered with. Aborting."
+                    exit 1
+                fi
+            else
+                echo "  Note: gh CLI not found — skipping attestation verification"
+                echo "  Install gh: https://cli.github.com/"
+            fi
             EXPECTED=$(grep " ${ARCHIVE}\$" "$TMPDIR/checksums.txt" | awk '{print $1}')
             if [ -n "$EXPECTED" ]; then
                 if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
## What

The release workflow now attests `checksums.txt` via `actions/attest-build-provenance@v2` (PILOT-120, PR #166). This PR adds consumer-side verification: before trusting the checksums file to validate the tarball digest, the installer now runs `gh attestation verify --repo TeoSlayer/pilotprotocol checksums.txt`.

## Why

An attacker with GitHub write access could publish a matched fake binary + fake checksums.txt. The SHA-256 check passes because the attacker controls both sides. SLSA attestation closes this gap — the attestation ties checksums.txt to the trusted CI workflow identity, which only triggers on pushes to main (not arbitrary PRs).

## What changed

- 1 file, +16 lines — adds attestation verification block after downloading checksums.txt, before trusting its contents
- Graceful skip when `gh` CLI not installed (warns + continues; sha256 still provides transport integrity)
- Hard abort when `gh` IS installed but verification fails

## Verification

- Shell script is manually reviewed line-by-line
- Follows same bash patterns as the surrounding code (POSIX sh, `set -e`)

Closes [PILOT-76](https://vulturelabs.atlassian.net/browse/PILOT-76) (install.sh half — updater half is a separate PR on pilot-protocol/updater).