### PR TITLE
chore(deps): bump beacon v0.2.5, common v0.4.7 to latest stable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/pilot-protocol/app-store v0.2.0
 	github.com/pilot-protocol/beacon v0.2.5
-	github.com/pilot-protocol/common v0.4.7
+	github.com/pilot-protocol/common v0.4.8
 	github.com/pilot-protocol/dataexchange v0.2.0
 	github.com/pilot-protocol/eventstream v0.2.2
 	github.com/pilot-protocol/handshake v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.10
 require (
 	github.com/coder/websocket v1.8.14
 	github.com/pilot-protocol/app-store v0.2.0
-	github.com/pilot-protocol/beacon v0.2.2
-	github.com/pilot-protocol/common v0.4.5
+	github.com/pilot-protocol/beacon v0.2.5
+	github.com/pilot-protocol/common v0.4.7
 	github.com/pilot-protocol/dataexchange v0.2.0
 	github.com/pilot-protocol/eventstream v0.2.2
 	github.com/pilot-protocol/handshake v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pilot-protocol/handshake v0.2.1
 	github.com/pilot-protocol/nameserver v0.2.1
 	github.com/pilot-protocol/policy v0.2.2
-	github.com/pilot-protocol/rendezvous v0.2.3
+	github.com/pilot-protocol/rendezvous v0.2.4
 	github.com/pilot-protocol/runtime v0.3.1
 	github.com/pilot-protocol/skillinject v0.2.2
 	github.com/pilot-protocol/trustedagents v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,10 @@ github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/pilot-protocol/app-store v0.2.0 h1:/SbLPa2dKnvhv0ITeaYMZw/2KXXxWDRuYUdM5z9eyKk=
 github.com/pilot-protocol/app-store v0.2.0/go.mod h1:f0umeJxswDG8/CctHpSFMlr5GLtE2GlPKkijIQErZuc=
-github.com/pilot-protocol/beacon v0.2.2 h1:G1P5wuBK75LTSGHhpjNsN7bWi8JiZ0bWk3yjWcQNkwA=
-github.com/pilot-protocol/beacon v0.2.2/go.mod h1:k/cHbldwYkkF7dN1WDlaDPGqiRfFgIAmiB71fXSPYW0=
-github.com/pilot-protocol/common v0.4.4 h1:Y5AJ2PMNwy+2eb4DJfLdJlle+d/Z9UBWTN6czMA84cY=
-github.com/pilot-protocol/common v0.4.4/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
-github.com/pilot-protocol/common v0.4.5 h1:WX7jQcJoWJe+GtynZ+gz0f3re7DIRpi3RWo2SEnZJYo=
-github.com/pilot-protocol/common v0.4.5/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
+github.com/pilot-protocol/beacon v0.2.5 h1:5+pkSPoA35r+u4Hfrph/ZfOltOyiy8lh1sCfK5XqXKs=
+github.com/pilot-protocol/beacon v0.2.5/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
+github.com/pilot-protocol/common v0.4.7 h1:cljZiC3haHvB9sokuUs/+IHNU9ZAnpNtv32V355R/eQ=
+github.com/pilot-protocol/common v0.4.7/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
 github.com/pilot-protocol/dataexchange v0.2.0 h1:ldE6AyrES1uvdnn1NBl0KZ7C+SSWNtmeHHU3CQhwSCo=
 github.com/pilot-protocol/dataexchange v0.2.0/go.mod h1:JVy2+hr/IjzMPshxjExbGO/4SbJTs7ZJ7iYvT/ODF3Q=
 github.com/pilot-protocol/eventstream v0.2.2 h1:E0IjveK7K+dsIbE/5hD3N821FkHzxVsx1tiAORMzt8k=

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,8 @@ github.com/pilot-protocol/policy v0.2.1 h1:s3aMgeDFVYzDNBcdvO4mzDRlrRF5CvMepW7az
 github.com/pilot-protocol/policy v0.2.1/go.mod h1:jzsAO71uGlRVyduPrQmS/UeqSwUpeUO/CjykHm/IfXM=
 github.com/pilot-protocol/policy v0.2.2 h1:Co8sqZ4lRQfFA0Ot8l33VhsEwfiEVqcPz+kHY49QbkM=
 github.com/pilot-protocol/policy v0.2.2/go.mod h1:jzsAO71uGlRVyduPrQmS/UeqSwUpeUO/CjykHm/IfXM=
-github.com/pilot-protocol/rendezvous v0.2.2 h1:YkiHeY0Wl4pmpuBmXDhewSV05sjvquNlz2S/CHjkxTc=
-github.com/pilot-protocol/rendezvous v0.2.2/go.mod h1:bVGb1Mc93faQ+bG3R/nt/wv53cHv0SgLzpf8SZc/dqY=
-github.com/pilot-protocol/rendezvous v0.2.3 h1:wB1RTnGSJ6walu8aTdpSNPUFKVoyEaZTviGZi+YCAFk=
-github.com/pilot-protocol/rendezvous v0.2.3/go.mod h1:bVGb1Mc93faQ+bG3R/nt/wv53cHv0SgLzpf8SZc/dqY=
+github.com/pilot-protocol/rendezvous v0.2.4 h1:nxYm12RzEUA6zzNGcnDqxNcGBSIALL5uRH9zX+Q0CSg=
+github.com/pilot-protocol/rendezvous v0.2.4/go.mod h1:w7SC0nZCmWPyc7hxdFZ200zQVA75UoaC25MznUQXNFE=
 github.com/pilot-protocol/runtime v0.3.0 h1:OVPv7hyaAZsw5EPWtf2XQGfCqxgaM/iANPhIYOMp+0w=
 github.com/pilot-protocol/runtime v0.3.0/go.mod h1:GfFEIji0w7H9SSNR9Wl2q72pd2OYN3PHY9Qhcbvyrqk=
 github.com/pilot-protocol/runtime v0.3.1 h1:+W9ww0dZY/FgOBtCmIOV3w5L5Z4Upt/RIsrYElXZ1zs=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/pilot-protocol/app-store v0.2.0 h1:/SbLPa2dKnvhv0ITeaYMZw/2KXXxWDRuYU
 github.com/pilot-protocol/app-store v0.2.0/go.mod h1:f0umeJxswDG8/CctHpSFMlr5GLtE2GlPKkijIQErZuc=
 github.com/pilot-protocol/beacon v0.2.5 h1:5+pkSPoA35r+u4Hfrph/ZfOltOyiy8lh1sCfK5XqXKs=
 github.com/pilot-protocol/beacon v0.2.5/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
-github.com/pilot-protocol/common v0.4.7 h1:cljZiC3haHvB9sokuUs/+IHNU9ZAnpNtv32V355R/eQ=
-github.com/pilot-protocol/common v0.4.7/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
+github.com/pilot-protocol/common v0.4.8 h1:eS2Bc+XcZWJ/qhwwOZbXwIWhtNdOijuoEp716kQE+/c=
+github.com/pilot-protocol/common v0.4.8/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
 github.com/pilot-protocol/dataexchange v0.2.0 h1:ldE6AyrES1uvdnn1NBl0KZ7C+SSWNtmeHHU3CQhwSCo=
 github.com/pilot-protocol/dataexchange v0.2.0/go.mod h1:JVy2+hr/IjzMPshxjExbGO/4SbJTs7ZJ7iYvT/ODF3Q=
 github.com/pilot-protocol/eventstream v0.2.2 h1:E0IjveK7K+dsIbE/5hD3N821FkHzxVsx1tiAORMzt8k=

--- a/pkg/daemon/zz_test_helpers_registry_test.go
+++ b/pkg/daemon/zz_test_helpers_registry_test.go
@@ -62,6 +62,19 @@ func startFakeRegistry(t *testing.T, respond func(req map[string]interface{}) ma
 					if resp == nil {
 						resp = map[string]interface{}{}
 					}
+					// common@v0.4.7 (PILOT-132) rejects any non-empty
+					// registry response that lacks a "type" envelope
+					// field. The fake-registry callbacks predate that
+					// requirement and rarely set "type" explicitly;
+					// inject a default so we don't have to update every
+					// single test. Tests that exercise a specific type
+					// (e.g. error envelopes) still win — we only fill
+					// the field when the callback didn't.
+					if len(resp) > 0 {
+						if _, hasType := resp["type"]; !hasType {
+							resp["type"] = "response"
+						}
+					}
 					out, _ := json.Marshal(resp)
 					if err := ipcutil.Write(c, out); err != nil {
 						return


### PR DESCRIPTION
Daemon was pinned to beacon v0.2.2 (3 patches behind v0.2.5) and common v0.4.5 (2 patches behind v0.4.7). Picks up PILOT-334 + PILOT-342 + recent common changes. CI tests against the bumped siblings — green = no incompatibility.