### PR TITLE
fix: log warning when tunnel encryption is disabled (PILOT-256)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -679,6 +679,8 @@ func (d *Daemon) Start() error {
 		if err := d.tunnels.EnableEncryption(); err != nil {
 			return fmt.Errorf("tunnel encryption: %w", err)
 		}
+	} else {
+		slog.Warn("tunnel encryption is disabled — all connections will send plaintext")
 	}
 
 	// 2b. Wire the event bus into the tunnel layer BEFORE starting the


### PR DESCRIPTION
## What

When `config.Encrypt` is false, the daemon silently runs without tunnel encryption — every connection sends plaintext with zero indication. A misconfigured or tampered `config.json` with `"encrypt": false` produces no log warning.

## Fix

Add `slog.Warn` when encryption is disabled so operators can immediately spot the issue at startup:

```go
if d.config.Encrypt {
    if err := d.tunnels.EnableEncryption(); err != nil {
        return fmt.Errorf("tunnel encryption: %w", err)
    }
} else {
    slog.Warn("tunnel encryption is disabled — all connections will send plaintext")
}
```

## Verification

- `go build ./...` ✅
- `go vet ./pkg/daemon/` ✅
- `go test -short -count=1 ./pkg/daemon/` ✅ (20.9s, all pass)
- 1 file changed (`pkg/daemon/daemon.go`), +3 lines

## Ticket

🔗 https://vulturelabs.atlassian.net/browse/PILOT-256