### PR TITLE
fix(pilotctl): atomic symlink replacement to close TOCTOU race on pilot.log (PILOT-291)

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -2352,9 +2352,14 @@ func cmdDaemonStart(args []string) {
 	logFile.Close()
 	os.Rename(tmpLogPath, pidLogPath)
 	// Update pilot.log symlink to point at the current PID's log.
+	// Atomically replace via temp file to avoid TOCTOU race (the
+	// gap between Remove and Symlink is exploitable by a local
+	// attacker with write access to the config directory).
 	symPath := logFilePath()
-	os.Remove(symPath)
-	os.Symlink(pidLogPath, symPath)
+	tmpSymPath := symPath + ".tmp"
+	os.Remove(tmpSymPath) // clean stale temp from prior crash
+	os.Symlink(pidLogPath, tmpSymPath)
+	os.Rename(tmpSymPath, symPath)
 
 	if !jsonOutput {
 		fmt.Fprintf(os.Stderr, "starting daemon (pid %d, socket %s)...", pid, socketPath)


### PR DESCRIPTION
## What
Fixes a TOCTOU race in the daemon start path where `pilot.log` symlink was updated with a non-atomic `os.Remove` → `os.Symlink` sequence.

## Root Cause
`cmd/pilotctl/main.go:2355-2357` — The gap between `os.Remove(symPath)` and `os.Symlink(pidLogPath, symPath)` is a window where a local attacker with write access to `~/.pilot/` could swap the symlink target.

## Fix
Replace with the standard atomic symlink pattern: create symlink at a `.tmp` path first, then `os.Rename` over the canonical path. `os.Rename` is atomic on the same filesystem on Linux.

## Verification
- `go build ./cmd/pilotctl/...` ✅
- `go vet ./cmd/pilotctl/...` ✅
- `go test -count=1 -timeout 120s ./cmd/pilotctl/...` ✅ (all pass)

## Scope
- **1 file**, +7/−2 lines (`cmd/pilotctl/main.go`)
- Tier: small

Closes [PILOT-291](https://vulturelabs.atlassian.net/browse/PILOT-291)