### PR TITLE
fix(tests): generate random TestAdminToken per run instead of hardcoded secret (PILOT-296)

### DIFF
--- a/tests/testenv.go
+++ b/tests/testenv.go
@@ -4,7 +4,9 @@ package tests
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
@@ -50,7 +52,17 @@ func resolveLocalAddr(addr net.Addr) string {
 }
 
 // TestAdminToken is the admin token used in tests for network creation.
-const TestAdminToken = "test-admin-secret"
+// Generated randomly at init time so that a test environment accidentally
+// deployed against staging/production won't share a predictable secret.
+var TestAdminToken string
+
+func init() {
+	b := make([]byte, 32)
+	if _, err := crand.Read(b); err != nil {
+		panic("failed to generate random admin token: " + err.Error())
+	}
+	TestAdminToken = "sk-test-" + hex.EncodeToString(b)
+}
 
 // TestEnv manages a complete Pilot Protocol test environment with
 // OS-assigned ports and proper readiness signaling (no time.Sleep).


### PR DESCRIPTION
## What

Replaces the hardcoded `const TestAdminToken = "test-admin-secret"` in `tests/testenv.go` with a `var` initialized via `crypto/rand` at package init time. The token is prefixed with `sk-test-` so the redaction-test regex catches any leaked instance in log captures.

## Why

The constant was used across 27 test files. If a test environment accidentally leaked into staging or production (CI runner mis-tagged, devcontainer copied into prod), the predictable token would be an instant compromise.

## Verification

- `go build ./tests/` — clean
- `go vet ./tests/` — clean
- `go test -run 'TestAdminToken' ./tests/ ./pkg/daemon/` — pass
- `go test -run 'TestAdminToken|TestProvision|TestCreateNetwork|TestAuditExport' ./tests/` — pass (18.9s)

## Scope

- 1 file: `tests/testenv.go`
- +13/−1 lines

Closes [PILOT-296](https://vulturelabs.atlassian.net/browse/PILOT-296)