### PR TITLE
fix(pilotctl): atomically claim PID file with O_CREAT|O_EXCL (PILOT-292)

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -2321,6 +2321,18 @@ func cmdDaemonStart(args []string) {
 		os.Remove(pidFilePath())
 	}
 
+	// Atomically claim the PID file to prevent concurrent daemon starts.
+	// O_CREAT|O_EXCL ensures only one pilotctl daemon start can succeed;
+	// a second concurrent invocation fails here before spawning a daemon.
+	if f, err := os.OpenFile(pidFilePath(), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600); err != nil {
+		fatalHint("already_exists",
+			"stop it first with: pilotctl daemon stop",
+			"another daemon start is in progress (PID file locked)")
+	} else {
+		_, _ = f.WriteString("0\n")
+		f.Close()
+	}
+
 	daemonArgs, socketPath, adminToken := buildDaemonArgs(args)
 
 	// Clean up stale socket


### PR DESCRIPTION
Resupersedes #197 — same single-block addition (atomic PID claim in cmdDaemonStart), rebased cleanly onto current main.