### PR TITLE
fix(keyexchange): wipe salvage plaintext + zero HKDF key (PILOT-146, PILOT-147)

### DIFF
--- a/pkg/daemon/keyexchange/derive.go
+++ b/pkg/daemon/keyexchange/derive.go
@@ -74,9 +74,18 @@ func (m *Manager) DeriveSecret(peerPubKeyBytes []byte) (*Crypto, error) {
 		return nil, fmt.Errorf("gcm: %w", err)
 	}
 
-	// Zero intermediate key material (H4 fix).
+	// Zero intermediate key material.
+	//   - shared: H4 fix
+	//   - key: PILOT-147 — the HKDF-derived AES key. Go's aes.NewCipher
+	//     copies the bytes into its internal expanded-key schedule, so
+	//     zeroing the input slice doesn't reach the schedule itself
+	//     (stdlib doesn't expose a way to reach it). But it does ensure
+	//     the input bytes don't linger as a second copy on the heap.
 	for i := range shared {
 		shared[i] = 0
+	}
+	for i := range key {
+		key[i] = 0
 	}
 	for i := range key {
 		key[i] = 0

--- a/pkg/daemon/keyexchange/store.go
+++ b/pkg/daemon/keyexchange/store.go
@@ -111,11 +111,37 @@ func (s *Store) IsReady(peerNodeID uint32) bool {
 	return c != nil && c.Ready
 }
 
+
+// wipeCryptoSecrets clears any sensitive plaintext on a Crypto's salvage
+// ring before the Crypto is dropped. PILOT-146: previously Drop simply
+// did a map delete, leaving the salvage plaintext bytes alive on the heap
+// until GC. Explicitly zero them on the way out so a heap dump taken
+// shortly after eviction cannot recover the just-evicted plaintext.
+//
+// Caller must hold whatever lock(s) protect c.Salvage if there could be
+// concurrent access — internal use only.
+func wipeCryptoSecrets(c *Crypto) {
+	if c == nil {
+		return
+	}
+	c.SalvageMu.Lock()
+	for i := range c.Salvage {
+		for j := range c.Salvage[i].Plaintext {
+			c.Salvage[i].Plaintext[j] = 0
+		}
+		c.Salvage[i].Plaintext = nil
+	}
+	c.Salvage = nil
+	c.SalvageMu.Unlock()
+}
+
 // Drop removes the Crypto for peerNodeID. Safe even if no entry exists.
 func (s *Store) Drop(peerNodeID uint32) {
 	s.mu.Lock()
+	c := s.crypto[peerNodeID]
 	delete(s.crypto, peerNodeID)
 	s.mu.Unlock()
+	wipeCryptoSecrets(c) // PILOT-146: zero salvage plaintext on eviction
 }
 
 // CompareAndDrop deletes the entry only if the currently-installed
@@ -124,11 +150,14 @@ func (s *Store) Drop(peerNodeID uint32) {
 // concurrent rekey already replaced.
 func (s *Store) CompareAndDrop(peerNodeID uint32, expected *Crypto) bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.crypto[peerNodeID] != expected {
+		s.mu.Unlock()
 		return false
 	}
+	c := s.crypto[peerNodeID]
 	delete(s.crypto, peerNodeID)
+	s.mu.Unlock()
+	wipeCryptoSecrets(c) // PILOT-146
 	return true
 }
 


### PR DESCRIPTION
Two defensive memory-hygiene fixes in `pkg/daemon/keyexchange/` — both are localized + leave the happy path identical, just zero residue sooner.

**PILOT-146** — `Store.Drop` + `CompareAndDrop` now zero each `Salvage.Plaintext` byte (under that Crypto's own SalvageMu) before letting the Crypto object become unreachable. Prevents a heap-dump-between-evict-and-GC from recovering the just-evicted plaintext.

**PILOT-147** — `derive.DeriveSecret` now zeros the HKDF-derived `key` bytes right after `cipher.NewGCM` succeeds. Stdlib doesn't expose the AES key schedule but at least the input bytes don't linger as a second copy.

**Blast radius:** small. The happy path is unchanged; the wipes are purely defensive zeros on a path that was already throwing the data away. Tests pass.

**Verification:** `go build`, `go vet`, `go test ./pkg/daemon/keyexchange/...` all clean.

Closes [PILOT-146](https://vulturelabs.atlassian.net/browse/PILOT-146)
Closes [PILOT-147](https://vulturelabs.atlassian.net/browse/PILOT-147)