### PR TITLE
fix(daemon): gate acceptLoop on done channel to close untracked-handleClient race (PILOT-253)

### DIFF
--- a/pkg/daemon/ipc.go
+++ b/pkg/daemon/ipc.go
@@ -445,6 +445,8 @@ type IPCServer struct {
 	daemon     *Daemon
 	mu         sync.Mutex
 	clients    map[*ipcConn]bool
+	closeOnce  sync.Once
+	done       chan struct{}
 }
 
 func NewIPCServer(socketPath string, d *Daemon) *IPCServer {
@@ -452,6 +454,7 @@ func NewIPCServer(socketPath string, d *Daemon) *IPCServer {
 		socketPath: socketPath,
 		daemon:     d,
 		clients:    make(map[*ipcConn]bool),
+		done:       make(chan struct{}),
 	}
 }
 
@@ -483,6 +486,13 @@ func (s *IPCServer) Start() error {
 }
 
 func (s *IPCServer) Close() error {
+	// PILOT-253: Close the done channel BEFORE closing the listener
+	// so that acceptLoop — which may be mid-Accept — sees the signal
+	// and refuses any newly-accepted connection that races past the
+	// listener close. Without this gate, a conn accepted concurrently
+	// with listener.Close() would spawn an untracked handleClient
+	// goroutine that outlives Close().
+	s.closeOnce.Do(func() { close(s.done) })
 	if s.listener != nil {
 		s.listener.Close()
 	}
@@ -517,6 +527,19 @@ func (s *IPCServer) acceptLoop() {
 			continue
 		}
 		s.mu.Lock()
+		// PILOT-253: Reject connections that raced past listener.Close().
+		// Accept may succeed concurrently with Close() closing the
+		// listener — the kernel-level accept dequeues a pending
+		// connection before the close takes effect. Without this check,
+		// the conn spawns an untracked handleClient goroutine that
+		// holds resources past Close().
+		select {
+		case <-s.done:
+			s.mu.Unlock()
+			conn.Close()
+			return
+		default:
+		}
 		full := len(s.clients) >= MaxIPCClients
 		if !full {
 			ic := newIPCConn(conn)


### PR DESCRIPTION
## What
Closes the race between acceptLoop and Close() where a connection accepted concurrently with listener.Close() spawns an untracked handleClient goroutine.

## Root cause
`Close()` calls `listener.Close()` then iterates `s.clients` closing each. But `acceptLoop`'s `Accept()` can succeed *just before* the listener close takes effect at the kernel level. That connection then gets added to `s.clients` and spawns `handleClient` after `Close()` has already iterated — leaving an untracked goroutine holding resources.

## Fix
Added `done chan struct{}` + `closeOnce sync.Once` to IPCServer:
1. `Close()` signals `done` before closing the listener
2. `acceptLoop` checks `s.done` after acquiring `s.mu`, before spawning handleClient — closing the conn and returning if done is signaled

## Verification
- `go build ./...` ✓
- `go vet ./pkg/daemon/` ✓
- `go test -count=1 ./pkg/daemon/` ✓ (all 56s of tests, including all IPCServer close tests)

## Scope
1 file, +23 lines. Small tier (`matthew-fix`).

Fixes: PILOT-253
Triage: matthew-pilot autonomous fix