### PR TITLE
docs(tests): add banner warning that Public:true is test-only (PILOT-297)

### DIFF
--- a/tests/testenv.go
+++ b/tests/testenv.go
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+// IMPORTANT — Do not copy-paste daemon.Config values from this file into
+// production code without review. In particular, AddDaemon and AddDaemonOnly
+// both set Public: true so that test daemons can freely exchange messages
+// without the handshake trust gate. Real deployments should use Public: false
+// to enforce peer authentication. See pkg/daemon/services.go:166-170 for the
+// trust-gate logic.
+
 package tests
 
 import (


### PR DESCRIPTION
## What failed

`tests/testenv.go` sets `Public: true` on daemon configs in `AddDaemon` and `AddDaemonOnly` helpers. This is correct for tests (free connectivity between local daemons), but anyone reading `testenv.go` as example code gets that as the implied default. The `Public` field enables/disables the handshake trust gate in `pkg/daemon/services.go:166-170`.

## Why this fix

Add a banner comment at the top of the file (after the SPDX header, before `package tests`) warning readers not to copy-paste daemon config values without review. Explicitly calls out `Public: true` → `Public: false` for real deployments, with a reference to the trust-gate logic.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- Comment-only change; no behavioral impact

## Scope

`tests/testenv.go` — 7 lines added (comment)

Closes [PILOT-297](https://vulturelabs.atlassian.net/browse/PILOT-297)