### PR TITLE
fix(ci): drop extracted pkg/registry + pkg/secure from arch-gates

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -27,7 +27,11 @@ jobs:
       # and the no_<plugin> build tags they exercised left with them.
 
       - name: Lock-graph race detection (sec 4.8)
-        run: go test -race -timeout 5m ./pkg/daemon ./pkg/registry/... ./pkg/secure
+        # pkg/registry/ and pkg/secure/ extracted to pilot-protocol/{rendezvous,common}
+        # in PR #155; lock-graph coverage for those layers now runs from
+        # their own repos. pkg/daemon stays — that's where the daemon-side
+        # lock graph (Store.mu, ReplayMu, SalvageMu, tm.mu, …) actually lives.
+        run: go test -race -timeout 5m ./pkg/daemon/...
 
       - name: Lock-graph stress harness (sec 4.8) — TestConcurrentDialEncryptDecrypt
         # 1000 goroutines × 30 s × 3 reps = ~90 s wall time. Race-clean,


### PR DESCRIPTION
## Summary
- Architecture-gates workflow has been failing on every PR since #155 merged (the extraction refactor)
- The workflow runs \`go test ./pkg/daemon ./pkg/registry/... ./pkg/secure\` but \`pkg/registry/\` and \`pkg/secure/\` no longer exist on \`main\` — they were extracted to \`pilot-protocol/rendezvous\` and \`pilot-protocol/common\`
- Drop the missing paths; keep \`./pkg/daemon/...\` which is the actual lock-graph surface for the daemon

## Failure pattern this fixes
\`\`\`
go test -race -timeout 5m ./pkg/daemon ./pkg/registry/... ./pkg/secure
# ./pkg/registry/...
FAIL ./pkg/registry/... [setup failed]
pattern ./pkg/registry/...: lstat ./pkg/registry/: no such file or directory
# ./pkg/secure
FAIL ./pkg/secure [setup failed]
\`\`\`

Currently failing this check on \`main\`: PRs #177, #178, #179, #180.

## Test plan
- [x] \`go test -race -timeout 5m ./pkg/daemon/...\` runs locally without the missing-directory errors
- [ ] PR's own arch-gates run goes green