### PR TITLE
feat(daemon): always-on app-store supervisor

### DIFF
--- a/cmd/daemon/appstore_adapter.go
+++ b/cmd/daemon/appstore_adapter.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Inline adapter from *appstore.Service to coreapi.Service.
+//
+// The app-store module (separate go.mod) ships an
+// integration.Adapter in its own integration/ package, but we don't
+// want web4 to pull in that whole separate module — the adapter is
+// 4 method shims. Duplicating them here keeps web4 self-buildable.
+//
+// Lockstep contract: if app-store/integration/adapter.go ever needs
+// a field added to its Start translation (new coreapi.Deps field
+// propagating into appstore.Deps), this file must follow.
+
+package main
+
+import (
+	"context"
+
+	"github.com/pilot-protocol/app-store/plugin/appstore"
+	"github.com/pilot-protocol/common/coreapi"
+)
+
+type appstoreAdapter struct {
+	svc *appstore.Service
+}
+
+func (a *appstoreAdapter) Name() string { return a.svc.Name() }
+func (a *appstoreAdapter) Order() int   { return a.svc.Order() }
+func (a *appstoreAdapter) Start(ctx context.Context, deps coreapi.Deps) error {
+	return a.svc.Start(ctx, appstore.Deps{
+		Streams:  deps.Streams,
+		Identity: deps.Identity,
+		Resolver: deps.Resolver,
+		Events:   deps.Events,
+		Logger:   deps.Logger,
+		Trust:    deps.Trust,
+	})
+}
+func (a *appstoreAdapter) Stop(ctx context.Context) error { return a.svc.Stop(ctx) }
+
+// Compile-time check — the build breaks loudly if coreapi.Service ever
+// drifts away from this shape.
+var _ coreapi.Service = (*appstoreAdapter)(nil)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -23,6 +24,7 @@ import (
 	// L11 plugin imports — cmd/daemon (L12) is the only place these
 	// are allowed. The daemon proper imports only pkg/coreapi
 	// interfaces.
+	"github.com/pilot-protocol/app-store/plugin/appstore"
 	"github.com/pilot-protocol/dataexchange"
 	"github.com/pilot-protocol/eventstream"
 	"github.com/pilot-protocol/handshake"
@@ -258,6 +260,28 @@ func main() {
 		log.Fatalf("register webhook: %v", err)
 	}
 	d.RegisterWebhookManager(webhookManagerAdapter{svc: webhookSvc})
+
+	// App store — ALWAYS on. The supervisor scans <home>/.pilot/apps
+	// every 2s, verifies each installed bundle's manifest signature
+	// against its embedded publisher, and spawns the app's binary under
+	// a child supervisor with an IPC socket the daemon brokers to. No
+	// flag gates this: apps are installed individually (via
+	// `pilotctl appstore install`), but the supervisor is part of every
+	// daemon process from now on.
+	//
+	// Default-on rationale: pilotctl appstore install/list/call all
+	// assume the supervisor is running. Gating it behind a flag would
+	// silently break those commands on hosts that forgot to enable it.
+	appstoreInstallRoot := ""
+	if home, herr := os.UserHomeDir(); herr == nil {
+		appstoreInstallRoot = filepath.Join(home, ".pilot", "apps")
+	}
+	if err := rt.Register(&appstoreAdapter{svc: appstore.NewService(appstore.Config{
+		InstallRoot:    appstoreInstallRoot,
+		RescanInterval: 2 * time.Second,
+	})}); err != nil {
+		log.Fatalf("register appstore: %v", err)
+	}
 
 	// T4.1: subscribe plugins to the bus BEFORE Daemon.Start so the
 	// webhook plugin captures the node.registered / agent.registered

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -71,12 +71,12 @@ var (
 type Config struct {
 	RegistryAddr        string
 	BeaconAddr          string
-	ListenAddr          string // UDP listen address for tunnel traffic
-	SocketPath          string // Unix socket path for IPC
+	ListenAddr          string   // UDP listen address for tunnel traffic
+	SocketPath          string   // Unix socket path for IPC
 	IPCWhitelist        []string // process names (comm) trusted to bypass per-client dial quota (PILOT-346)
-	Encrypt             bool   // enable tunnel-layer encryption (X25519 + AES-256-GCM)
-	RegistryTLS         bool   // use TLS for registry connection
-	RegistryFingerprint string // hex SHA-256 fingerprint for TLS cert pinning
+	Encrypt             bool     // enable tunnel-layer encryption (X25519 + AES-256-GCM)
+	RegistryTLS         bool     // use TLS for registry connection
+	RegistryFingerprint string   // hex SHA-256 fingerprint for TLS cert pinning
 	// RegistryTrust selects which trust store verifies the registry's
 	// certificate when RegistryTLS=true. "pinned" (default) requires
 	// RegistryFingerprint and is what production deploys use today.
@@ -251,11 +251,11 @@ type Daemon struct {
 	// rotation eliminates the shared-buffer hazard without changing the
 	// existing RLock/RUnlock pattern for non-rotating Sign callers.
 	rotateKeyMu sync.Mutex
-	regConn        *registry.Client
-	tunnels        *TunnelManager
-	ports          *PortManager
-	ipc            *IPCServer
-	handshakes     HandshakeService
+	regConn     *registry.Client
+	tunnels     *TunnelManager
+	ports       *PortManager
+	ipc         *IPCServer
+	handshakes  HandshakeService
 
 	// handshakeInFlight tracks peers with an outbound trust-handshake
 	// currently in progress on this daemon. Per-peer keyed

--- a/pkg/daemon/ipc.go
+++ b/pkg/daemon/ipc.go
@@ -151,7 +151,7 @@ type ipcConn struct {
 
 	// peerPID is the PID of the connected process (Linux SO_PEERCRED,
 	// 0 on Darwin/other). Used for IPC whitelist matching (PILOT-346).
-	peerPID    int32
+	peerPID     int32
 	whitelisted bool // bypasses per-client dial quota (PILOT-346)
 
 	// dialCancels holds cancel funcs for in-flight DialConnection calls


### PR DESCRIPTION
## Summary

Wires \`appstore.NewService\` unconditionally into pilot-daemon, pointed at \`~/.pilot/apps\` with a 2 s rescan. **No flag**, no config knob — per the directive that the daemon must always have the appstore active.

Until now the daemon never loaded the app-store plugin, so every \`pilotctl appstore\` subcommand (\`install\`, \`list\`, \`call\`, \`uninstall\`, ...) silently did nothing useful on any host.

## Why inline the adapter

\`app-store/integration/\` ships a real \`coreapi.Service\` adapter, but it's a separate Go module which web4 doesn't otherwise depend on. Rather than pull in the whole module for a 4-method shim, the adapter is inlined at \`cmd/daemon/appstore_adapter.go\`. A compile-time \`var _ coreapi.Service = (*appstoreAdapter)(nil)\` assertion breaks the build loudly if \`coreapi.Service\` ever drifts.

## Verification

End-to-end smoke test lands in #PR_3 (\`scripts/smoke-test-appstore.sh\`). On every run against this PR's branch:

- Daemon starts cleanly with the supervisor log line \`appstore starting: install_root=<home>/.pilot/apps installed_apps=N\`.
- Wallet installed via \`pilotctl appstore install\` is picked up within the rescan window, spawned, IPC reachable.
- \`pilotctl appstore uninstall\` propagates: daemon logs \`removed from disk; supervise goroutine canceled\`.

## Test plan

- [x] \`go vet ./cmd/daemon\` clean
- [x] \`go build ./cmd/daemon\` clean
- [x] Live smoke test green (lands in #PR_3 with the test script)