### PR TITLE
fix: gate managed.policy.set IPC on admin-token validation (PILOT-233)

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -6393,7 +6393,7 @@ func cmdPolicySet(args []string) {
 	d := connectDriver()
 	defer d.Close()
 
-	resp, err := d.PolicySet(netID, policyJSON)
+	resp, err := d.PolicySet(netID, policyJSON, adminToken)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: policy saved to registry but daemon apply failed: %v\n", err)
 		return

--- a/pkg/daemon/ipc.go
+++ b/pkg/daemon/ipc.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -1669,8 +1670,30 @@ func (s *IPCServer) handleManaged(conn *ipcConn, reqID uint64, payload []byte) {
 			}
 			data, _ := json.Marshal(resp)
 			s.ipcWriteManagedOK(conn, reqID, data)
-		case 0x01: // set — reload policy from registry
-			policyJSON := rest[3:]
+		case 0x01: // set — apply policy from registry (admin-token gated)
+			// Wire: [netID(2)][tokenLen(2)][token...][policyJSON...]
+			if len(rest) < 5 {
+				s.sendError(conn, reqID, "managed policy set: missing token length")
+				return
+			}
+			tokenLen := binary.BigEndian.Uint16(rest[3:5])
+			if len(rest) < 5+int(tokenLen) {
+				s.sendError(conn, reqID, "managed policy set: truncated token")
+				return
+			}
+			token := string(rest[5 : 5+tokenLen])
+			policyJSON := rest[5+tokenLen:]
+
+			// Validate admin token if the daemon has one configured.
+			// Without this gate any same-UID process can inject a
+			// policy that disables network gates.
+			if s.daemon.AdminToken() != "" {
+				if subtle.ConstantTimeCompare([]byte(token), []byte(s.daemon.AdminToken())) != 1 {
+					s.sendError(conn, reqID, "managed policy set: invalid admin token")
+					return
+				}
+			}
+
 			if len(policyJSON) == 0 {
 				s.sendError(conn, reqID, "managed policy set: missing policy JSON")
 				return

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -455,13 +455,19 @@ func (d *Driver) PolicyGet(networkID uint16) (map[string]interface{}, error) {
 }
 
 // PolicySet sends a policy document to the daemon for immediate application.
-func (d *Driver) PolicySet(networkID uint16, policyJSON []byte) (map[string]interface{}, error) {
-	msg := make([]byte, 5+len(policyJSON))
+// adminToken is validated by the daemon against its configured AdminToken.
+// Pass "" when the daemon has no admin token configured.
+func (d *Driver) PolicySet(networkID uint16, policyJSON []byte, adminToken string) (map[string]interface{}, error) {
+	// Wire: [cmd][sub][action=0x01][netID(2)][tokenLen(2)][token...][policyJSON...]
+	tokenLen := len(adminToken)
+	msg := make([]byte, 7+tokenLen+len(policyJSON))
 	msg[0] = cmdManaged
 	msg[1] = subManagedPolicy
 	msg[2] = 0x01 // set
 	binary.BigEndian.PutUint16(msg[3:5], networkID)
-	copy(msg[5:], policyJSON)
+	binary.BigEndian.PutUint16(msg[5:7], uint16(tokenLen))
+	copy(msg[7:7+tokenLen], []byte(adminToken))
+	copy(msg[7+tokenLen:], policyJSON)
 	return d.jsonRPC(msg, cmdManagedOK, "policy set")
 }
 

--- a/pkg/driver/zz_driver_test.go
+++ b/pkg/driver/zz_driver_test.go
@@ -704,7 +704,7 @@ func TestManagedFamilyRoundTrips(t *testing.T) {
 	if _, err := drv.PolicyGet(5); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := drv.PolicySet(5, []byte(`{"version":1}`)); err != nil {
+	if _, err := drv.PolicySet(5, []byte(`{"version":1}`), ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := drv.MemberTagsGet(5, 99); err != nil {

--- a/tests/zz_data_exchange_policy_test.go
+++ b/tests/zz_data_exchange_policy_test.go
@@ -104,7 +104,7 @@ func TestDataExchangePolicy(t *testing.T) {
 
 	// Deploy policy to each daemon via driver IPC (starts policy runner, bootstraps peers+tags)
 	for name, d := range map[string]*DaemonInfo{"svc1": svc1, "svc2": svc2, "reg1": reg1, "reg2": reg2} {
-		if _, err := d.Driver.PolicySet(netID, policyJSON); err != nil {
+		if _, err := d.Driver.PolicySet(netID, policyJSON, ""); err != nil {
 			t.Fatalf("policy set %s: %v", name, err)
 		}
 	}

--- a/tests/zz_ipc_ops_test.go
+++ b/tests/zz_ipc_ops_test.go
@@ -395,7 +395,7 @@ func TestPolicySetGetViaIPC(t *testing.T) {
 	}
 
 	// Apply policy to daemon via IPC
-	setResult, err := di.Driver.PolicySet(netID, policyJSON)
+	setResult, err := di.Driver.PolicySet(netID, policyJSON, "")
 	if err != nil {
 		t.Fatalf("PolicySet: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestManagedOpsViaIPCWithPolicyRunner(t *testing.T) {
 
 	// Set policy with cycle/prune rules
 	policyJSON := []byte(`{"version":1,"config":{"cycle":"1h","max_peers":50},"rules":[{"name":"cycle","on":"cycle","match":"true","actions":[{"type":"prune","params":{"count":2,"by":"age"}}]}]}`)
-	_, err = di.Driver.PolicySet(netID, policyJSON)
+	_, err = di.Driver.PolicySet(netID, policyJSON, "")
 	if err != nil {
 		t.Fatalf("PolicySet: %v", err)
 	}


### PR DESCRIPTION
## What failed

`pkg/daemon/ipc.go:1672` (SubManagedPolicy, case 0x01 "set") accepted arbitrary policy JSON from any same-UID process with no admin-token check, allowing a malicious local process to inject a policy that disables network gates.

## Root cause

The `managed.policy.set` IPC handler called `daemon.StartPolicyRunner(netID, policyJSON)` directly with no admin-token validation. Unlike network join/leave (which pass `AdminToken` to the registry for server-side auth), this is a purely local operation with no auth gate.

## Fix

- **Wire format** extended from `[netID(2)][policyJSON...]` to `[netID(2)][tokenLen(2)][token...][policyJSON...]`
- **Daemon handler** validates the token via `subtle.ConstantTimeCompare` against the daemon's configured `AdminToken` (no-op when no token is configured)
- **Driver.PolicySet** signature updated to accept `adminToken string`
- All callers updated (pilotctl, driver tests, integration tests)

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./pkg/driver/` — PASS
- `go test -run TestIPC ./tests/` — PASS
- `go test -run TestDataExchangePolicy ./tests/` — PASS

Closes [PILOT-233](https://vulturelabs.atlassian.net/browse/PILOT-233)