### PR TITLE
fix: warn when PILOT_REGISTRY/PILOT_BEACON env vars override compiled defaults (PILOT-236)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -38,12 +38,16 @@ var version = "dev"
 func main() {
 	configPath := flag.String("config", "", "path to config file (JSON)")
 	registryDefault := "34.71.57.205:9000"
+	registryFromEnv := false
 	if v := os.Getenv("PILOT_REGISTRY"); v != "" {
 		registryDefault = v
+		registryFromEnv = true
 	}
 	beaconDefault := "34.71.57.205:9001"
+	beaconFromEnv := false
 	if v := os.Getenv("PILOT_BEACON"); v != "" {
 		beaconDefault = v
+		beaconFromEnv = true
 	}
 	registryAddr := flag.String("registry", registryDefault, "registry server address (or $PILOT_REGISTRY)")
 	beaconAddr := flag.String("beacon", beaconDefault, "beacon server address (or $PILOT_BEACON)")
@@ -137,6 +141,13 @@ func main() {
 	}
 
 	logging.Setup(*logLevel, *logFormat)
+
+	if registryFromEnv {
+		slog.Warn("PILOT_REGISTRY env var overrides compiled default — registry address redirected to " + *registryAddr + ". If this is unexpected, check the daemon's environment for tampering.")
+	}
+	if beaconFromEnv {
+		slog.Warn("PILOT_BEACON env var overrides compiled default — beacon address redirected to " + *beaconAddr + ". If this is unexpected, check the daemon's environment for tampering.")
+	}
 
 	d := daemon.New(daemon.Config{
 		RegistryAddr:          *registryAddr,


### PR DESCRIPTION
## What failed

`PILOT_REGISTRY` and `PILOT_BEACON` environment variables silently override the compiled default registry (34.71.57.205:9000) and beacon (34.71.57.205:9001) addresses at daemon startup (cmd/daemon/main.go:41-46). No warning, no log entry. An attacker who controls the daemon's environment — via .bashrc, .zshenv, /etc/environment, systemd unit override, or container env block — can redirect the daemon to attacker-controlled rendezvous and beacon, granting trust to an impostor who can impersonate any peer.

## Why this fix

After `logging.Setup`, emit a `slog.Warn` when either env var was used to override the compiled default. This alerts the operator that their daemon is connecting to a non-default registry or beacon address. The warning includes the redirected address and a prompt to check for tampering if unexpected.

Tracked with two booleans (`registryFromEnv`, `beaconFromEnv`) set during env-var reading, consumed after structured logging is online. No behavioral change — the daemon still respects the env var; the only difference is a visible warning.

## Verification

- `go build ./cmd/daemon/` — clean
- `go vet ./cmd/daemon/` — clean
- Integration test suite (`./tests/`) — running

## Diff

```
 cmd/daemon/main.go | 11 +++++++++++
 1 file changed, 11 insertions(+)
```

Closes [PILOT-236](https://vulturelabs.atlassian.net/browse/PILOT-236)