### PR TITLE
fix: add -n to ln -sf in install.sh to prevent symlink TOCTOU (PILOT-271)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -340,10 +340,10 @@ chmod 755 "$BIN_DIR/pilot-daemon" "$BIN_DIR/pilotctl" "$BIN_DIR/pilot-gateway"
 
 LINK_DIR="/usr/local/bin"
 if [ -d "$LINK_DIR" ] && [ -w "$LINK_DIR" ]; then
-    ln -sf "$BIN_DIR/pilot-daemon" "$LINK_DIR/pilot-daemon"
-    ln -sf "$BIN_DIR/pilotctl" "$LINK_DIR/pilotctl"
-    ln -sf "$BIN_DIR/pilot-gateway" "$LINK_DIR/pilot-gateway"
-    [ -f "$BIN_DIR/pilot-updater" ] && ln -sf "$BIN_DIR/pilot-updater" "$LINK_DIR/pilot-updater"
+    ln -sfn "$BIN_DIR/pilot-daemon" "$LINK_DIR/pilot-daemon"
+    ln -sfn "$BIN_DIR/pilotctl" "$LINK_DIR/pilotctl"
+    ln -sfn "$BIN_DIR/pilot-gateway" "$LINK_DIR/pilot-gateway"
+    [ -f "$BIN_DIR/pilot-updater" ] && ln -sfn "$BIN_DIR/pilot-updater" "$LINK_DIR/pilot-updater"
     echo "  Symlinked to ${LINK_DIR}"
 fi
 


### PR DESCRIPTION
## What

Adds `-n` (--no-dereference) flag to all `ln -sf` calls in the install.sh symlink section.

## Why

The writable-check then `ln -sf` in install.sh:342-349 is non-atomic (TOCTOU). Without `-n`, if an attacker races between the check and the `ln` call to replace a destination path with a symlink to a directory, `ln` would follow it and create the link inside that directory instead of at the intended location.

`ln -sfn` treats the destination as a non-directory, preventing symlink dereference.

## Change

- **1 file, +4/-4** — added `n` to each `ln -sf` → `ln -sfn`

## Verification

- `bash -n install.sh` — syntax OK
- `go build ./...` — green
- `go vet ./...` — green

Fixes: PILOT-271