### PR TITLE
fix: add 5s timeout to bgWG.Wait() in doStop() (PILOT-318)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1312,7 +1312,19 @@ func (d *Daemon) Stop() error {
 func (d *Daemon) doStop() {
 	// Wait for all daemon-scoped background goroutines to notice
 	// stopCh and exit before tearing down shared infrastructure.
-	d.bgWG.Wait()
+	// Use a 5-second timeout to prevent a hung goroutine (e.g.
+	// blocked on registry I/O during an outage) from blocking
+	// shutdown forever. Leaked goroutines are the lesser evil.
+	done := make(chan struct{})
+	go func() {
+		d.bgWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		slog.Warn("timed out waiting for background goroutines to exit", "leaked", true)
+	}
 
 	// v1.9.1: emit a shutdown signal BEFORE any teardown so operators
 	// can distinguish planned drain from crash. Auto-scalers and


### PR DESCRIPTION
## Summary
- **Ticket:** [PILOT-318](https://vulturelabs.atlassian.net/browse/PILOT-318) — daemon.Stop: bgWG.Wait() has no timeout
- **Branch:** `openclaw/pilot-318-20260531-004305`
- **Scope:** 1 file, +13/−1 (small)

## Problem
`doStop()` calls `bgWG.Wait()` with no timeout. If any background goroutine is blocked (e.g. registry I/O during an outage), shutdown hangs forever and the process exits only when systemd/launchd SIGKILLs it.

## Fix
Wrap `bgWG.Wait()` with a 5-second timeout using a goroutine + select. If the wait times out, log a warning and proceed with teardown — leaked goroutines are the lesser evil compared to a hung shutdown.

## Verification
- `go build ./...` — ✅ clean
- `go vet ./pkg/daemon/` — ✅ clean
- `go test -count=1 -timeout 120s ./pkg/daemon/` — ✅ all pass (59.5s)

## Checklist
- [x] Build passes
- [x] Tests pass
- [x] Single-file, small-scope change
- [ ] Canary (triggered separately)
- [ ] Human review before merge

---
🔗 **Jira:** https://vulturelabs.atlassian.net/browse/PILOT-318
🤖 **Agent:** matthew-pilot (deep)