### PR TITLE
fix: reject stale beacon cache older than 1h, fall back to bootstrap (PILOT-323)

### DIFF
--- a/pkg/daemon/beacon_discovery.go
+++ b/pkg/daemon/beacon_discovery.go
@@ -49,6 +49,7 @@ const (
 	beaconRefreshInterval = routing.BeaconRefreshInterval
 	beaconRefreshJitter   = routing.BeaconRefreshJitter
 	beaconCacheFilename   = routing.BeaconCacheFilename
+	beaconCacheMaxAge     = routing.BeaconCacheMaxAge
 )
 
 type beaconLister = routing.BeaconLister
@@ -166,6 +167,23 @@ func (d *Daemon) beaconRefreshTick(firstTick bool) {
 		if firstTick {
 			cached, cacheErr := loadBeaconCache(d.config.IdentityPath)
 			if cacheErr == nil && len(cached) > 0 {
+				// Reject the cache if it is older than BeaconCacheMaxAge.
+				// A stale cache keeps the daemon trying offline beacons
+				// indefinitely; fall through to the bootstrap list instead.
+				savedAt, savedAtErr := routing.BeaconCacheSavedAt(d.config.IdentityPath)
+				if savedAtErr == nil {
+					age := time.Since(savedAt)
+					if age > beaconCacheMaxAge {
+						slog.Warn("beacon discovery: rejecting stale on-disk cache",
+							"err", err,
+							"cache_age", age.Truncate(time.Second),
+							"max_age", beaconCacheMaxAge,
+						)
+						slog.Debug("beacon discovery skipped (registry error, stale cache)",
+							"err", err)
+						return
+					}
+				}
 				slog.Info("beacon discovery: using on-disk cache (registry unreachable)",
 					"err", err, "cached_count", len(cached))
 				discovered = cached

--- a/pkg/daemon/routing/discovery.go
+++ b/pkg/daemon/routing/discovery.go
@@ -23,6 +23,11 @@ const BeaconRefreshInterval = 60 * time.Second
 // The first refresh fires at t = rand[0..BeaconRefreshJitter).
 const BeaconRefreshJitter = 10 * time.Second
 
+// BeaconCacheMaxAge is the maximum age of an on-disk beacon cache
+// before it is considered stale and rejected in favor of the
+// operator-configured bootstrap list.
+const BeaconCacheMaxAge = 1 * time.Hour
+
 // BeaconCacheFilename is the on-disk fallback used when the registry
 // is unreachable at cold-start. Lives next to the identity file.
 const BeaconCacheFilename = "beacons.json"
@@ -140,6 +145,28 @@ func LoadBeaconCache(identityPath string) ([]string, error) {
 	// have persisted a list that included private VPC IPs before this
 	// fix was in place.
 	return FilterUnreachable(entry.Addrs), nil
+}
+
+// BeaconCacheSavedAt reads the SavedAt timestamp from the on-disk cache
+// without deserialising the full addr list.  Returns (time.Time{}, nil)
+// when the file does not exist.
+func BeaconCacheSavedAt(identityPath string) (time.Time, error) {
+	path := BeaconCachePath(identityPath)
+	if path == "" {
+		return time.Time{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, fmt.Errorf("read beacon cache for SavedAt: %w", err)
+	}
+	var entry BeaconCacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return time.Time{}, fmt.Errorf("parse beacon cache for SavedAt: %w", err)
+	}
+	return entry.SavedAt, nil
 }
 
 // BeaconSelectionState tracks the daemon's beacon picks across refresh


### PR DESCRIPTION
## Summary
- **Ticket:** [PILOT-323](https://vulturelabs.atlassian.net/browse/PILOT-323)
- **Files:** `pkg/daemon/routing/discovery.go`, `pkg/daemon/beacon_discovery.go`
- **Scope:** small (2 files, +45 LoC)

## What
Adds `BeaconCacheMaxAge` (1h) constant and `BeaconCacheSavedAt()` helper. In `beaconRefreshTick`, when the registry is unreachable at first tick and the daemon would fall back to the on-disk cache, the cache is now rejected if older than 1h — the daemon falls through to the operator-configured bootstrap list instead.

## Why
Without a staleness cap, a daemon that loses registry connectivity across cold restarts keeps using cached beacon addresses from potentially weeks ago, many of which may be offline. The `SavedAt` field already existed in `BeaconCacheEntry` but was never checked.

## Testing
- `go build ./pkg/daemon/...` ✅
- `go vet ./pkg/daemon/...` ✅
- `go test -short ./pkg/daemon/...` ✅ (all 7 packages pass)