### PR TITLE
fix(install.sh): validate EMAIL against shell/XML injection (PILOT-245)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,6 +185,15 @@ if [ -z "$EMAIL" ] && [ ! -x "$BIN_DIR/pilotctl" ]; then
     fi
 fi
 
+# --- Validate email (prevent shell/XML injection) ---
+
+if [ -n "$EMAIL" ]; then
+    if ! echo "$EMAIL" | grep -qE '^[A-Za-z0-9@._+-]+$'; then
+        echo "  Error: EMAIL contains invalid characters (only A-Z a-z 0-9 @ . _ + - allowed)"
+        exit 1
+    fi
+fi
+
 # --- Detect existing installation ---
 
 UPDATING=false


### PR DESCRIPTION
## What failed

`install.sh` writes `${EMAIL}` unquoted into systemd `ExecStart=` (line 419) and unescaped into macOS plist `<string>` elements (line 493). A malicious email containing shell metacharacters (spaces, semicolons, pipes) or XML metacharacters (`<`, `>`, `&`) can inject additional command-line arguments or break out of the plist structure.

## Why this fix

Validate `EMAIL` against `^[A-Za-z0-9@._+-]+$` after resolution (after the email prompt/read block) and refuse install with a clear error if it contains unsafe characters. The check only runs when `EMAIL` is non-empty.

## Verification

- Manual regex tests: 6 test cases (valid email ✓, space injection ✓, semicolon injection ✓, angle bracket injection ✓, dollar sign injection ✓, path traversal ✓)
- `go build ./...` ✓
- `go vet ./...` ✓
- Scope: 1 file, +9 lines

Closes [PILOT-245](https://vulturelabs.atlassian.net/browse/PILOT-245)