### PR TITLE
fix(install): validate REGISTRY/BEACON against JSON injection (PILOT-270)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,15 @@ set -e
 REPO="TeoSlayer/pilotprotocol"
 REGISTRY="${PILOT_REGISTRY:-34.71.57.205:9000}"
 BEACON="${PILOT_BEACON:-34.71.57.205:9001}"
+# PILOT-270: validate REGISTRY/BEACON to prevent JSON injection into config.json
+if ! echo "$REGISTRY" | grep -qE '^[a-zA-Z0-9.:_-]+$'; then
+    echo "Error: REGISTRY contains invalid characters (only a-z A-Z 0-9 . : _ - allowed)"
+    exit 1
+fi
+if ! echo "$BEACON" | grep -qE '^[a-zA-Z0-9.:_-]+$'; then
+    echo "Error: BEACON contains invalid characters (only a-z A-Z 0-9 . : _ - allowed)"
+    exit 1
+fi
 PILOT_DIR="$HOME/.pilot"
 BIN_DIR="$PILOT_DIR/bin"
 


### PR DESCRIPTION
## What

`install.sh` interpolates `REGISTRY` and `BEACON` env vars directly into `config.json` without validation. A crafted value containing JSON metacharacters (`", `, `{`, `}`) can inject arbitrary keys — e.g. disabling encryption with `","encrypt":false,"x":"y`.

## Root Cause

Lines 60-61 assign from `$PILOT_REGISTRY` / `$PILOT_BEACON` (defaulting to prod addresses), then lines 370-379 write them verbatim into the JSON config template. No input validation guards the interpolation.

`EMAIL` already has a regex guard at line 190-192 (`^[A-Za-z0-9@._+-]+$`). `REGISTRY` and `BEACON` did not.

## Fix

Add the same regex validation pattern (`^[a-zA-Z0-9.:_-]+$`) for both `REGISTRY` and `BEACON` immediately after their assignment. The script exits with a clear error on invalid input before any config is written.

## Verification

- `go build ./...` — ✅ clean
- `go vet ./...` — ✅ clean
- Manual test: valid values (IP:port, hostnames) pass; injection payloads (`"encrypt":false`) get rejected

Closes [PILOT-270](https://vulturelabs.atlassian.net/browse/PILOT-270)