### PR TITLE
ci: add canary dispatcher for canary-tested PRs (PILOT-162)

### DIFF
--- a/.github/workflows/notify-canary.yml
+++ b/.github/workflows/notify-canary.yml
@@ -1,0 +1,45 @@
+# DISPATCHER TEMPLATE — copy this into each source-component repo
+# (rendezvous, web4, etc.) as .github/workflows/notify-canary.yml.
+#
+# What it does: on push to ANY branch, it tells pilot-canary to rebuild
+# itself with THIS branch for THIS component, plus latest-stable for
+# everything else.
+#
+# Setup steps for each source repo:
+#   1. Drop this file into the repo at .github/workflows/notify-canary.yml
+#   2. Edit `component:` below to match this repo's name in pilot-canary's
+#      resolve step (rendezvous, web4, etc.)
+#   3. Add a repo secret `CANARY_DISPATCH_TOKEN`:
+#        gh secret set CANARY_DISPATCH_TOKEN --repo <this-repo> \
+#          --body "$(security find-generic-password -s github-openclaw-pat -a $USER -w)"
+#      (matthew-pilot's PAT has the `repo` + `workflow` scopes needed)
+#
+# That's it. Every push fires a canary rebuild.
+
+name: Notify canary of changes
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch repository_dispatch to pilot-canary
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_DISPATCH_TOKEN }}
+          # CHANGE THIS to match your component name in pilot-canary's resolve step
+          COMPONENT: web4
+          REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching: component=$COMPONENT  ref=$REF"
+          gh api -X POST /repos/pilot-protocol/pilot-canary/dispatches \
+            -f event_type=component-changed \
+            -f client_payload[component]="$COMPONENT" \
+            -f client_payload[ref]="$REF" \
+            -f client_payload[source_repo]="${{ github.repository }}" \
+            -f client_payload[source_sha]="${{ github.sha }}"

--- a/.github/workflows/notify-canary.yml
+++ b/.github/workflows/notify-canary.yml
@@ -28,7 +28,25 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
+      # The dispatch step requires CANARY_DISPATCH_TOKEN to be set as a
+      # repo secret (see header). Until an operator runs the `gh secret set`,
+      # treat "secret absent" as a skip, not a failure — this workflow runs
+      # on every PR and push, so a hard fail here would gate the entire
+      # check rollup on a credential that's intentionally not committed.
+      - name: Check token presence
+        id: token_check
+        env:
+          TOKEN: ${{ secrets.CANARY_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${TOKEN}" ]; then
+            echo "::notice::CANARY_DISPATCH_TOKEN not set in repo secrets — skipping canary dispatch"
+            echo "have_token=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Dispatch repository_dispatch to pilot-canary
+        if: steps.token_check.outputs.have_token == 'true'
         env:
           GH_TOKEN: ${{ secrets.CANARY_DISPATCH_TOKEN }}
           # CHANGE THIS to match your component name in pilot-canary's resolve step


### PR DESCRIPTION
## PILOT-162 — Wire canary CI from web4

Copies the dispatcher template from `pilot-protocol/pilot-canary/.github/templates/dispatcher.yml`.

### What it does
On every push/PR to any branch, dispatches a `repository_dispatch` event to `pilot-protocol/pilot-canary` with:
- `event_type: component-changed`
- `component: web4`
- `ref: <branch-name>`

The canary build resolves web4 to this branch, using latest-stable for other components (rendezvous, updater, common).

### Setup required
Add `CANARY_DISPATCH_TOKEN` secret to this repo (use matthew-pilot's PAT with `repo` + `workflow` scopes).