### PR TITLE
fix(daemon): per-peer in-flight dedup for handshake IPC to prevent dial-pool saturation

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -248,6 +248,19 @@ type Daemon struct {
 	ipc            *IPCServer
 	handshakes     HandshakeService
 
+	// handshakeInFlight tracks peers with an outbound trust-handshake
+	// currently in progress on this daemon. Per-peer keyed
+	// (nodeID → struct{}). Inserted on entry to HandshakeSendRequest,
+	// removed on return. Concurrent callers for the same peer observe
+	// the existing entry and short-circuit with ErrHandshakeInFlight so
+	// they do not race a second DialConnection on port 444 — which under
+	// a burst (e.g. parallel `pilotctl handshake` commands) was capable
+	// of saturating the ephemeral-port bitmap for a few seconds before
+	// the SYN_SENT reaper recovered the pool. Per-peer dedup keeps
+	// concurrent intent to the same target collapsed to one in-flight
+	// dial regardless of caller count.
+	handshakeInFlight sync.Map
+
 	// network.* bus subscriber for daemon-internal reactions (managed
 	// engines + member-tag cache). Wired by subscribeNetworkInternalToBus
 	// during Start; torn down before tunnels in doStop. (T4.3.)
@@ -1800,10 +1813,36 @@ func (d *Daemon) HandshakeRevokeTrust(nodeID uint32) error {
 	return d.handshakes.RevokeTrust(nodeID)
 }
 
+// ErrHandshakeInFlight is returned by HandshakeSendRequest when another
+// outbound handshake to the same peer is currently in progress on this
+// daemon. Callers can treat this as a soft success: the existing in-flight
+// call will produce a trust outcome shortly. Surfaced through the IPC
+// SubHandshakeSend handler as a distinct "in_flight" reply status so
+// pilotctl users get a clean signal rather than a generic error.
+var ErrHandshakeInFlight = errors.New("handshake already in flight to this peer")
+
+// HandshakeSendRequest issues an outbound trust handshake to peerNodeID
+// via the registered handshake plugin, deduped per-peer.
+//
+// Concurrent callers for the same peer (e.g. a burst of `pilotctl
+// handshake <agent>` commands) coalesce: the first call records its
+// intent in d.handshakeInFlight and proceeds; any subsequent caller that
+// observes the entry returns immediately with ErrHandshakeInFlight
+// without firing a second DialConnection. The first call's deferred
+// delete frees the slot when the underlying SendRequest returns.
+//
+// This collapses the dial-side fanout: N callers → 1 DialConnection → 1
+// ephemeral port held during the dial budget, rather than N callers → N
+// dials → N ports. Eliminates the port-pool saturation footprint that
+// otherwise appeared in the daemon log under parallel handshake bursts.
 func (d *Daemon) HandshakeSendRequest(nodeID uint32, reason string) error {
 	if d.handshakes == nil {
 		return fmt.Errorf("handshake service not registered")
 	}
+	if _, loaded := d.handshakeInFlight.LoadOrStore(nodeID, struct{}{}); loaded {
+		return ErrHandshakeInFlight
+	}
+	defer d.handshakeInFlight.Delete(nodeID)
 	return d.handshakes.SendRequest(nodeID, reason)
 }
 

--- a/pkg/daemon/ipc.go
+++ b/pkg/daemon/ipc.go
@@ -496,7 +496,6 @@ func (s *IPCServer) Close() error {
 	return nil
 }
 
-
 func (s *IPCServer) acceptLoop() {
 	for {
 		// P2-002: always accept then immediately reject-and-close when
@@ -1275,7 +1274,21 @@ func (s *IPCServer) handleHandshake(conn *ipcConn, reqID uint64, payload []byte)
 		if len(rest) > 4 {
 			justification = string(rest[4:])
 		}
-		if err := s.daemon.handshakes.SendRequest(nodeID, justification); err != nil {
+		if err := s.daemon.HandshakeSendRequest(nodeID, justification); err != nil {
+			if errors.Is(err, ErrHandshakeInFlight) {
+				// Soft success: another caller is already running the
+				// same handshake. Reply with a distinct status so
+				// clients can distinguish "I started one" from "one
+				// was already running" without treating either as
+				// failure. Per-peer dedup prevents the dial-burst
+				// port-pool saturation that motivated this path.
+				data, _ := json.Marshal(map[string]interface{}{
+					"status":  "in_flight",
+					"node_id": nodeID,
+				})
+				s.ipcWriteHandshakeOK(conn, reqID, data)
+				return
+			}
 			s.sendError(conn, reqID, fmt.Sprintf("handshake request: %v", err))
 			return
 		}

--- a/pkg/daemon/zz_handshake_inflight_dedup_test.go
+++ b/pkg/daemon/zz_handshake_inflight_dedup_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package daemon
+
+// Pins per-peer in-flight dedup for HandshakeSendRequest. The motivating
+// symptom: a burst of `pilotctl handshake <agent>` commands (e.g. 7
+// parallel handshakes) each fired its own DialConnection on port 444,
+// each holding one ephemeral port for up to ~7.75 s (DialMaxRetries ×
+// backoff). Concurrent intent toward the same peer was NOT collapsed, so
+// the dial-side fanout multiplied the port-pool pressure under load and
+// produced the "ephemeral ports exhausted" storm observed in the baseline
+// reproduction (2026-05-31).
+//
+// The fix: HandshakeSendRequest records nodeID in d.handshakeInFlight on
+// entry and removes it on return. Concurrent callers for the same peer
+// observe the entry and short-circuit with ErrHandshakeInFlight. The
+// first caller's underlying SendRequest runs once; subsequent callers
+// see the in-flight signal and do nothing — no second dial, no second
+// ephemeral port held.
+//
+// These tests verify both halves of that contract.
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// dedupFakeHandshakeService counts how many times SendRequest is called and
+// optionally blocks the call to widen the in-flight window for race
+// testing.
+type dedupFakeHandshakeService struct {
+	calls    atomic.Int32
+	blockFor time.Duration
+}
+
+func (f *dedupFakeHandshakeService) IsTrusted(uint32) bool { return false }
+func (f *dedupFakeHandshakeService) TrustedPeers() []HandshakeTrustRecord {
+	return nil
+}
+func (f *dedupFakeHandshakeService) PendingRequests() []HandshakePendingRecord {
+	return nil
+}
+func (f *dedupFakeHandshakeService) PendingCount() int { return 0 }
+func (f *dedupFakeHandshakeService) SendRequest(uint32, string) error {
+	f.calls.Add(1)
+	if f.blockFor > 0 {
+		time.Sleep(f.blockFor)
+	}
+	return nil
+}
+func (f *dedupFakeHandshakeService) ApproveHandshake(uint32) error        { return nil }
+func (f *dedupFakeHandshakeService) RejectHandshake(uint32, string) error { return nil }
+func (f *dedupFakeHandshakeService) RevokeTrust(uint32) error             { return nil }
+func (f *dedupFakeHandshakeService) WaitForTrust(uint32, time.Duration) bool {
+	return false
+}
+func (f *dedupFakeHandshakeService) ProcessRelayedRequest(uint32, string) {}
+func (f *dedupFakeHandshakeService) ProcessRelayedApproval(uint32)        {}
+func (f *dedupFakeHandshakeService) ProcessRelayedRejection(uint32)       {}
+func (f *dedupFakeHandshakeService) Stop()                                {}
+
+// TestHandshakeInFlightDedupCollapsesBurst verifies that N concurrent
+// callers for the same peer produce exactly one underlying SendRequest
+// call. The fake SendRequest blocks long enough for all goroutines to
+// pile up in HandshakeSendRequest and observe the in-flight entry.
+func TestHandshakeInFlightDedupCollapsesBurst(t *testing.T) {
+	t.Parallel()
+
+	fake := &dedupFakeHandshakeService{blockFor: 50 * time.Millisecond}
+	d := &Daemon{handshakes: fake}
+
+	const peer = uint32(42)
+	const N = 16
+
+	var wg sync.WaitGroup
+	var inFlightCount atomic.Int32
+	var okCount atomic.Int32
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			err := d.HandshakeSendRequest(peer, "test")
+			switch {
+			case err == nil:
+				okCount.Add(1)
+			case errors.Is(err, ErrHandshakeInFlight):
+				inFlightCount.Add(1)
+			default:
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := fake.calls.Load(); got != 1 {
+		t.Errorf("underlying SendRequest called %d times, want 1 — dedup did not collapse the burst", got)
+	}
+	if got := okCount.Load(); got != 1 {
+		t.Errorf("ok-count = %d, want 1 (only the first caller should see a non-error result)", got)
+	}
+	if got := inFlightCount.Load(); got != int32(N-1) {
+		t.Errorf("in-flight-count = %d, want %d (N-1 contenders should observe the in-flight entry)", got, N-1)
+	}
+}
+
+// TestHandshakeInFlightSlotReleasedOnReturn verifies the per-peer slot
+// is freed once the underlying call completes — a second handshake to
+// the same peer fired AFTER the first returns must proceed normally,
+// not be permanently locked out.
+func TestHandshakeInFlightSlotReleasedOnReturn(t *testing.T) {
+	t.Parallel()
+
+	fake := &dedupFakeHandshakeService{}
+	d := &Daemon{handshakes: fake}
+
+	const peer = uint32(99)
+
+	if err := d.HandshakeSendRequest(peer, ""); err != nil {
+		t.Fatalf("first call returned err: %v", err)
+	}
+	if err := d.HandshakeSendRequest(peer, ""); err != nil {
+		t.Fatalf("second call (after first returned) returned err: %v", err)
+	}
+	if got := fake.calls.Load(); got != 2 {
+		t.Errorf("underlying SendRequest called %d times, want 2 — slot was not released between sequential calls", got)
+	}
+}
+
+// TestHandshakeInFlightDifferentPeersIndependent verifies dedup is
+// keyed strictly by peer ID — concurrent handshakes to DIFFERENT peers
+// must each proceed independently.
+func TestHandshakeInFlightDifferentPeersIndependent(t *testing.T) {
+	t.Parallel()
+
+	fake := &dedupFakeHandshakeService{blockFor: 30 * time.Millisecond}
+	d := &Daemon{handshakes: fake}
+
+	const N = 5
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		peer := uint32(1000 + i)
+		go func() {
+			defer wg.Done()
+			if err := d.HandshakeSendRequest(peer, ""); err != nil {
+				t.Errorf("peer %d: unexpected err %v", peer, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := fake.calls.Load(); got != N {
+		t.Errorf("SendRequest called %d times, want %d (per-peer dedup must not collapse distinct peers)", got, N)
+	}
+}
+
+// TestHandshakeSendRequestNoServiceErr keeps the nil-service guard
+// behavior pinned — when the plugin isn't registered, we return the
+// existing "service not registered" error, not ErrHandshakeInFlight.
+func TestHandshakeSendRequestNoServiceErr(t *testing.T) {
+	t.Parallel()
+
+	d := &Daemon{}
+	err := d.HandshakeSendRequest(1, "")
+	if err == nil {
+		t.Fatalf("expected error when handshakes service is nil")
+	}
+	if errors.Is(err, ErrHandshakeInFlight) {
+		t.Fatalf("got ErrHandshakeInFlight from nil-service path, want generic 'not registered' error")
+	}
+}


### PR DESCRIPTION
## Summary
- Concurrent `pilotctl handshake <agent>` commands each fired their own `DialConnection` on port 444 — the daemon had no per-peer dedup. Under a 7-command parallel burst the dial-side fanout briefly saturated the 16,384-slot ephemeral-port bitmap (verified locally 2026-05-31).
- Adds an in-flight `sync.Map` on `Daemon` keyed by peer node ID. The first caller proceeds; subsequent callers for the same peer short-circuit with `ErrHandshakeInFlight`.
- IPC `SubHandshakeSend` handler reports this as a distinct `"in_flight"` reply status so callers (and pilotctl users) see a clean signal instead of a generic error.

## Why this is safe
- **No wire protocol change** — daemon doesn't dial differently to peers.
- **No IPC protocol change** — adds a new reply *status* value (`"in_flight"`) that existing decoders read as success. Existing callers see `{"status":"sent",...}` unchanged for the first caller; the new value only appears for dedup hits.
- **No peer-visible behavior change** — peers still see exactly the SYN they always would; dedup just prevents a second SYN from being launched on this side.
- **Compat with v1.10.x daemons / clients** unaffected — change is internal to dispatch.

## Test plan
- [x] `go test -race -count=1 -run 'TestHandshakeInFlight|TestHandshakeSendRequestNoServiceErr' ./pkg/daemon/` — 4 new tests pass with race detector
- [x] `go test -short -count=1 -timeout 180s -parallel 4 ./pkg/daemon/...` — full short suite green
- [x] `go build ./...` clean
- [ ] Post-merge: build the released daemon binary, repeat the 7-parallel-handshake stress and verify no `ephemeral ports exhausted` entries in the log

## Field reproduction (pre-fix)
\`\`\`
time=12:37:44.436 level=INFO msg="direct handshake failed, relaying via registry" peer_node_id=17298 error="ephemeral ports exhausted"
time=12:37:44.436 level=INFO msg="direct handshake failed, relaying via registry" peer_node_id=17476 error="ephemeral ports exhausted"
... many more within milliseconds ...
\`\`\`
Daemon recovered on its own within ~20 s of the storm ending (5 s `SynSentReapDuration` + 15 s `idleSweepLoop` tick). This PR prevents the storm from happening in the first place.