### PR TITLE
fix: warn when compat-mode silently flips registry-trust to system (PILOT-312)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -137,6 +137,7 @@ func main() {
 		if !explicit["registry-trust"] {
 			v := "system"
 			registryTrust = &v
+			slog.Warn("compat-mode registry-trust defaulted to 'system' (Let's Encrypt validation). Override with -registry-trust=pinned if using pinned certificates (supply -registry-fingerprint).")
 		}
 	}
 


### PR DESCRIPTION
## What

When `-transport=compat` is selected without an explicit `-registry-trust` flag, the daemon silently flips the trust store from `pinned` (the compiled default) to `system` (Let's Encrypt). Operators selecting compat for single-port operation may not realize they are now trusting every CA in the OS root store.

## Fix

Add a `slog.Warn` at `cmd/daemon/main.go:139` matching the existing pattern for `PILOT_REGISTRY` and `PILOT_BEACON` env-var override warnings. The warning fires once at daemon startup when the silent flip occurs.

## Scope

- **1 file**, **+1 line** — `matthew-fix` (small)
- No behavioral change; observation-only.

## Test

```
go build ./cmd/daemon/    # green
go vet ./cmd/daemon/       # green
```

## Ticket

🔗 [PILOT-312](https://vulturelabs.atlassian.net/browse/PILOT-312)