### PR TITLE
feat(pilotctl): appstore gen-key + sign for app publishers

### DIFF
--- a/cmd/pilotctl/appstore.go
+++ b/cmd/pilotctl/appstore.go
@@ -63,6 +63,10 @@ func cmdAppStore(args []string) {
 		cmdAppStoreVerify(args[1:])
 	case "install":
 		cmdAppStoreInstall(args[1:])
+	case "gen-key":
+		cmdAppStoreGenKey(args[1:])
+	case "sign":
+		cmdAppStoreSign(args[1:])
 	case "restart":
 		cmdAppStoreRestart(args[1:])
 	case "caps":
@@ -73,7 +77,7 @@ func cmdAppStore(args []string) {
 		appStoreHelp()
 	default:
 		fatalHint("invalid_argument",
-			"available: list, status, audit, uninstall, verify, install, restart, caps, actions, call",
+			"available: list, status, audit, uninstall, verify, install, gen-key, sign, restart, caps, actions, call",
 			"unknown appstore subcommand: %s", args[0])
 	}
 }
@@ -97,6 +101,9 @@ Usage:
   pilotctl appstore verify <bundle-dir>      sha256-check a pre-install bundle against its manifest
   pilotctl appstore install <bundle-dir> [--force]
                                              stage + atomically place a verified bundle into the install root
+  pilotctl appstore gen-key <key-file>       generate a fresh ed25519 publisher keypair; prints the public side
+  pilotctl appstore sign --key <key-file> <manifest>
+                                             sign (or re-sign) a manifest's store.signature so the supervisor accepts it
   pilotctl appstore restart <id>             ask the daemon to clear crash-loop suspension and respawn this app
   pilotctl appstore caps <id>                show the manifest's spend caps and current rolling-window usage
   pilotctl appstore actions [--tail N] [--event NAME]

--- a/cmd/pilotctl/appstore_sign.go
+++ b/cmd/pilotctl/appstore_sign.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// pilotctl appstore sign / gen-key — publisher-side manifest signing.
+//
+// The app-store supervisor refuses to spawn an app whose manifest's
+// ed25519 store.signature doesn't verify against store.publisher. This
+// file gives an operator the two commands needed to publish a bundle:
+//
+//   1. gen-key — once per publisher identity, write a fresh
+//      ed25519 private key to disk. The matching public key is
+//      printed so it can be pasted into the manifest.
+//
+//   2. sign --key <key> <manifest> — recompute the canonical signing
+//      payload (publisher || ":" || id || ":" || manifest_version ||
+//      ":" || binary.sha256 || ":" || grants-sha256-hex) and write
+//      a fresh signature into the manifest's store fields. Publisher
+//      is also rewritten to match the key — preventing the
+//      footgun where someone swaps the key but leaves a stale
+//      publisher line and ships a half-broken bundle.
+//
+// Format note: the signing payload is reconstructed manually here
+// because manifest.signingPayload is package-private. The format is
+// documented in app-store/pkg/manifest/manifest.go:185 — keep them in
+// lockstep.
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pilot-protocol/app-store/pkg/manifest"
+)
+
+func cmdAppStoreGenKey(args []string) {
+	if len(args) != 1 {
+		fatalHint("invalid_argument",
+			"usage: pilotctl appstore gen-key <key-file>",
+			"missing or extra argument")
+	}
+	keyFile := args[0]
+	if _, err := os.Stat(keyFile); err == nil {
+		fatalHint("invalid_argument",
+			"refuse to overwrite an existing key; pass a fresh path or remove the old one first",
+			"%s already exists", keyFile)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		fatalHint("crypto_error", "the ed25519 keygen failed; retry once", "generate: %v", err)
+	}
+	if err := os.WriteFile(keyFile, []byte(hex.EncodeToString(priv)), 0o600); err != nil {
+		fatalHint("io_error",
+			"check the parent dir is writable and not full",
+			"write key: %v", err)
+	}
+	fmt.Printf("private key written to %s (mode 0600 — protect this file)\n", keyFile)
+	fmt.Printf("publisher (paste verbatim into manifest.store.publisher):\n")
+	fmt.Printf("ed25519:%s\n", base64.StdEncoding.EncodeToString(pub))
+}
+
+func cmdAppStoreSign(args []string) {
+	var keyFile string
+	rest := args
+	for len(rest) > 0 {
+		switch rest[0] {
+		case "--key", "-k":
+			if len(rest) < 2 {
+				fatalHint("invalid_argument",
+					"--key takes a path",
+					"missing value after %s", rest[0])
+			}
+			keyFile = rest[1]
+			rest = rest[2:]
+		default:
+			if keyFile == "" {
+				fatalHint("invalid_argument",
+					"usage: pilotctl appstore sign --key <key-file> <manifest>",
+					"--key must come before the manifest path")
+			}
+			// Anything that isn't a flag is the manifest path.
+			break
+		}
+		if len(rest) > 0 && rest[0] != "--key" && rest[0] != "-k" {
+			break
+		}
+	}
+	if keyFile == "" || len(rest) == 0 {
+		fatalHint("invalid_argument",
+			"usage: pilotctl appstore sign --key <key-file> <manifest>",
+			"missing --key or manifest path")
+	}
+	mfPath := rest[0]
+
+	keyHex, err := os.ReadFile(keyFile)
+	if err != nil {
+		fatalHint("io_error",
+			"the key path doesn't exist or is unreadable; did you mean a different file?",
+			"read key: %v", err)
+	}
+	privBytes, err := hex.DecodeString(string(keyHex))
+	if err != nil {
+		fatalHint("invalid_argument",
+			"the file should be a single hex-encoded ed25519 private key — same shape `pilotctl appstore gen-key` produces",
+			"decode key: %v", err)
+	}
+	if len(privBytes) != ed25519.PrivateKeySize {
+		fatalHint("invalid_argument",
+			fmt.Sprintf("expected %d bytes; got %d — wrong file?", ed25519.PrivateKeySize, len(privBytes)),
+			"key length mismatch")
+	}
+	priv := ed25519.PrivateKey(privBytes)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	raw, err := os.ReadFile(mfPath)
+	if err != nil {
+		fatalHint("io_error",
+			"pass the path to a manifest.json file",
+			"read manifest: %v", err)
+	}
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		fatalHint("invalid_argument",
+			"the manifest JSON failed to parse; check it loads without errors first",
+			"parse: %v", err)
+	}
+
+	// Set publisher to match the supplied key BEFORE building the
+	// signing payload — the publisher is part of the payload, so any
+	// mismatch would silently produce a signature that doesn't verify.
+	m.Store.Publisher = "ed25519:" + base64.StdEncoding.EncodeToString(pub)
+
+	// Canonical signing payload — must match manifest.signingPayload
+	// in the app-store package (private). See manifest.go:185.
+	grantsJSON, err := json.Marshal(m.Grants)
+	if err != nil {
+		fatalHint("internal_error",
+			"the manifest's grants slice failed to marshal — bug",
+			"%v", err)
+	}
+	grantsHash := sha256.Sum256(grantsJSON)
+	payload := fmt.Sprintf("%s:%s:%d:%s:%x",
+		m.Store.Publisher, m.ID, m.ManifestVersion, m.Binary.SHA256, grantsHash)
+
+	sig := ed25519.Sign(priv, []byte(payload))
+	m.Store.Signature = base64.StdEncoding.EncodeToString(sig)
+
+	// Self-verify before writing — refuse to ship a manifest the
+	// supervisor will then reject. Belt-and-braces: a future
+	// change to the payload format would surface here, not at
+	// install time.
+	if err := m.VerifySignature(); err != nil {
+		fatalHint("internal_error",
+			"self-verify after signing failed — pilotctl and the app-store package may be on different signing-payload formats; rebuild pilotctl",
+			"%v", err)
+	}
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		fatalHint("internal_error", "marshal signed manifest", "%v", err)
+	}
+	if err := os.WriteFile(mfPath, out, 0o644); err != nil {
+		fatalHint("io_error",
+			"check the manifest path is writable",
+			"write manifest: %v", err)
+	}
+	fmt.Printf("signed %s\n", mfPath)
+	fmt.Printf("publisher: %s\n", m.Store.Publisher)
+}


### PR DESCRIPTION
**Stacked on #231.** Review #231 first.

## Summary

The supervisor refuses any manifest whose ed25519 \`store.signature\` doesn't verify against \`store.publisher\`. Until now, signing required a one-off Go program — publishers couldn't ship a bundle without first writing their own tool. This adds the missing publisher-side commands:

\`\`\`bash
# generate the keypair (once per publisher identity)
pilotctl appstore gen-key /secure/path/publisher.key
# → prints \`ed25519:<base64>\` to paste into manifest.store.publisher

# sign (or re-sign) a manifest in-place
pilotctl appstore sign --key /secure/path/publisher.key path/to/manifest.json
\`\`\`

## Footgun guard

\`sign\` **rewrites \`store.publisher\` to match the supplied key** before computing the signature. The publisher field is part of the signing payload, so a stale publisher line would silently produce a signature that doesn't verify. Forcing them to match means the round-trip always succeeds.

Trade-off: the key file by itself is enough to claim any publisher identity — which is intentional. Publisher identity IS the key. Treat \`publisher.key\` accordingly.

## Test plan

- [x] \`go vet ./cmd/pilotctl\` clean
- [x] \`go build ./cmd/pilotctl\` clean
- [x] Round-trip verified live: \`gen-key\` → \`sign\` → \`manifest.VerifySignature\` passes (covered by smoke test in #PR_3)