### PR TITLE
fix: gate IPC rotate_key on admin token (PILOT-230)

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -2814,7 +2814,8 @@ func cmdRotateKey(args []string) {
 	_ = args
 	d := connectDriver()
 	defer d.Close()
-	resp, err := d.RotateKey()
+	adminToken := getAdminToken()
+	resp, err := d.RotateKey(adminToken)
 	if err != nil {
 		fatalCode("connection_failed", "rotate-key: %v", err)
 	}

--- a/pkg/daemon/ipc.go
+++ b/pkg/daemon/ipc.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -645,7 +646,7 @@ func (s *IPCServer) dispatch(conn *ipcConn, cmd byte, reqID uint64, payload []by
 	case CmdManaged:
 		s.handleManaged(conn, reqID, payload)
 	case CmdRotateKey:
-		s.handleRotateKey(conn, reqID)
+		s.handleRotateKey(conn, reqID, payload)
 	default:
 		s.sendError(conn, reqID, fmt.Sprintf("unknown command: 0x%02X", cmd))
 	}
@@ -1155,7 +1156,34 @@ func (s *IPCServer) handleSetTags(conn *ipcConn, reqID uint64, payload []byte) {
 	}
 }
 
-func (s *IPCServer) handleRotateKey(conn *ipcConn, reqID uint64) {
+// handleRotateKey services CmdRotateKey — admin-token-gated key rotation.
+// Wire payload: [tokenLen(2)][token...]
+//
+// On success, replies with CmdRotateKeyOK carrying the new public key.
+// On failure, replies with CmdError — "rotate_key denied: daemon has no
+// admin token configured" or "rotate_key denied: invalid admin token".
+func (s *IPCServer) handleRotateKey(conn *ipcConn, reqID uint64, payload []byte) {
+	// Admin token required: [tokenLen(2)][token...]
+	if len(payload) < 2 {
+		s.sendError(conn, reqID, "rotate_key: missing admin token")
+		return
+	}
+	tokenLen := binary.BigEndian.Uint16(payload[0:2])
+	if len(payload) < 2+int(tokenLen) {
+		s.sendError(conn, reqID, "rotate_key: truncated admin token")
+		return
+	}
+	token := string(payload[2 : 2+tokenLen])
+
+	if s.daemon.config.AdminToken == "" {
+		s.sendError(conn, reqID, "rotate_key denied: daemon has no admin token configured")
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(s.daemon.config.AdminToken)) != 1 {
+		s.sendError(conn, reqID, "rotate_key denied: invalid admin token")
+		return
+	}
+
 	result, err := s.daemon.RotateKey()
 	if err != nil {
 		s.sendError(conn, reqID, err.Error())

--- a/pkg/daemon/zz_coverage_pkg_daemon_round2_test.go
+++ b/pkg/daemon/zz_coverage_pkg_daemon_round2_test.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -805,13 +806,18 @@ func TestHandleRotateKeyHappyPath(t *testing.T) {
 	t.Cleanup(func() { reg.Close() })
 	t.Cleanup(func() { rc.Close() })
 
-	d := New(Config{})
+	d := New(Config{AdminToken: "test-token"})
 	d.regConn = rc
 	registerSelfOnRegistry(t, d)
 
 	s := d.ipc
 	ic, client := newIPCTestConn(t)
-	reply := runHandler(t, client, func() { s.handleRotateKey(ic, 0) })
+	// Wire payload: [tokenLen(2)][token...]
+	token := "test-token"
+	payload := make([]byte, 2+len(token))
+	binary.BigEndian.PutUint16(payload[0:2], uint16(len(token)))
+	copy(payload[2:], token)
+	reply := runHandler(t, client, func() { s.handleRotateKey(ic, 0, payload) })
 
 	if len(reply) < 1 {
 		t.Fatalf("rotate-key reply too short: %d", len(reply))

--- a/pkg/daemon/zz_coverage_pkg_daemon_test.go
+++ b/pkg/daemon/zz_coverage_pkg_daemon_test.go
@@ -1388,11 +1388,16 @@ func TestHandleManagedPolicyGetNoEngine(t *testing.T) {
 
 func TestHandleRotateKeyNoIdentitySendsError(t *testing.T) {
 	t.Parallel()
-	d := New(Config{}) // no identity
+	d := New(Config{AdminToken: "test"}) // no identity, but admin token configured
 	s := d.ipc
 	ic, client := newIPCTestConn(t)
+	// send valid admin token; RotateKey should still fail because identity is nil
+	token := "test"
+	payload := make([]byte, 2+len(token))
+	binary.BigEndian.PutUint16(payload[0:2], uint16(len(token)))
+	copy(payload[2:], token)
 	reply := runHandler(t, client, func() {
-		s.handleRotateKey(ic, 0)
+		s.handleRotateKey(ic, 0, payload)
 	})
 	if reply[0] != CmdError {
 		t.Fatalf("expected error reply; got 0x%02X", reply[0])

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -334,8 +334,16 @@ func (d *Driver) SetWebhook(url string) (map[string]interface{}, error) {
 // RotateKey asks the daemon to rotate its Ed25519 identity at the registry.
 // The daemon generates a new keypair, signs proof of the current key, calls
 // registry.RotateKey, then atomically swaps and persists the new identity.
-func (d *Driver) RotateKey() (map[string]interface{}, error) {
-	return d.jsonRPC([]byte{cmdRotateKey}, cmdRotateKeyOK, "rotate_key")
+// RotateKey sends a key-rotation request to the daemon. The adminToken
+// must match the daemon's configured AdminToken (empty = denied). The
+// wire format is [cmd(1)][tokenLen(2)][token...].
+func (d *Driver) RotateKey(adminToken string) (map[string]interface{}, error) {
+	tokenLen := len(adminToken)
+	msg := make([]byte, 3+tokenLen)
+	msg[0] = cmdRotateKey
+	binary.BigEndian.PutUint16(msg[1:3], uint16(tokenLen))
+	copy(msg[3:], adminToken)
+	return d.jsonRPC(msg, cmdRotateKeyOK, "rotate_key")
 }
 
 // Disconnect closes a connection by ID. Used by administrative tools.

--- a/pkg/driver/zz_driver_simple_ops_test.go
+++ b/pkg/driver/zz_driver_simple_ops_test.go
@@ -124,7 +124,7 @@ func TestDriverRotateKey(t *testing.T) {
 	}
 	defer drv.Close()
 
-	result, err := drv.RotateKey()
+	result, err := drv.RotateKey("")
 	if err != nil {
 		t.Fatalf("RotateKey: %v", err)
 	}


### PR DESCRIPTION
## What failed

The daemon IPC `rotate_key` handler (`pkg/daemon/ipc.go:1158`) accepted requests with zero auth — any process sharing the daemon's UID could send `CmdRotateKey` and swap the daemon's Ed25519 identity. The admin token gate (used by `BroadcastDatagram`) was missing from this path.

## Why this fix

Added admin-token verification to `handleRotateKey`, matching the pattern in `handleBroadcast` / `BroadcastDatagram`: parse `[tokenLen(2)][token...]` from the wire payload, constant-time compare against `Config.AdminToken`. Deny when the token is empty or mismatched.

### Changes

```
cmd/pilotctl/main.go                             |  3 ++-
 pkg/daemon/ipc.go                                | 32 ++++++++++++++++++++++--
 pkg/daemon/zz_coverage_pkg_daemon_round2_test.go | 10 ++++++--
 pkg/daemon/zz_coverage_pkg_daemon_test.go        |  9 +++++--
 pkg/driver/driver.go                             | 12 +++++++--
 pkg/driver/zz_driver_simple_ops_test.go          |  2 +-
 6 files changed, 58 insertions(+), 10 deletions(-)
```

- **`pkg/daemon/ipc.go`** — `handleRotateKey` now extracts and verifies admin token
- **`pkg/driver/driver.go`** — `RotateKey` accepts `adminToken` param, encodes in wire format
- **`cmd/pilotctl/main.go`** — `cmdRotateKey` passes token from `PILOT_ADMIN_TOKEN` / config

## Verification

- `go build ./...` — green
- `go vet ./...` — clean (pkg/daemon, pkg/driver, cmd/pilotctl)
- `go test -run 'TestHandleRotateKey|TestRotateKey|TestCmdRotateKey' ./pkg/daemon/ ./pkg/driver/ ./cmd/pilotctl/` — all green

## Tier

Medium (`matthew-fix-larger`): 6 files, 58 insertions / 10 deletions.

Closes [PILOT-230](https://vulturelabs.atlassian.net/browse/PILOT-230)