### PR TITLE
fix(daemon): route auto-handshake through HandshakeSendRequest wrapper (follow-up to #208)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -3122,7 +3122,21 @@ func (d *Daemon) dialConnectionLocked(ctx context.Context, dstAddr protocol.Addr
 	// proactive handshake when the plugin isn't loaded.
 	if d.handshakes != nil && !d.handshakes.IsTrusted(dstAddr.Node) {
 		if _, ok := trustedagents.IsTrusted(dstAddr.Node); ok {
-			go d.handshakes.SendRequest(dstAddr.Node, "")
+			// Route through HandshakeSendRequest (not the plugin's raw
+			// SendRequest) so the per-peer in-flight dedup catches the
+			// recursive case: this proactive auto-handshake fires from
+			// within DialConnection, and SendRequest itself eventually
+			// calls back into DialConnection on port 444, which re-checks
+			// this same gate. Without dedup that's a self-driving fanout
+			// — verified locally 2026-05-31: ~12k "direct handshake
+			// failed" entries within 800 ms for a single trusted-agents
+			// peer, all from the recursive go-fired chain. The wrapper's
+			// LoadOrStore caps it at one in-flight call per peer.
+			//
+			// Returns are intentionally discarded — the goroutine is best
+			// effort, just like before. ErrHandshakeInFlight short-circuit
+			// is the dedup hit, which is the success case.
+			go func() { _ = d.HandshakeSendRequest(dstAddr.Node, "") }()
 		}
 	}
 


### PR DESCRIPTION
## Summary
Follow-up to #208. That PR added per-peer in-flight dedup at the daemon's IPC entry point (\`HandshakeSendRequest\`) and the IPC-side burst symptom is gone — 0 \"ephemeral ports exhausted\" errors in the local repro post-merge.

But the same repro surfaced a second pathway: the proactive auto-handshake fired from inside \`DialConnection\` (\`daemon.go:3125\`) calls \`d.handshakes.SendRequest\` **directly**, bypassing the dedup wrapper. That call re-enters \`DialConnection\` on port 444 for the same peer, which re-checks the same gate, fires another \`go SendRequest\`, and the chain self-fuels until the dial budget cuts it.

In the local repro one user-triggered handshake to a \`trustedagents\` peer (crossref-funders, node 41451) produced **~12,279 \"direct handshake failed\" log entries within ~800 ms** before the dial timeout cleared it.

## Fix
One-line: route the auto-handshake through \`d.HandshakeSendRequest\` instead of \`d.handshakes.SendRequest\`. The dedup map now catches the recursive call — second entry sees the in-flight slot, short-circuits with \`ErrHandshakeInFlight\`, the goroutine returns, fanout doesn't happen.

The error return is discarded — the goroutine is fire-and-forget, same as before. \`ErrHandshakeInFlight\` is the dedup success case.

## Why this is safe
- **No wire / IPC / persistence change.**
- **No peer-visible behavior change** — the proactive handshake still fires; it just fires once instead of recursively.
- **Same compat surface as #208.**

## Test plan
- [x] \`go test -race -count=1 -run 'TestHandshakeInFlight|TestHandshakeSendRequestNoServiceErr' ./pkg/daemon/\` — existing dedup regression tests still pass
- [x] \`go build ./...\` clean
- [ ] Post-merge: rerun the 7-distinct-peer + 10-same-peer handshake stress, verify no \"direct handshake failed\" storm