### PR TITLE
fix: add pilotctl quickstart command (PILOT-225)

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -1154,6 +1154,9 @@ func usage() {
 Global flags:
   --json                        Output structured JSON (for agent/programmatic use)
 
+Getting started:
+  pilotctl quickstart             3-command getting-started flow
+
 Bootstrap:
   pilotctl init --registry <addr> [--hostname <name>] [--beacon <addr>]
   pilotctl config [--set key=value]
@@ -1299,6 +1302,10 @@ dispatch:
 
 	case "version":
 		fmt.Println(version)
+		return
+
+	case "quickstart":
+		cmdQuickstart()
 		return
 
 	case "updates":
@@ -1606,6 +1613,33 @@ dispatch:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
 		usage()
 	}
+}
+
+// ===================== QUICKSTART =====================
+
+func cmdQuickstart() {
+	fmt.Print(`
+╔══════════════════════════════════════════════════════════════╗
+║              PILOT PROTOCOL — Quickstart                   ║
+╚══════════════════════════════════════════════════════════════╝
+
+Getting started with Pilot Protocol in 3 commands:
+
+  1. DISCOVER — see who is out there:
+       pilotctl send-message list-agents --data "list all agents"
+
+  2. TRUST   — shake hands with an agent:
+       pilotctl handshake <node_id>
+
+  3. TALK    — send your first message:
+       pilotctl send-message <node_id> --data "Hello, world!"
+
+First-time setup (run once):
+     pilotctl init --registry 34.71.57.205:9000
+     pilotctl daemon start
+
+For the full command list: pilotctl --help
+`)
 }
 
 // ===================== BOOTSTRAP =====================


### PR DESCRIPTION
## What

Adds `pilotctl quickstart` — a 3-command getting-started flow for new Pilot Protocol users.

## Why

`pilotctl --help` lists 60+ commands with no "start here" path. New users (Mira, Nova) had to read SKILL.md to discover the canonical 3-command pattern (list-agents → handshake → send-message).

## Change

- **cmd/pilotctl/main.go** (+34 lines): New `quickstart` subcommand that prints discover → trust → talk flow plus first-time setup instructions.

## Tier

`matthew-fix` — 1 file, 34 LoC.

## Verification

- [x] `go build ./cmd/pilotctl/` — clean
- [x] `go vet ./cmd/pilotctl/` — clean
- [x] `go test ./cmd/pilotctl/` — all tests pass (8.2s)
- [x] Manual output verified

## Ticket

PILOT-225