### PR TITLE
fix(ci): release build only ships daemon/pilotctl/updater + drop dead harness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME}
           LDFLAGS="-s -w -X main.version=${VERSION}"
-          BINS="daemon pilotctl gateway registry beacon rendezvous nameserver updater"
+          BINS="daemon pilotctl updater"
           mkdir -p dist
           for bin in $BINS; do
             echo "Building $bin for ${{ matrix.goos }}/${{ matrix.goarch }}..."
@@ -114,13 +114,6 @@ jobs:
           done
 
           echo ""
-          echo "=== Registry start/stop test ==="
-          dist/registry -addr 127.0.0.1:0 &
-          REG_PID=$!
-          sleep 1
-          kill $REG_PID 2>/dev/null && echo "  ✓ registry starts and stops cleanly"
-
-          echo ""
           echo "=== Daemon help test ==="
           dist/daemon -h 2>&1 | head -5
           echo "  ✓ daemon shows help"
@@ -142,73 +135,9 @@ jobs:
           name: pilot-${{ matrix.goos }}-${{ matrix.goarch }}
           path: ${{ env.ARCHIVE }}
 
-  harness:
-    name: Integration harness
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download linux/amd64 binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: pilot-linux-amd64
-
-      - name: Extract binaries
-        run: |
-          mkdir -p bin
-          tar -xzf pilot-linux-amd64.tar.gz -C bin
-          chmod +x bin/*
-
-      - name: End-to-end harness
-        run: |
-          set -e
-          echo "=== Starting registry ==="
-          bin/registry -addr 127.0.0.1:19000 -log-level error &
-          REG_PID=$!
-          sleep 1
-
-          echo "=== Starting beacon ==="
-          bin/beacon -registry-addr 127.0.0.1:19000 -listen :19001 -log-level error &
-          BEACON_PID=$!
-          sleep 1
-
-          echo "=== Starting daemon A ==="
-          PILOT_HOME=$(mktemp -d)
-          bin/daemon -registry 127.0.0.1:19000 -beacon 127.0.0.1:19001 \
-            -hostname harness-a -home "$PILOT_HOME/a" -log-level error &
-          DA_PID=$!
-          sleep 2
-
-          echo "=== Starting daemon B ==="
-          bin/daemon -registry 127.0.0.1:19000 -beacon 127.0.0.1:19001 \
-            -hostname harness-b -home "$PILOT_HOME/b" -log-level error &
-          DB_PID=$!
-          sleep 2
-
-          echo "=== Verify nodes registered ==="
-          # pilotctl info via daemon A
-          PILOT_SOCK="$PILOT_HOME/a/pilot.sock" bin/pilotctl info --json 2>&1 | head -20
-          echo "  ✓ daemon A responds to info"
-
-          PILOT_SOCK="$PILOT_HOME/b/pilot.sock" bin/pilotctl info --json 2>&1 | head -20
-          echo "  ✓ daemon B responds to info"
-
-          echo "=== Health check ==="
-          PILOT_SOCK="$PILOT_HOME/a/pilot.sock" bin/pilotctl health --json 2>&1 | head -20
-          echo "  ✓ daemon A health OK"
-
-          echo "=== Teardown ==="
-          kill $DA_PID $DB_PID $BEACON_PID $REG_PID 2>/dev/null || true
-          wait $DA_PID $DB_PID $BEACON_PID $REG_PID 2>/dev/null || true
-          rm -rf "$PILOT_HOME"
-          echo "  ✓ all processes stopped cleanly"
-          echo ""
-          echo "=== HARNESS PASSED ==="
-
   release:
     name: Create release
-    needs: harness
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Same rot as #185: build step still lists extracted-to-sibling cmd dirs (gateway/registry/beacon/rendezvous/nameserver) in BINS. `stat: cmd/gateway: directory not found` aborts the build stage. Also drops the harness job that drives bin/registry + bin/beacon.

Tests confirmed green on PR #185's workflow. This is the next layer of cleanup before v1.10.6 release pipeline completes end-to-end.