### PR TITLE
fix(daemon): flush identity to disk on shutdown (PILOT-321)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1420,6 +1420,18 @@ func (d *Daemon) doStop() {
 	// so the daemon.shutting_down event published above flows through
 	// the bus to the still-subscribed plugin, which drains its
 	// internal queue on Stop().
+
+	// Defense-in-depth: flush identity to disk on shutdown.
+	// Today all identity mutations persist eagerly (GenerateIdentity
+	// in startNetworked and RotateKey save synchronously), but a
+	// future code path that mutates d.identity in-memory without a
+	// write would lose the change on next start. Writing here ensures
+	// identity on disk always reflects the shutdown state.
+	if d.config.IdentityPath != "" {
+		if err := crypto.SaveIdentity(d.config.IdentityPath, d.identity); err != nil {
+			slog.Warn("identity flush on shutdown failed", "error", err)
+		}
+	}
 }
 
 // startManaged detects managed networks this node belongs to and starts engines.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1427,9 +1427,22 @@ func (d *Daemon) doStop() {
 	// future code path that mutates d.identity in-memory without a
 	// write would lose the change on next start. Writing here ensures
 	// identity on disk always reflects the shutdown state.
+	//
+	// d.identity can be nil here — many short-lived test daemons
+	// (and any daemon that stops before startNetworked has loaded /
+	// generated an identity) reach doStop without ever populating it.
+	// SaveIdentity dereferences the second arg unconditionally, so
+	// passing nil panics with SIGSEGV (see TestL7RetxLoopPanicSurvival).
+	// Read under identityMu so a concurrent RotateKey on the shutdown
+	// path can't tear the pointer load either.
 	if d.config.IdentityPath != "" {
-		if err := crypto.SaveIdentity(d.config.IdentityPath, d.identity); err != nil {
-			slog.Warn("identity flush on shutdown failed", "error", err)
+		d.identityMu.RLock()
+		id := d.identity
+		d.identityMu.RUnlock()
+		if id != nil {
+			if err := crypto.SaveIdentity(d.config.IdentityPath, id); err != nil {
+				slog.Warn("identity flush on shutdown failed", "error", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What failed

`doStop()` tears down IPC, tunnels, managed engines, and the network subscriber, but never calls `SaveIdentity`. Today every identity mutation (GenerateIdentity in startNetworked, RotateKey) persists eagerly, so this is a no-op on current code paths. The risk is forward-looking: a future code path that mutates `d.identity` in-memory without writing would lose the change on next start with zero diagnostic.

## Why this fix

Add a defense-in-depth `SaveIdentity` call as the final step of `doStop()` so the on-disk identity always reflects shutdown state. Mirrors the existing pattern in `startNetworked` (:525-531) and `RotateKey` (:2073-2077): guard on `IdentityPath != \"\"` and log a warning on failure.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- Full integration test suite running via canary harness

## Scope

1 file, +12 LoC (`pkg/daemon/daemon.go`)

Closes [PILOT-321](https://vulturelabs.atlassian.net/browse/PILOT-321)