### PR TITLE
fix(daemon): wrap bgWG.Wait() with 5s timeout in doStop() (PILOT-318)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1325,7 +1325,19 @@ func (d *Daemon) Stop() error {
 func (d *Daemon) doStop() {
 	// Wait for all daemon-scoped background goroutines to notice
 	// stopCh and exit before tearing down shared infrastructure.
-	d.bgWG.Wait()
+	// Use a 5-second timeout to prevent a hung goroutine (e.g.
+	// blocked on registry I/O during an outage) from blocking
+	// shutdown forever. Leaked goroutines are the lesser evil.
+	done := make(chan struct{})
+	go func() {
+		d.bgWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		slog.Warn("timed out waiting for background goroutines to exit", "leaked", true)
+	}
 
 	// v1.9.1: emit a shutdown signal BEFORE any teardown so operators
 	// can distinguish planned drain from crash. Auto-scalers and


### PR DESCRIPTION
## What
`doStop()` calls `bgWG.Wait()` with no deadline. If any background goroutine is blocked on registry I/O during an outage, shutdown blocks forever — the process only exits when the supervisor SIGKILLs it.

## Fix
Wrap the Wait with a 5-second timeout via goroutine + select. On timeout, `slog.Warn` records the leak event. Hung goroutines are the lesser evil compared to an unkillable daemon.

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/daemon/...` ✅ (55.7s)

## Diff
1 file, +13/−1 (`pkg/daemon/daemon.go`)

---

**Note:** This replaces PR #205 which had a bad rebase that reverted the handshake-inflight dedup (#208) and auto-handshake routing (#209). This fresh branch is based directly on current main (273bb0f) with only the timeout change.

Closes [PILOT-318](https://vulturelabs.atlassian.net/browse/PILOT-318)