### PR TITLE
fix(install): refuse uninstall when PILOT_DIR is a symlink (PILOT-273)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,6 +118,10 @@ if [ "${1}" = "uninstall" ]; then
     fi
 
     # Remove pilot directory (binaries, config, identity, received files)
+    if [ -h "$PILOT_DIR" ]; then
+        echo "  Refusing to uninstall: $PILOT_DIR is a symlink"
+        exit 1
+    fi
     if [ -d "$PILOT_DIR" ]; then
         rm -rf "$PILOT_DIR"
         echo "  Removed $PILOT_DIR"


### PR DESCRIPTION
## What failed

`install.sh` uninstall path (line 122) removes `$PILOT_DIR` via `rm -rf`, which follows symlinks. If `~/.pilot` was swapped to a symlink by a concurrent attacker, `rm -rf` follows it and clobbers the target directory — not the symlink itself.

## Why this fix

Added a `-h` (symlink) test before the `-d` (directory) test. If `PILOT_DIR` is a symlink, the uninstall aborts with an error message and exit code 1 instead of following the link.

**Change:** 1 file, +4 lines

```diff
     # Remove pilot directory (binaries, config, identity, received files)
+    if [ -h "$PILOT_DIR" ]; then
+        echo "  Refusing to uninstall: $PILOT_DIR is a symlink"
+        exit 1
+    fi
     if [ -d "$PILOT_DIR" ]; then
         rm -rf "$PILOT_DIR"
         echo "  Removed $PILOT_DIR"
     fi
```

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- Test package compilation ✓ (install.sh is bash — no Go test surface)

Combined with the `ln -sfn` fix from PILOT-271 (PR #190), this closes a second symlink footgun in the install/uninstall paths.

Closes [PILOT-273](https://vulturelabs.atlassian.net/browse/PILOT-273)