### PR TITLE
feat: reply-on-connection — daemon --auto-answer + pilotctl --reply-on-conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ project uses [Semantic Versioning](https://semver.org/).
 Detailed per-release notes are on the
 [GitHub Releases page](https://github.com/TeoSlayer/pilotprotocol/releases).
 
+## [Unreleased]
+
+### Added
+- **Reply-on-connection** — answers ride back on the connection the sender
+  opened, eliminating the dial-back for opted-in requests. Two halves, each
+  independently rollable and backwards-compatible:
+  - **Daemon `--auto-answer <url>` (SPECIALISED — service/directory agents
+    ONLY; regular nodes must not set it).** When set, a `TypeAutoAnswer` request
+    is dispatched to `<url>` (the local responder's `/dispatch`) and the reply is
+    written back on the same connection, then the connection closes after exactly
+    one request + one reply. Plain requests are untouched and still use the inbox
+    path, so enabling this never changes how the node serves ordinary senders.
+  - **`pilotctl send-message --reply-on-conn`** (env `PILOT_REPLY_ON_CONN=1`) —
+    sends the request as `TypeAutoAnswer` and reads the reply off the connection
+    into `~/.pilot/inbox/` (same format as a dial-back reply), with no `--wait`
+    and no dial-back. **Always safe — never worse than a plain send:** against an
+    `--auto-answer` agent the reply comes on the connection; against any other
+    agent it falls back to a normal dial-back (an updated agent saved it; an
+    old/stock agent acks the frame as `UNKNOWN`, which triggers an automatic
+    resend as plain `TEXT`). The on-connection benefit is gained only against
+    `--auto-answer` agents.
+- The reply lands as an ordinary inbox message — `pilotctl inbox` reads it
+  unchanged.
+
+### Notes / limitations
+- Reply-on-connection helps senders that **run a client which reads the reply**
+  (updated `pilotctl`/SDK). It does not change the ceiling for transient clients
+  with no daemon/inbox.
+- The new loop is gated on the **request type**, so it is safe to enable
+  `--auto-answer` on a live directory agent without disturbing current traffic.
+- **Sender-side fan-out is out of scope:** a single requester daemon opening
+  *many* simultaneous dials (dozens) can see sender-side `dial` failures under
+  NAT/relay pressure — a property of overloading one sender daemon, not of the
+  receiver (which dropped zero replies in testing). Regular senders issue a few
+  dials and are unaffected.
+
 ## [1.10.7] - 2026-06-06
 
 ### Fixed

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -6,8 +6,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -34,6 +37,34 @@ import (
 )
 
 var version = "dev"
+
+// newAutoAnswerReplyHook builds the dataexchange ReplyHook for --auto-answer: it
+// dispatches each request to the responder's HTTP endpoint and returns the body
+// as a TEXT reply. The read is bounded at the data-exchange frame limit — the
+// same effective ceiling the normal inbox→dial-back path hits — so
+// reply-on-connection delivers byte-for-byte what a dial-back would, never
+// truncating a large reply. Returns ok=false (no reply written) on transport
+// error or an empty body, which lets the sender fall back to a dial-back.
+func newAutoAnswerReplyHook(endpoint string, hc *http.Client) func(reqType uint32, payload []byte) (uint32, []byte, bool) {
+	return func(reqType uint32, payload []byte) (uint32, []byte, bool) {
+		resp, err := hc.Get(endpoint + "?message=" + url.QueryEscape(string(payload)))
+		if err != nil {
+			return 0, nil, false
+		}
+		defer resp.Body.Close()
+		// Only a 200 carries a real reply. 204 (dropped by loop-prevention) and
+		// any error status (e.g. 400 "missing message") must NOT be delivered as
+		// a reply — returning ok=false lets the sender fall back to a dial-back.
+		if resp.StatusCode != http.StatusOK {
+			return 0, nil, false
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, dataexchange.MaxFrameSize))
+		if len(body) == 0 {
+			return 0, nil, false
+		}
+		return dataexchange.TypeText, body, true
+	}
+}
 
 func main() {
 	configPath := flag.String("config", "", "path to config file (JSON)")
@@ -80,6 +111,7 @@ func main() {
 	hostname := flag.String("hostname", "", "hostname for discovery (lowercase alphanumeric + hyphens, max 63 chars)")
 	noEcho := flag.Bool("no-echo", false, "disable built-in echo service (port 7)")
 	noDataExchange := flag.Bool("no-dataexchange", false, "disable built-in data exchange service (port 1001)")
+	autoAnswer := flag.String("auto-answer", "", "SPECIALISED — directory/service agents ONLY (e.g. list-agents); regular nodes MUST leave this empty. Enables reply-on-connection: an opted-in request (TypeAutoAnswer, from `send-message --reply-on-conn`) is dispatched to this HTTP endpoint and the reply is written back on the SAME connection the sender opened, then the connection closes (exactly 1 request + 1 response — no loop). This lets a sender receive the answer in its inbox with no dial-back, even when it is unreachable. Plain requests are unaffected and still flow through the normal inbox path, so setting this never changes how this node serves ordinary senders. A regular node has no reason to hold connections open to generate replies and should never set this.")
 	dataExchangeB64 := flag.Bool("dataexchange-b64", false, "include raw base64 payload (`data_b64`) alongside `data` in inbox messages — needed only for binary payloads (e.g. zlib-compressed envelopes)")
 	noEventStream := flag.Bool("no-eventstream", false, "disable built-in event stream service (port 1002)")
 	webhookURL := flag.String("webhook", "", "HTTP(S) endpoint for event notifications (empty = disabled)")
@@ -223,9 +255,21 @@ func main() {
 	}
 
 	if !*noDataExchange {
-		if err := rt.Register(dataexchange.NewService(dataexchange.ServiceConfig{
-			IncludeBase64: *dataExchangeB64,
-		})); err != nil {
+		dxCfg := dataexchange.ServiceConfig{IncludeBase64: *dataExchangeB64}
+		if *autoAnswer != "" {
+			ru := *autoAnswer
+			// Timeout chain (must be strictly increasing so no stage cuts off
+			// the one beneath it): responder fetch (35s, the service call) <
+			// this ReplyHook HTTP client (38s, the /dispatch round trip that
+			// CONTAINS that fetch) < service autoAnswerWindow watchdog (40s) <=
+			// sender on-connection read window (45s). At 38s this client gives
+			// the responder's 35s fetch room to finish before the daemon gives up.
+			hc := &http.Client{Timeout: 38 * time.Second}
+			dxCfg.AutoAnswer = true
+			dxCfg.ReplyHook = newAutoAnswerReplyHook(ru, hc)
+			slog.Info("dataexchange auto-answer (reply-on-connection) enabled", "endpoint", ru)
+		}
+		if err := rt.Register(dataexchange.NewService(dxCfg)); err != nil {
 			log.Fatalf("register dataexchange: %v", err)
 		}
 	}

--- a/cmd/daemon/zz_autoanswer_test.go
+++ b/cmd/daemon/zz_autoanswer_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pilot-protocol/dataexchange"
+)
+
+// TestAutoAnswerReplyHook_LargeBodyNotTruncated proves the reply-on-connection
+// read is NOT capped at the old 1 MiB limit: a body well over 1 MiB is returned
+// in full, so a large directory reply is delivered byte-for-byte like a
+// dial-back would.
+func TestAutoAnswerReplyHook_LargeBodyNotTruncated(t *testing.T) {
+	const size = 3 << 20 // 3 MiB, well past the retired 1 MiB cap
+	big := strings.Repeat("x", size)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("message") == "" {
+			t.Error("reply hook did not forward the message query param")
+		}
+		_, _ = w.Write([]byte(big))
+	}))
+	defer srv.Close()
+
+	hook := newAutoAnswerReplyHook(srv.URL, &http.Client{Timeout: 10 * time.Second})
+	rt, body, ok := hook(dataexchange.TypeAutoAnswer, []byte("/data"))
+	if !ok {
+		t.Fatal("hook returned ok=false for a valid large body")
+	}
+	if rt != dataexchange.TypeText {
+		t.Errorf("reply type = %d, want TypeText", rt)
+	}
+	if len(body) != size {
+		t.Fatalf("reply truncated: got %d bytes, want %d", len(body), size)
+	}
+}
+
+// TestAutoAnswerReplyHook_EmptyAndError: an empty body or a transport error
+// yields ok=false (no reply on the connection → the sender falls back).
+func TestAutoAnswerReplyHook_EmptyAndError(t *testing.T) {
+	// Empty body (e.g. /dispatch 204 for a dropped message).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	hook := newAutoAnswerReplyHook(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	if _, _, ok := hook(dataexchange.TypeAutoAnswer, []byte("prose")); ok {
+		t.Error("empty body should yield ok=false")
+	}
+	srv.Close()
+
+	// Transport error (server gone).
+	if _, _, ok := hook(dataexchange.TypeAutoAnswer, []byte("/data")); ok {
+		t.Error("transport error should yield ok=false")
+	}
+
+	// Non-200 with a non-empty body (e.g. 400 "missing message") must NOT be
+	// delivered as a reply.
+	errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "missing message", http.StatusBadRequest)
+	}))
+	defer errSrv.Close()
+	h2 := newAutoAnswerReplyHook(errSrv.URL, &http.Client{Timeout: 5 * time.Second})
+	if _, body, ok := h2(dataexchange.TypeAutoAnswer, []byte("/data")); ok {
+		t.Errorf("a 400 response must yield ok=false, got body=%q", body)
+	}
+}

--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -3649,6 +3649,39 @@ func cmdSendMessage(args []string) {
 	}
 	msgType := flagString(flags, "type", "text")
 
+	// --reply-on-conn opts this request into reply-on-connection: send it as a
+	// TypeAutoAnswer frame and read the reply the receiver writes back on the
+	// SAME connection (into the inbox), instead of relying on a dial-back.
+	//
+	// ALWAYS SAFE — never worse than a plain send. Against an --auto-answer agent
+	// the reply rides back on this connection (so it works even when this sender
+	// is NAT'd / has no public port / is transient). Against ANY other agent it
+	// transparently falls back to a normal dial-back: an updated agent saved the
+	// request, and an old/stock agent (which acks the frame as UNKNOWN) triggers
+	// an automatic resend as plain TEXT — either way the reply is dial-backed
+	// exactly as for a normal send. Current senders that don't set it are
+	// untouched. Env: PILOT_REPLY_ON_CONN=1.
+	replyOnConn := flagBool(flags, "reply-on-conn") || os.Getenv("PILOT_REPLY_ON_CONN") != ""
+	if replyOnConn {
+		// reply-on-connection carries the request as a text query, so true binary
+		// would be lossily url-escaped — reject it rather than diverge silently
+		// from a plain --type binary send.
+		if msgType == "binary" {
+			fatalCode("invalid_argument", "--reply-on-conn does not support --type binary")
+		}
+		// --trace sends a TypeTrace frame for timing and is incompatible with
+		// reply-on-connection; trace wins, so disable reply-on-conn handling to
+		// avoid a spurious fallback resend (double inbox entry).
+		if traceTime {
+			replyOnConn = false
+		}
+		// An --auto-answer receiver closes after one request+reply, so a reused
+		// connection can't carry a second send. Dial fresh per send instead.
+		if reuseConn {
+			reuseConn = false
+		}
+	}
+
 	// Auto-handshake to peers in the embedded trusted-agents list.
 	// Best-effort: warns on stderr and continues if handshake fails.
 	maybeAutoHandshake(d, target, flagBool(flags, "no-auto-handshake"))
@@ -3687,12 +3720,16 @@ func cmdSendMessage(args []string) {
 			sentAtNs, sendErr = cl.SendTrace(innerType, []byte(data))
 		} else {
 			sendStart := time.Now()
-			switch msgType {
-			case "text":
+			switch {
+			case replyOnConn:
+				// Opt in to reply-on-connection (TypeAutoAnswer); the reply is
+				// read off this connection below and saved to the inbox.
+				sendErr = cl.SendAutoAnswer(data)
+			case msgType == "text":
 				sendErr = cl.SendText(data)
-			case "json":
+			case msgType == "json":
 				sendErr = cl.SendJSON([]byte(data))
-			case "binary":
+			case msgType == "binary":
 				sendErr = cl.SendBinary([]byte(data))
 			}
 			sentAtNs = sendStart.UnixNano()
@@ -3713,7 +3750,62 @@ func cmdSendMessage(args []string) {
 			"reused": reused,
 		}
 		if ack != nil {
-			r["ack"] = string(ack.Payload)
+			ackStr := string(ack.Payload)
+			r["ack"] = ackStr
+			// reply-on-connection delivery + GUARANTEED fallback. With
+			// --reply-on-conn we sent a TypeAutoAnswer request; decide whether a
+			// reply is (or will be) delivered, and if not, fall back so the flag
+			// is ALWAYS at least as good as a plain send:
+			//   * ACK+REPLY        → an --auto-answer agent's reply follows on
+			//                        THIS connection; read it into the inbox.
+			//   * ack names the AUTOANSWER type → an updated, non-auto-answering
+			//                        agent saved the request; it will dial back.
+			//   * anything else (an OLD/stock daemon acks UNKNOWN and does NOT
+			//                        save it; or the on-connection read failed)
+			//                        → resend as plain TEXT so ANY daemon saves
+			//                        it and the responder dial-backs the reply.
+			if replyOnConn {
+				delivered := false
+				switch replyOnConnOutcome(ackStr) {
+				case replyOnConnRead:
+					// Read window is tied to the receiver's autoAnswerWindow (40s)
+					// plus margin — NOT to --wait. --wait bounds the later inbox
+					// poll; capping the on-connection read by a small --wait would
+					// abandon a reply the receiver has already committed to send
+					// (it skipped the inbox) and force a needless resend.
+					_ = cl.SetReadDeadline(time.Now().Add(45 * time.Second))
+					reply, rerr := cl.Recv()
+					_ = cl.SetReadDeadline(time.Time{})
+					if rerr == nil && reply != nil && len(reply.Payload) > 0 {
+						if p, serr := saveReplyToInbox(target.String(), reply.Type, reply.Payload); serr == nil {
+							r["reply_bytes"] = len(reply.Payload)
+							r["reply_inbox"] = p
+							delivered = true
+						} else {
+							r["reply_error"] = serr.Error()
+						}
+					} else if rerr != nil {
+						r["reply_error"] = rerr.Error()
+					}
+				case replyOnConnDelivered:
+					// Understood by an updated daemon and saved for dial-back.
+					delivered = true
+				}
+				if !delivered {
+					// Old/stock receiver (or a lost on-connection reply): resend
+					// as a plain TEXT message — exactly the pre-feature path — so
+					// the receiver saves it and the reply is dial-backed. This is
+					// what makes --reply-on-conn never worse than a plain send.
+					if rc, derr := dataexchange.Dial(d, target); derr == nil {
+						_ = rc.SendText(data)
+						_, _ = rc.Recv() // consume ack
+						_ = rc.Close()
+						r["fallback"] = "dialback"
+					} else {
+						r["fallback_error"] = derr.Error()
+					}
+				}
+			}
 		}
 		if traceTime {
 			r["total_ms"] = float64(time.Duration(ackRecvAtNs-sentAtNs).Microseconds()) / 1000.0
@@ -5273,9 +5365,70 @@ func cmdReceived(args []string) {
 	fmt.Printf("\ntotal: %d\n", len(files))
 }
 
+// reply-on-connection sender outcomes, decided from the receiver's ack.
+const (
+	replyOnConnRead      = "read"      // --auto-answer agent: read the reply on this connection
+	replyOnConnDelivered = "delivered" // updated agent understood + saved it: a dial-back is coming
+	replyOnConnResend    = "resend"    // old/stock agent did not understand it: resend as plain TEXT
+)
+
+// replyOnConnOutcome decides what a --reply-on-conn sender must do, from the
+// receiver's ack payload. This is the core of the "always safe" guarantee: only
+// an "ACK+REPLY" ack carries a reply on the connection; only a daemon that knows
+// the AUTOANSWER type echoes it in the ack (so it understood and saved the
+// request for dial-back); everything else is an old/stock daemon that acked the
+// frame as UNKNOWN without saving it, so the sender must resend as plain TEXT.
+func replyOnConnOutcome(ackPayload string) string {
+	switch {
+	case strings.HasPrefix(ackPayload, "ACK+REPLY"):
+		return replyOnConnRead
+	case strings.Contains(ackPayload, dataexchange.TypeName(dataexchange.TypeAutoAnswer)):
+		return replyOnConnDelivered
+	default:
+		return replyOnConnResend
+	}
+}
+
+// saveReplyToInbox writes a reply-on-connection frame to ~/.pilot/inbox/ in the
+// exact shape the daemon's dataexchange service uses, so it is indistinguishable
+// from a dial-back reply to `pilotctl inbox` and any inbox tooling. Returns the
+// written path. This is how a reply-aware sender lands the answer in its own
+// inbox without ever being dialed back.
+func saveReplyToInbox(from string, frameType uint32, payload []byte) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".pilot", "inbox")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	ts := time.Now()
+	msg := map[string]interface{}{
+		"type":        dataexchange.TypeName(frameType),
+		"from":        from,
+		"data":        string(payload),
+		"bytes":       len(payload),
+		"received_at": ts.Format(time.RFC3339Nano),
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return "", err
+	}
+	// Nanosecond stamp + pid keep the filename unique without the daemon's
+	// shared atomic sequence counter.
+	filename := fmt.Sprintf("%s-%s-%06d.json", dataexchange.TypeName(frameType),
+		ts.Format("20060102-150405.000000000"), os.Getpid()%1000000)
+	destPath := filepath.Join(dir, filename)
+	if err := os.WriteFile(destPath, data, 0600); err != nil {
+		return "", err
+	}
+	return destPath, nil
+}
+
 // cmdInbox lists or clears messages received via data exchange (port 1001).
 // waitForInboxReply polls ~/.pilot/inbox/ until a JSON file arrives that is
-// newer than cutoff and (if agentHint is non-empty) has a matching "agent"
+// newer than cutoff and (if agentHint is non-empty) has a matching "from"
 // field. Returns the parsed message or an error on timeout.
 func waitForInboxReply(agentHint string, cutoff time.Time, timeout time.Duration) (map[string]interface{}, error) {
 	home, err := os.UserHomeDir()

--- a/cmd/pilotctl/zz_replyonconn_test.go
+++ b/cmd/pilotctl/zz_replyonconn_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pilot-protocol/dataexchange"
+)
+
+// TestSaveReplyToInbox asserts the sender-side reply-on-connection helper writes
+// an inbox entry in the EXACT shape the daemon's dataexchange service uses, so a
+// reply read off the connection is indistinguishable from a dial-back reply.
+func TestSaveReplyToInbox(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	payload := []byte(`{"source":"list-agents","tiers":{}}`)
+	path, err := saveReplyToInbox("0:0000.0003.9ECE", dataexchange.TypeText, payload)
+	if err != nil {
+		t.Fatalf("saveReplyToInbox: %v", err)
+	}
+	if want := filepath.Join(tmp, ".pilot", "inbox"); filepath.Dir(path) != want {
+		t.Fatalf("wrote to %q, want under %q", path, want)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var msg map[string]interface{}
+	if err := json.Unmarshal(b, &msg); err != nil {
+		t.Fatalf("inbox entry is not valid JSON: %v", err)
+	}
+	for _, k := range []string{"type", "from", "data", "bytes", "received_at"} {
+		if _, ok := msg[k]; !ok {
+			t.Errorf("inbox entry missing %q (daemon-format mismatch)", k)
+		}
+	}
+	if msg["type"] != "TEXT" {
+		t.Errorf("type = %v, want TEXT", msg["type"])
+	}
+	if msg["from"] != "0:0000.0003.9ECE" {
+		t.Errorf("from = %v", msg["from"])
+	}
+	if msg["data"] != string(payload) {
+		t.Errorf("data = %v", msg["data"])
+	}
+	if int(msg["bytes"].(float64)) != len(payload) {
+		t.Errorf("bytes = %v, want %d", msg["bytes"], len(payload))
+	}
+}
+
+// TestSaveReplyToInbox_UniqueFilenames: two replies in quick succession must not
+// collide on filename.
+func TestSaveReplyToInbox_UniqueFilenames(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	p1, err1 := saveReplyToInbox("0:0000.0000.0001", dataexchange.TypeText, []byte("a"))
+	p2, err2 := saveReplyToInbox("0:0000.0000.0001", dataexchange.TypeText, []byte("b"))
+	if err1 != nil || err2 != nil {
+		t.Fatalf("errs: %v %v", err1, err2)
+	}
+	if p1 == p2 {
+		t.Fatalf("filenames collided: %q", p1)
+	}
+}
+
+// frameTypesSent decodes every frame the fake daemon captured and returns the
+// set of dataexchange frame types observed (the captured bytes are whole frames:
+// [type(4)][len(4)][payload]).
+func frameTypesSent(sd *streamDaemon) map[uint32]bool {
+	types := map[uint32]bool{}
+	sd.capturedMu.Lock()
+	defer sd.capturedMu.Unlock()
+	for _, frames := range sd.captured {
+		for _, f := range frames {
+			if len(f) >= 8 {
+				types[binary.BigEndian.Uint32(f[0:4])] = true
+			}
+		}
+	}
+	return types
+}
+
+// TestCmdSendMessage_ReplyOnConn_SendsAutoAnswerFrame is the sender-side
+// integration test: --reply-on-conn must put a TypeAutoAnswer frame on the wire
+// (the opt-in that an --auto-answer receiver keys on), where a plain send puts a
+// TypeText frame. This is what gates the new loop to opted-in requests.
+func TestCmdSendMessage_ReplyOnConn_SendsAutoAnswerFrame(t *testing.T) {
+	sd := newStreamDaemon(t)
+	sd.useDaemonNoRegistry(t)
+	captureStdout(t, func() {
+		withJSON(func() {
+			cmdSendMessage([]string{"0:0000.0000.002A", "--data", `/data {}`, "--reply-on-conn"})
+		})
+	})
+	if types := frameTypesSent(sd); !types[dataexchange.TypeAutoAnswer] {
+		t.Fatalf("--reply-on-conn did not send a TypeAutoAnswer frame; saw types %v", types)
+	}
+}
+
+// TestReplyOnConnOutcome covers the decision at the heart of the "always safe"
+// guarantee: classify the receiver's ack into read / delivered / resend.
+func TestReplyOnConnOutcome(t *testing.T) {
+	cases := []struct {
+		name, ack, want string
+	}{
+		{"auto-answer reply", "ACK+REPLY AUTOANSWER 29 bytes", replyOnConnRead},
+		{"updated saved for dial-back", "ACK AUTOANSWER 29 bytes", replyOnConnDelivered},
+		{"old/stock unknown type", "ACK UNKNOWN(6) 29 bytes", replyOnConnResend},
+		{"plain text ack", "ACK TEXT 29 bytes", replyOnConnResend},
+		{"empty", "", replyOnConnResend},
+	}
+	for _, c := range cases {
+		if got := replyOnConnOutcome(c.ack); got != c.want {
+			t.Errorf("%s: replyOnConnOutcome(%q) = %q, want %q", c.name, c.ack, got, c.want)
+		}
+	}
+}
+
+// TestCmdSendMessage_ReplyOnConn_FallsBackToText is the always-safe integration
+// test: the fake daemon echoes the request as its "ack", so it never returns
+// ACK+REPLY or names the AUTOANSWER type — i.e. it stands in for an OLD/stock
+// receiver. --reply-on-conn must then ALSO put a plain TypeText frame on the
+// wire (the dial-back fallback), so the request is delivered no matter what.
+func TestCmdSendMessage_ReplyOnConn_FallsBackToText(t *testing.T) {
+	sd := newStreamDaemon(t)
+	sd.useDaemonNoRegistry(t)
+	captureStdout(t, func() {
+		withJSON(func() {
+			cmdSendMessage([]string{"0:0000.0000.002A", "--data", `/data {}`, "--reply-on-conn"})
+		})
+	})
+	types := frameTypesSent(sd)
+	if !types[dataexchange.TypeAutoAnswer] {
+		t.Fatalf("expected the initial TypeAutoAnswer frame; saw %v", types)
+	}
+	if !types[dataexchange.TypeText] {
+		t.Fatalf("--reply-on-conn against an un-understanding receiver did NOT fall back to a TypeText send; saw %v", types)
+	}
+}
+
+// TestCmdSendMessage_PlainSendsTextFrame is the control: no flag → TypeText, and
+// crucially NOT TypeAutoAnswer (current senders must never opt in by accident).
+func TestCmdSendMessage_PlainSendsTextFrame(t *testing.T) {
+	sd := newStreamDaemon(t)
+	sd.useDaemonNoRegistry(t)
+	captureStdout(t, func() {
+		withJSON(func() {
+			cmdSendMessage([]string{"0:0000.0000.002A", "--data", "hello"})
+		})
+	})
+	types := frameTypesSent(sd)
+	if !types[dataexchange.TypeText] {
+		t.Fatalf("plain send did not put a TypeText frame on the wire; saw %v", types)
+	}
+	if types[dataexchange.TypeAutoAnswer] {
+		t.Fatalf("plain send put a TypeAutoAnswer frame on the wire — current senders must not opt in")
+	}
+}

--- a/docs/reply-on-connection.md
+++ b/docs/reply-on-connection.md
@@ -1,0 +1,123 @@
+# Reply-on-connection
+
+Reply-on-connection lets a **directory/service agent answer on the same
+connection the requester opened**, instead of dialing the requester back to
+deliver the reply. It exists so a requester that is unreachable for an inbound
+dial — behind NAT, no public port, or a short-lived client — can still receive
+the answer, with no `--wait` and no dial-back.
+
+> **`--auto-answer` is a specialised flag for service/directory agents only
+> (e.g. `list-agents`). Regular nodes must never set it.** A normal node has no
+> reason to hold a connection open to generate a reply; setting it on an
+> ordinary node is incorrect and unsupported.
+
+## How it works
+
+```
+ REQUESTER (any node, even NAT'd / transient)        SERVICE AGENT (--auto-answer)
+ send-message <agent> --data '/data {…}' --reply-on-conn
+   │  sends a TypeAutoAnswer frame ─────────────────▶ accepts on port 1001
+   │                                                  TypeAutoAnswer → does NOT save to inbox
+   │                                                  → GET <responder>/dispatch?message=…
+   │                                                       (responder: classify → cache → fetch)
+   │  ◀── ACK "ACK+REPLY …" ─────────────────────────  writes ACK (marked)
+   │  ◀── reply (the answer) on the SAME connection ─  writes reply, then graceful close
+   │  reads reply → ~/.pilot/inbox/, then closes
+   ✅ answer is in the requester's inbox — no dial-back
+```
+
+Exactly **one request + one reply**, then the connection closes — there is no
+loop, so two `--auto-answer` peers cannot ping-pong.
+
+## Requester side — `send-message --reply-on-conn`
+
+```bash
+pilotctl send-message list-agents --data '/data {"search":"weather"}' --reply-on-conn
+# reply is written to ~/.pilot/inbox/ as a normal message (read it with: pilotctl inbox)
+```
+
+- Sends the request as a `TypeAutoAnswer` frame and reads the reply off the
+  connection into `~/.pilot/inbox/` — same JSON shape as a dial-back reply.
+- No `--wait` needed; the reply arrives on the connection the requester opened.
+- **Always safe — never worse than a plain send.** Against an `--auto-answer`
+  agent the reply rides back on the connection (so it works even when the sender
+  is NAT'd, has no public port, or is transient). Against **any other agent** the
+  client transparently falls back to a normal dial-back: an updated agent saved
+  the request; an old/stock agent — which acks the frame as `UNKNOWN` — triggers
+  an automatic resend as plain `TEXT`. Either way the reply is dial-backed just
+  like a normal send. Env: `PILOT_REPLY_ON_CONN=1`.
+- Requires an updated `pilotctl`/SDK. A stock `pilotctl` (no flag) behaves
+  exactly as before and is unaffected.
+
+> **How the fallback works.** A `--reply-on-conn` sender looks at the ack: an
+> `ACK+REPLY` reads the reply on the connection; an ack naming the `AUTOANSWER`
+> type means an updated agent saved it for dial-back; anything else means an old
+> agent didn't understand it, so the sender resends as plain `TEXT`. The benefit
+> (no dial-back) is realised only against `--auto-answer` agents, but the flag is
+> safe to set against anyone.
+
+## Service-agent side — `--auto-answer` + responder `--serve-addr`
+
+Two processes on the service-agent host:
+
+```bash
+# responder: keep the inbox→dial-back loop for current senders, AND expose its
+# real dispatch (classify + loop-prevention + cache + fetch) over HTTP.
+responder-go --endpoints …/endpoints.yaml --inbox-dir …/inbox \
+             --serve-addr 127.0.0.1:18200        # env: RESPONDER_SERVE_ADDR
+
+# daemon: answer opted-in requests on-connection via the responder's /dispatch.
+pilot-daemon … --auto-answer http://127.0.0.1:18200/dispatch
+```
+
+- `--auto-answer` must point at the **responder's `/dispatch`**, not the raw
+  agent service — so the reply uses the responder's real logic, including
+  **loop-prevention** (prose and envelope-reply inputs are dropped, never
+  forwarded) and the response cache.
+- The daemon's normal data-exchange path (port 1001 → inbox) is **unchanged**.
+  Plain `TypeText`/`TypeJSON` requests from current senders are served exactly as
+  before. The auto-answer loop runs *only* for `TypeAutoAnswer` requests. This is
+  why `--auto-answer` can be enabled on a live directory agent **without
+  disturbing current traffic** — and why it is safe to test incrementally.
+
+## Compatibility matrix
+
+| Requester ↓ / Agent → | old/stock daemon | updated daemon (plain) | updated + `--auto-answer` |
+|---|---|---|---|
+| stock `pilotctl` | dial-back (as today) | dial-back | dial-back |
+| `--reply-on-conn` | dial-back (auto-resend as TEXT) | dial-back (saved) | **reply-on-connection** ✅ |
+
+`--reply-on-conn` always delivers a reply — it falls back to dial-back against
+any non-`--auto-answer` agent. The new on-connection benefit (no dial-back, works
+when the sender is unreachable) is gained only against `--auto-answer` agents, so
+roll the daemon out to receivers to extend that benefit; the flag is safe to use
+before then.
+
+## Semantics & flag interactions
+
+- **At-least-once dispatch.** If an on-connection reply is lost in flight (relay
+  hiccup) or the agent exceeds the window, the client resends as plain TEXT to
+  guarantee delivery — which can cause the agent to process the request **twice**.
+  This is fine for the read-only directory/specialist queries reply-on-connection
+  is meant for; do not use it for non-idempotent requests.
+- **Timeout chain (strictly increasing).** responder fetch `35s` < daemon
+  `--auto-answer` HTTP `38s` < service `autoAnswerWindow` `40s` ≤ sender
+  on-connection read `45s`. The on-connection read window is **independent of
+  `--wait`** (which only bounds the later inbox poll).
+- **Flag interactions.** `--reply-on-conn` rejects `--type binary` (the request
+  is sent as a text query); it is ignored under `--trace` (trace wins); and it
+  forces a fresh connection per send (an `--auto-answer` receiver closes after
+  one request+reply, so `--reuse-conn` cannot apply).
+
+## Limitations
+
+- **Scope: receivers that run a client which reads the reply.** Reply-on-connection
+  delivers to any sender whose client reads the reply off the connection (updated
+  `pilotctl`/SDK). It does not change outcomes for transient clients that have no
+  daemon/inbox at all.
+- **Sender-side fan-out is out of scope.** A single requester daemon opening
+  *many* simultaneous dials (dozens at once) can hit sender-side `dial` failures
+  under NAT/relay pressure. This is a property of overloading one sender daemon —
+  not of the `--auto-answer` receiver, which dropped zero replies under test.
+  Regular requesters issue only a few dials and are unaffected; we do not expect
+  or support a single requester fanning out at that level.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/pilot-protocol/app-store v0.2.0
 	github.com/pilot-protocol/beacon v0.2.5
 	github.com/pilot-protocol/common v0.4.8
-	github.com/pilot-protocol/dataexchange v0.2.0
+	github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260607214932-68dd65364867
 	github.com/pilot-protocol/eventstream v0.2.2
 	github.com/pilot-protocol/handshake v0.2.1
 	github.com/pilot-protocol/nameserver v0.2.1
@@ -18,10 +18,10 @@ require (
 	github.com/pilot-protocol/trustedagents v0.2.3
 	github.com/pilot-protocol/updater v0.2.2-0.20260529065627-220ed5b8383f
 	github.com/pilot-protocol/webhook v0.2.0
+	golang.org/x/sys v0.45.0
 )
 
 require (
 	github.com/expr-lang/expr v1.17.8 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/pilot-protocol/common v0.4.8 h1:eS2Bc+XcZWJ/qhwwOZbXwIWhtNdOijuoEp716
 github.com/pilot-protocol/common v0.4.8/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
 github.com/pilot-protocol/dataexchange v0.2.0 h1:ldE6AyrES1uvdnn1NBl0KZ7C+SSWNtmeHHU3CQhwSCo=
 github.com/pilot-protocol/dataexchange v0.2.0/go.mod h1:JVy2+hr/IjzMPshxjExbGO/4SbJTs7ZJ7iYvT/ODF3Q=
+github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260607214932-68dd65364867 h1:rbh9s8sB33wl++71TarNIZsLTYgnYBR2vBhteUXosYQ=
+github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260607214932-68dd65364867/go.mod h1:tIFRJOxjM3UwtT0VjHJX3xBZ6BUpWY4TQDrPvURz/bo=
 github.com/pilot-protocol/eventstream v0.2.2 h1:E0IjveK7K+dsIbE/5hD3N821FkHzxVsx1tiAORMzt8k=
 github.com/pilot-protocol/eventstream v0.2.2/go.mod h1:gUjoMEItW1SRJYEq39VlcIeDe2LcE5B18/4bcaUJNrs=
 github.com/pilot-protocol/handshake v0.2.0 h1:uLeV8iNHcsHbcVH+GZ9p7uuIbObA8BReDByF5XGjzB8=


### PR DESCRIPTION
## What
The daemon + CLI halves of **reply-on-connection** (the data-exchange piece is the dataexchange PR):
- **Daemon `--auto-answer <url>`** — SPECIALISED, directory/service agents only (regular nodes must not set it): dispatches a `TypeAutoAnswer` request to the responder's `/dispatch` and writes the reply back on the same connection.
- **`pilotctl send-message --reply-on-conn`** (env `PILOT_REPLY_ON_CONN=1`): sends `TypeAutoAnswer`, reads the reply off the connection into `~/.pilot/inbox/` (same format as a dial-back reply), with no `--wait` and no dial-back.

## Always safe — never worse than a plain send
`--reply-on-conn` inspects the ack:
- `ACK+REPLY` → read the reply on the connection (an `--auto-answer` agent);
- ack names the `AUTOANSWER` type → an updated agent saved it for dial-back;
- anything else (old/stock agent acks `UNKNOWN`) → **auto-resend as plain TEXT** so a normal dial-back delivers it.

Verified live against the real stock list-agents (19/20 ≡ a stock requester's 19/20).

## Gating / non-disruption
The new loop is gated on the **request type**, so current senders (plain TEXT) are served exactly as before — safe to enable `--auto-answer` on a live directory agent.

## Correctness
- Reply read bounded at `dataexchange.MaxFrameSize` (matches the dial-back path — no truncation of large replies).
- Reply hook only trusts HTTP 200 (204/4xx → fall back).
- Strict timeout chain: responder fetch 35s < daemon hook 38s < service window 40s < sender read 45s.
- Flag interactions: `--reply-on-conn` rejects `--type binary`, is ignored under `--trace`, and forces a fresh connection (incompatible with `--reuse-conn`).

## Tests
`cmd/daemon/zz_autoanswer_test.go` (reply hook: large-body-not-truncated, status codes) and `cmd/pilotctl/zz_replyonconn_test.go` (outcome decision, `saveReplyToInbox` format, sends TypeAutoAnswer, falls back to TEXT).

## Reviewer note
`go.mod` currently pins `dataexchange` to the **branch** (pseudo-version) so this builds before the dataexchange release. Bump to `dataexchange v0.3.0` at release.

---
Load-tested + validated on a list-agents clone and the real list-agents: **0 receiver-side reply drops across ~45k requests.**
