### PR TITLE
fix(ci): workflow-level permissions on codeql.yml + notify-canary.yml (CodeQL #41)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "0 6 * * 1" # weekly, Monday 6 AM UTC
 
+# Workflow-level default — least privilege. The analyze job elevates
+# security-events to write for the CodeQL upload step.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Go

--- a/.github/workflows/notify-canary.yml
+++ b/.github/workflows/notify-canary.yml
@@ -24,6 +24,11 @@ on:
   pull_request:
     branches: ['**']
 
+# Workflow-level default — least privilege. This workflow only reads
+# the repo and dispatches an external event using its own PAT secret.
+permissions:
+  contents: read
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` at the workflow root level. codeql.yml already had job-level perms; notify-canary had none. Closes CodeQL alert #41.