### PR TITLE
fix(install): use DNS for registry/beacon defaults (PILOT-330)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,8 +57,8 @@ set -e
 # error.
 
 REPO="TeoSlayer/pilotprotocol"
-REGISTRY="${PILOT_REGISTRY:-34.71.57.205:9000}"
-BEACON="${PILOT_BEACON:-34.71.57.205:9001}"
+REGISTRY="${PILOT_REGISTRY:-registry.pilotprotocol.network:9000}"
+BEACON="${PILOT_BEACON:-registry.pilotprotocol.network:9001}"
 # PILOT-270: validate REGISTRY/BEACON to prevent JSON injection into config.json
 if ! echo "$REGISTRY" | grep -qE '^[a-zA-Z0-9.:_-]+$'; then
     echo "Error: REGISTRY contains invalid characters (only a-z A-Z 0-9 . : _ - allowed)"


### PR DESCRIPTION
Resupersedes #189 — same two-line default change (IP → DNS), rebased cleanly onto current main with the validation regex already in place.