### PR TITLE
fix: add --no-same-owner --no-same-permissions to tar extraction (PILOT-272)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -266,11 +266,18 @@ if [ -n "$TAG" ]; then
                 [ -n "$ACTUAL" ] && echo "  Verified SHA-256"
             fi
         fi
+        # GNU tar preserves ownership and permissions from the archive by
+        # default (including setuid/setgid bits). BSD tar ignores ownership
+        # without root, so these flags are only needed on GNU tar.
+        TAR_SAFE=""
+        if tar --version 2>/dev/null | grep -q 'GNU tar'; then
+            TAR_SAFE="--no-same-owner --no-same-permissions"
+        fi
         # macOS bsdtar can fail silently on GitHub gzip archives.
         # Try tar -xzf first; fall back to gunzip|tar on failure.
-        if ! tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" 2>/dev/null || [ ! -f "$TMPDIR/pilotctl" ]; then
+        if ! tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" $TAR_SAFE 2>/dev/null || [ ! -f "$TMPDIR/pilotctl" ]; then
             echo "  tar -xzf failed or produced no output; trying gunzip fallback..."
-            gunzip -c "$TMPDIR/$ARCHIVE" | tar -x -C "$TMPDIR"
+            gunzip -c "$TMPDIR/$ARCHIVE" | tar -x $TAR_SAFE -C "$TMPDIR"
         fi
         if [ ! -f "$TMPDIR/pilotctl" ]; then
             echo "Error: failed to extract binaries from ${ARCHIVE}"


### PR DESCRIPTION
## What

Add `--no-same-owner --no-same-permissions` flags to `tar -xzf` and the fallback `gunzip | tar -x` extraction in `install.sh`.

## Why

GNU tar preserves file ownership and permissions from the archive by default, including setuid/setgid bits. A compromised GitHub release with matching SHA-256 checksums could deliver setuid binaries via the tarball (defense-in-depth — the checksums attestation gate must also be bypassed, but layered defenses are appropriate for an installer).

BSD/macOS tar already defaults to safe behavior (ignores ownership without root), so the flags are only set when GNU tar is detected at runtime.

## Changes

- `install.sh`: +9/-2 lines
  - Detect GNU tar via `tar --version | grep 'GNU tar'`
  - Set `TAR_SAFE="--no-same-owner --no-same-permissions"` when GNU tar detected
  - Pass `$TAR_SAFE` to both tar invocations (primary and fallback)

## Verification

- Shell syntax check passes (`sh -n install.sh`)
- GNU tar detection logic tested in-container
- Flags verified accepted by GNU tar (`tar -xzf ... --no-same-owner --no-same-permissions -C ...`)

## Tier

**small** — 1 file, +9/-2 LoC

---
🤖 matthew-pilot | PILOT-272