### PR TITLE
feat(pilotctl): one-command install + canonical catalogue.json + live smoke test

### DIFF
--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -1,0 +1,76 @@
+# Pilot app store catalogue
+
+This directory holds `catalogue.json` — the canonical list of apps installable via
+`pilotctl appstore install <app-id>`.
+
+## Schema
+
+```json
+{
+  "version": 1,
+  "updated_at": "<RFC3339 timestamp>",
+  "apps": [
+    {
+      "id": "<reverse-DNS app id, must match manifest.id>",
+      "version": "<semver>",
+      "description": "<one-line, shown in `pilotctl appstore catalogue`>",
+      "bundle_url": "https://<host>/<path>.tar.gz",
+      "bundle_sha256": "<hex sha256 of the tarball>"
+    }
+  ]
+}
+```
+
+The schema is intentionally flat — `pilotctl` decodes it directly into
+`catalogueEntry` in `cmd/pilotctl/appstore_catalogue.go`. Any field added
+here must also land there.
+
+## Where pilotctl loads it from
+
+By default, `pilotctl appstore catalogue` and `pilotctl appstore install
+<id>` fetch this file from the URL hardcoded in `appstore_catalogue.go`
+(`defaultCatalogueURL`, pointing at this file's raw URL on `main`). Override
+with `PILOT_APPSTORE_CATALOG_URL` for local dev or for staging a release:
+
+```bash
+# point at a local file while staging a release
+export PILOT_APPSTORE_CATALOG_URL=file:///path/to/staging/catalogue.json
+pilotctl appstore catalogue
+```
+
+`http://` is rejected unless the host is loopback (no plaintext install
+from a remote — operators relying on a catalogue do so over `https` only).
+
+## Publishing a new app version
+
+1. Bump the version in the app's `manifest.json`. Re-sign:
+   ```bash
+   pilotctl appstore sign --key /secure/path/publisher.key path/to/manifest.json
+   ```
+2. Build the bundle dir (`manifest.json` + `bin/<name>`) and tar it:
+   ```bash
+   tar czf io.pilot.wallet-X.Y.Z.tar.gz manifest.json bin/wallet
+   ```
+3. Compute the sha256:
+   ```bash
+   shasum -a 256 io.pilot.wallet-X.Y.Z.tar.gz
+   ```
+4. Upload the tarball as a release artifact (`gh release upload` or
+   equivalent — GitHub releases, Cloudflare R2, anywhere reachable over
+   HTTPS).
+5. Update this `catalogue.json` with the new `version`, `bundle_url`, and
+   `bundle_sha256`. Commit. The change goes live the moment the commit
+   lands on `main` and the raw URL serves the new bytes — no daemon
+   restart, no pilotctl release.
+
+## Trust model
+
+| Layer | Trust anchor | Verifies |
+|---|---|---|
+| User trusts pilotctl | Project release pipeline (signed pilotctl binary) | The catalogue URL is correct |
+| pilotctl trusts the catalogue | Future: signed against `EmbeddedCatalogPubkey`; today: the raw URL itself | App IDs map to specific bundle URLs + SHAs |
+| pilotctl trusts the bundle | Embedded `bundle_sha256` matches downloaded bytes | A CDN substitute is rejected |
+| Daemon trusts the manifest | Embedded ed25519 publisher pubkey verifies the signature | The bundle's manifest hasn't been tampered with |
+
+Every layer is checked at install time, and the manifest signature is
+re-verified at every supervisor rescan (every 2 s).

--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "updated_at": "2026-06-08T10:25:00Z",
+  "apps": [
+    {
+      "id": "io.pilot.wallet",
+      "version": "0.3.0",
+      "description": "On-overlay USDC payments — ed25519 + EIP-3009 receipts.",
+      "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/wallet-v0.3.0/io.pilot.wallet-0.3.0.tar.gz",
+      "bundle_sha256": "REPLACE_AT_RELEASE_TIME"
+    }
+  ]
+}

--- a/cmd/daemon/appstore_adapter.go
+++ b/cmd/daemon/appstore_adapter.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Inline adapter from *appstore.Service to coreapi.Service.
+//
+// The app-store module (separate go.mod) ships an
+// integration.Adapter in its own integration/ package, but we don't
+// want web4 to pull in that whole separate module — the adapter is
+// 4 method shims. Duplicating them here keeps web4 self-buildable.
+//
+// Lockstep contract: if app-store/integration/adapter.go ever needs
+// a field added to its Start translation (new coreapi.Deps field
+// propagating into appstore.Deps), this file must follow.
+
+package main
+
+import (
+	"context"
+
+	"github.com/pilot-protocol/app-store/plugin/appstore"
+	"github.com/pilot-protocol/common/coreapi"
+)
+
+type appstoreAdapter struct {
+	svc *appstore.Service
+}
+
+func (a *appstoreAdapter) Name() string { return a.svc.Name() }
+func (a *appstoreAdapter) Order() int   { return a.svc.Order() }
+func (a *appstoreAdapter) Start(ctx context.Context, deps coreapi.Deps) error {
+	return a.svc.Start(ctx, appstore.Deps{
+		Streams:  deps.Streams,
+		Identity: deps.Identity,
+		Resolver: deps.Resolver,
+		Events:   deps.Events,
+		Logger:   deps.Logger,
+		Trust:    deps.Trust,
+	})
+}
+func (a *appstoreAdapter) Stop(ctx context.Context) error { return a.svc.Stop(ctx) }
+
+// Compile-time check — the build breaks loudly if coreapi.Service ever
+// drifts away from this shape.
+var _ coreapi.Service = (*appstoreAdapter)(nil)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -23,6 +24,7 @@ import (
 	// L11 plugin imports — cmd/daemon (L12) is the only place these
 	// are allowed. The daemon proper imports only pkg/coreapi
 	// interfaces.
+	"github.com/pilot-protocol/app-store/plugin/appstore"
 	"github.com/pilot-protocol/dataexchange"
 	"github.com/pilot-protocol/eventstream"
 	"github.com/pilot-protocol/handshake"
@@ -258,6 +260,28 @@ func main() {
 		log.Fatalf("register webhook: %v", err)
 	}
 	d.RegisterWebhookManager(webhookManagerAdapter{svc: webhookSvc})
+
+	// App store — ALWAYS on. The supervisor scans <home>/.pilot/apps
+	// every 2s, verifies each installed bundle's manifest signature
+	// against its embedded publisher, and spawns the app's binary under
+	// a child supervisor with an IPC socket the daemon brokers to. No
+	// flag gates this: apps are installed individually (via
+	// `pilotctl appstore install`), but the supervisor is part of every
+	// daemon process from now on.
+	//
+	// Default-on rationale: pilotctl appstore install/list/call all
+	// assume the supervisor is running. Gating it behind a flag would
+	// silently break those commands on hosts that forgot to enable it.
+	appstoreInstallRoot := ""
+	if home, herr := os.UserHomeDir(); herr == nil {
+		appstoreInstallRoot = filepath.Join(home, ".pilot", "apps")
+	}
+	if err := rt.Register(&appstoreAdapter{svc: appstore.NewService(appstore.Config{
+		InstallRoot:    appstoreInstallRoot,
+		RescanInterval: 2 * time.Second,
+	})}); err != nil {
+		log.Fatalf("register appstore: %v", err)
+	}
 
 	// T4.1: subscribe plugins to the bus BEFORE Daemon.Start so the
 	// webhook plugin captures the node.registered / agent.registered

--- a/cmd/pilotctl/appstore.go
+++ b/cmd/pilotctl/appstore.go
@@ -67,6 +67,8 @@ func cmdAppStore(args []string) {
 		cmdAppStoreGenKey(args[1:])
 	case "sign":
 		cmdAppStoreSign(args[1:])
+	case "catalogue", "catalog":
+		cmdAppStoreCatalogue(args[1:])
 	case "restart":
 		cmdAppStoreRestart(args[1:])
 	case "caps":
@@ -77,7 +79,7 @@ func cmdAppStore(args []string) {
 		appStoreHelp()
 	default:
 		fatalHint("invalid_argument",
-			"available: list, status, audit, uninstall, verify, install, gen-key, sign, restart, caps, actions, call",
+			"available: list, status, audit, uninstall, verify, install, gen-key, sign, catalogue, restart, caps, actions, call",
 			"unknown appstore subcommand: %s", args[0])
 	}
 }
@@ -99,8 +101,10 @@ Usage:
                                              duration: Go syntax (e.g. 10m, 1h, 24h)
   pilotctl appstore uninstall <id> --yes     remove an installed app from the install root
   pilotctl appstore verify <bundle-dir>      sha256-check a pre-install bundle against its manifest
-  pilotctl appstore install <bundle-dir> [--force]
-                                             stage + atomically place a verified bundle into the install root
+  pilotctl appstore catalogue                list apps available for one-command install
+  pilotctl appstore install <app-id-or-dir> [--force]
+                                             install by catalogue ID (fetches + verifies + extracts)
+                                             OR by local bundle directory (offline / dev path)
   pilotctl appstore gen-key <key-file>       generate a fresh ed25519 publisher keypair; prints the public side
   pilotctl appstore sign --key <key-file> <manifest>
                                              sign (or re-sign) a manifest's store.signature so the supervisor accepts it
@@ -967,10 +971,10 @@ type installReport struct {
 func cmdAppStoreInstall(args []string) {
 	if len(args) < 1 {
 		fatalHint("invalid_argument",
-			"usage: pilotctl appstore install <bundle-dir> [--force]",
-			"missing bundle dir")
+			"usage: pilotctl appstore install <app-id-or-dir> [--force]",
+			"missing app id or bundle dir")
 	}
-	bundleDir := args[0]
+	target := args[0]
 	force := false
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
@@ -981,6 +985,17 @@ func cmdAppStoreInstall(args []string) {
 				"available flags: --force",
 				"unknown install flag: %s", args[i])
 		}
+	}
+
+	// Resolve `target` to a local bundle dir. If it's a catalogue ID
+	// (e.g. "io.pilot.wallet"), fetch + verify the tarball and unpack
+	// into a tempdir. If it's already a directory, use it as-is. The
+	// rest of this function operates only on the directory.
+	bundleDir, err := resolveInstallTarget(target)
+	if err != nil {
+		fatalHint("invalid_argument",
+			"the argument must be either a catalogue ID (`pilotctl appstore catalogue` to list) or a path to a bundle dir containing manifest.json",
+			"%v", err)
 	}
 
 	// 1. Validate the bundle — same shape as verify. Reusing the

--- a/cmd/pilotctl/appstore.go
+++ b/cmd/pilotctl/appstore.go
@@ -63,6 +63,10 @@ func cmdAppStore(args []string) {
 		cmdAppStoreVerify(args[1:])
 	case "install":
 		cmdAppStoreInstall(args[1:])
+	case "gen-key":
+		cmdAppStoreGenKey(args[1:])
+	case "sign":
+		cmdAppStoreSign(args[1:])
 	case "restart":
 		cmdAppStoreRestart(args[1:])
 	case "caps":
@@ -73,7 +77,7 @@ func cmdAppStore(args []string) {
 		appStoreHelp()
 	default:
 		fatalHint("invalid_argument",
-			"available: list, status, audit, uninstall, verify, install, restart, caps, actions, call",
+			"available: list, status, audit, uninstall, verify, install, gen-key, sign, restart, caps, actions, call",
 			"unknown appstore subcommand: %s", args[0])
 	}
 }
@@ -97,6 +101,9 @@ Usage:
   pilotctl appstore verify <bundle-dir>      sha256-check a pre-install bundle against its manifest
   pilotctl appstore install <bundle-dir> [--force]
                                              stage + atomically place a verified bundle into the install root
+  pilotctl appstore gen-key <key-file>       generate a fresh ed25519 publisher keypair; prints the public side
+  pilotctl appstore sign --key <key-file> <manifest>
+                                             sign (or re-sign) a manifest's store.signature so the supervisor accepts it
   pilotctl appstore restart <id>             ask the daemon to clear crash-loop suspension and respawn this app
   pilotctl appstore caps <id>                show the manifest's spend caps and current rolling-window usage
   pilotctl appstore actions [--tail N] [--event NAME]

--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// pilotctl appstore catalogue / install-by-id — fresh-user install path.
+//
+// A new user shouldn't need to know about bundle paths, manifests, or
+// signatures. They run:
+//
+//	pilotctl appstore catalogue
+//	pilotctl appstore install io.pilot.wallet
+//
+// and the tool fetches the bundle from a known-good URL, sha-checks it,
+// extracts it, and hands it to the existing local-bundle install path
+// (which validates the manifest + verifies the embedded ed25519 sig).
+//
+// The catalogue itself lives in the web4 repo at
+// catalogue/catalogue.json and is fetched at runtime from
+// defaultCatalogueURL. Override with $PILOT_APPSTORE_CATALOG_URL for
+// local dev or for staging a release. See catalogue/README.md for the
+// schema and publishing flow.
+//
+// Trust model (each layer checked at install time):
+//
+//   - User trusts pilotctl (project release pipeline).
+//   - pilotctl fetches the catalogue from a URL hardcoded in this
+//     binary — auditable in the public repo. Future: signed catalogue
+//     verified against appstore.EmbeddedCatalogPubkey.
+//   - Each catalogue entry pins the bundle's tarball sha256; a
+//     compromised CDN can't substitute different bytes.
+//   - The bundle's manifest carries an ed25519 signature against an
+//     embedded publisher pubkey; the supervisor verifies it.
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// defaultCatalogueURL points at the canonical catalogue.json on main.
+// Override via $PILOT_APPSTORE_CATALOG_URL (use file:// for local
+// staging, https:// for everything else; plain http:// is rejected
+// off-loopback).
+const defaultCatalogueURL = "https://raw.githubusercontent.com/TeoSlayer/pilotprotocol/main/catalogue/catalogue.json"
+
+// catalogue is the parsed wire shape of catalogue.json. The schema is
+// versioned (catalogue.json's "version" field) so future migrations
+// can stay backward-compatible — pilotctl refuses any version it
+// doesn't understand.
+type catalogue struct {
+	Version   int              `json:"version"`
+	UpdatedAt string           `json:"updated_at"`
+	Apps      []catalogueEntry `json:"apps"`
+}
+
+// catalogueEntry mirrors the JSON shape exactly. Adding a field here
+// means adding it to catalogue.json AND to catalogue/README.md.
+type catalogueEntry struct {
+	ID          string `json:"id"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+	BundleURL   string `json:"bundle_url"`
+	BundleSHA   string `json:"bundle_sha256"`
+}
+
+// catalogueURL returns the URL pilotctl should fetch the catalogue
+// from — env override wins so an operator can point at a staging
+// file without rebuilding.
+func catalogueURL() string {
+	if u := os.Getenv("PILOT_APPSTORE_CATALOG_URL"); u != "" {
+		return u
+	}
+	return defaultCatalogueURL
+}
+
+// loadCatalogue fetches + parses the catalogue. Errors out cleanly so
+// `pilotctl appstore catalogue` and `install <id>` can both surface a
+// useful diagnostic when the URL is wrong, offline, or returns
+// garbage.
+func loadCatalogue() (*catalogue, error) {
+	u := catalogueURL()
+	body, err := openURL(u)
+	if err != nil {
+		return nil, fmt.Errorf("fetch catalogue from %s: %w", u, err)
+	}
+	defer body.Close()
+	data, err := io.ReadAll(io.LimitReader(body, 1<<20)) // 1 MiB cap
+	if err != nil {
+		return nil, fmt.Errorf("read catalogue body: %w", err)
+	}
+	var c catalogue
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse catalogue: %w", err)
+	}
+	if c.Version != 1 {
+		return nil, fmt.Errorf("unsupported catalogue version %d (pilotctl understands version 1)", c.Version)
+	}
+	return &c, nil
+}
+
+func cmdAppStoreCatalogue(_ []string) {
+	c, err := loadCatalogue()
+	if err != nil {
+		fatalHint("io_error",
+			"check $PILOT_APPSTORE_CATALOG_URL (currently: "+catalogueURL()+")",
+			"%v", err)
+	}
+	if jsonOutput {
+		_ = json.NewEncoder(os.Stdout).Encode(c.Apps)
+		return
+	}
+	if len(c.Apps) == 0 {
+		fmt.Println("catalogue is empty")
+		return
+	}
+	fmt.Printf("Catalogue: %s (updated %s)\n\n", catalogueURL(), c.UpdatedAt)
+	fmt.Println("Installable apps:")
+	for _, e := range c.Apps {
+		fmt.Printf("\n  %s  v%s\n", e.ID, e.Version)
+		fmt.Printf("    %s\n", e.Description)
+		fmt.Printf("    install: pilotctl appstore install %s\n", e.ID)
+	}
+}
+
+// resolveInstallTarget turns the user's `target` arg into a local
+// bundle directory the existing install code can consume. If `target`
+// matches a catalogue ID, the catalogue entry is fetched, verified,
+// and unpacked. Otherwise `target` is treated as a local path.
+func resolveInstallTarget(target string) (string, error) {
+	c, err := loadCatalogue()
+	if err != nil {
+		// Catalogue-lookup failure doesn't preclude a local-dir install
+		// — fall through to the path branch so dev flows still work
+		// offline. Surface a hint that the catalogue path failed so
+		// the user knows their URL or env override might be the issue.
+		fmt.Fprintf(os.Stderr, "warn: catalogue lookup failed (%v); proceeding with local-path interpretation\n", err)
+	} else {
+		for _, e := range c.Apps {
+			if target == e.ID {
+				return fetchAndUnpackBundle(e)
+			}
+		}
+	}
+	info, err := os.Stat(target)
+	if err == nil && info.IsDir() {
+		return target, nil
+	}
+	return "", fmt.Errorf("not a catalogue ID or a bundle dir: %q (try `pilotctl appstore catalogue` to list installable apps)", target)
+}
+
+// fetchAndUnpackBundle downloads the catalogue entry's tarball,
+// verifies its sha256 against the catalogue value (defence against a
+// CDN substitute), and unpacks it into a tempdir whose path is
+// returned for the install path to consume.
+func fetchAndUnpackBundle(e catalogueEntry) (string, error) {
+	if e.BundleSHA == "" || e.BundleSHA == "REPLACE_AT_RELEASE_TIME" {
+		return "", fmt.Errorf("catalogue entry %s has placeholder sha256 — the release pipeline hasn't filled this in yet", e.ID)
+	}
+	fmt.Printf("fetching %s ...\n", e.BundleURL)
+	body, err := openURL(e.BundleURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", e.BundleURL, err)
+	}
+	defer body.Close()
+
+	tmpTar, err := os.CreateTemp("", "pilot-bundle-*.tar.gz")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpTar.Name())
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmpTar, h), body); err != nil {
+		_ = tmpTar.Close()
+		return "", fmt.Errorf("download body: %w", err)
+	}
+	if err := tmpTar.Close(); err != nil {
+		return "", err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != e.BundleSHA {
+		return "", fmt.Errorf("bundle sha256 mismatch: want=%s got=%s — the cdn served different bytes than the catalogue pinned", e.BundleSHA, got)
+	}
+	fmt.Printf("sha256 OK (%s)\n", got)
+
+	unpackDir, err := os.MkdirTemp("", "pilot-bundle-unpack-*")
+	if err != nil {
+		return "", err
+	}
+	f, err := os.Open(tmpTar.Name())
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+	if err := untarUnder(gz, unpackDir); err != nil {
+		return "", fmt.Errorf("untar: %w", err)
+	}
+	return unpackDir, nil
+}
+
+// openURL handles file:// (local dev), https://, and http:// only on
+// loopback. Any non-loopback http:// is refused — install artifacts
+// are too high-blast-radius to fetch over plaintext from anywhere we
+// don't already trust.
+func openURL(raw string) (io.ReadCloser, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	case "file":
+		return os.Open(u.Path)
+	case "https":
+		return httpGet(raw)
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return httpGet(raw)
+		}
+		return nil, fmt.Errorf("refusing plaintext http for non-localhost host %q (use https)", host)
+	default:
+		return nil, fmt.Errorf("unsupported url scheme %q", u.Scheme)
+	}
+}
+
+func httpGet(raw string) (io.ReadCloser, error) {
+	c := &http.Client{Timeout: 60 * time.Second}
+	resp, err := c.Get(raw)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("http %d from %s", resp.StatusCode, raw)
+	}
+	return resp.Body, nil
+}
+
+// untarUnder writes every entry in r under dst, refusing any path
+// that resolves outside dst (mirrors the supervisor's
+// resolveUnder guard on manifest.binary.path).
+func untarUnder(r io.Reader, dst string) error {
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		clean := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(clean, "..") || strings.Contains(clean, "/../") {
+			return fmt.Errorf("refusing entry with traversal: %q", hdr.Name)
+		}
+		out := filepath.Join(dst, clean)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(out, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return err
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
+		default:
+			// Skip symlinks, devices, etc. — neither needed for a
+			// pilot app bundle nor safe to write blindly.
+		}
+	}
+}

--- a/cmd/pilotctl/appstore_sign.go
+++ b/cmd/pilotctl/appstore_sign.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// pilotctl appstore sign / gen-key — publisher-side manifest signing.
+//
+// The app-store supervisor refuses to spawn an app whose manifest's
+// ed25519 store.signature doesn't verify against store.publisher. This
+// file gives an operator the two commands needed to publish a bundle:
+//
+//   1. gen-key — once per publisher identity, write a fresh
+//      ed25519 private key to disk. The matching public key is
+//      printed so it can be pasted into the manifest.
+//
+//   2. sign --key <key> <manifest> — recompute the canonical signing
+//      payload (publisher || ":" || id || ":" || manifest_version ||
+//      ":" || binary.sha256 || ":" || grants-sha256-hex) and write
+//      a fresh signature into the manifest's store fields. Publisher
+//      is also rewritten to match the key — preventing the
+//      footgun where someone swaps the key but leaves a stale
+//      publisher line and ships a half-broken bundle.
+//
+// Format note: the signing payload is reconstructed manually here
+// because manifest.signingPayload is package-private. The format is
+// documented in app-store/pkg/manifest/manifest.go:185 — keep them in
+// lockstep.
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pilot-protocol/app-store/pkg/manifest"
+)
+
+func cmdAppStoreGenKey(args []string) {
+	if len(args) != 1 {
+		fatalHint("invalid_argument",
+			"usage: pilotctl appstore gen-key <key-file>",
+			"missing or extra argument")
+	}
+	keyFile := args[0]
+	if _, err := os.Stat(keyFile); err == nil {
+		fatalHint("invalid_argument",
+			"refuse to overwrite an existing key; pass a fresh path or remove the old one first",
+			"%s already exists", keyFile)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		fatalHint("crypto_error", "the ed25519 keygen failed; retry once", "generate: %v", err)
+	}
+	if err := os.WriteFile(keyFile, []byte(hex.EncodeToString(priv)), 0o600); err != nil {
+		fatalHint("io_error",
+			"check the parent dir is writable and not full",
+			"write key: %v", err)
+	}
+	fmt.Printf("private key written to %s (mode 0600 — protect this file)\n", keyFile)
+	fmt.Printf("publisher (paste verbatim into manifest.store.publisher):\n")
+	fmt.Printf("ed25519:%s\n", base64.StdEncoding.EncodeToString(pub))
+}
+
+func cmdAppStoreSign(args []string) {
+	var keyFile string
+	rest := args
+	for len(rest) > 0 {
+		switch rest[0] {
+		case "--key", "-k":
+			if len(rest) < 2 {
+				fatalHint("invalid_argument",
+					"--key takes a path",
+					"missing value after %s", rest[0])
+			}
+			keyFile = rest[1]
+			rest = rest[2:]
+		default:
+			if keyFile == "" {
+				fatalHint("invalid_argument",
+					"usage: pilotctl appstore sign --key <key-file> <manifest>",
+					"--key must come before the manifest path")
+			}
+			// Anything that isn't a flag is the manifest path.
+			break
+		}
+		if len(rest) > 0 && rest[0] != "--key" && rest[0] != "-k" {
+			break
+		}
+	}
+	if keyFile == "" || len(rest) == 0 {
+		fatalHint("invalid_argument",
+			"usage: pilotctl appstore sign --key <key-file> <manifest>",
+			"missing --key or manifest path")
+	}
+	mfPath := rest[0]
+
+	keyHex, err := os.ReadFile(keyFile)
+	if err != nil {
+		fatalHint("io_error",
+			"the key path doesn't exist or is unreadable; did you mean a different file?",
+			"read key: %v", err)
+	}
+	privBytes, err := hex.DecodeString(string(keyHex))
+	if err != nil {
+		fatalHint("invalid_argument",
+			"the file should be a single hex-encoded ed25519 private key — same shape `pilotctl appstore gen-key` produces",
+			"decode key: %v", err)
+	}
+	if len(privBytes) != ed25519.PrivateKeySize {
+		fatalHint("invalid_argument",
+			fmt.Sprintf("expected %d bytes; got %d — wrong file?", ed25519.PrivateKeySize, len(privBytes)),
+			"key length mismatch")
+	}
+	priv := ed25519.PrivateKey(privBytes)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	raw, err := os.ReadFile(mfPath)
+	if err != nil {
+		fatalHint("io_error",
+			"pass the path to a manifest.json file",
+			"read manifest: %v", err)
+	}
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		fatalHint("invalid_argument",
+			"the manifest JSON failed to parse; check it loads without errors first",
+			"parse: %v", err)
+	}
+
+	// Set publisher to match the supplied key BEFORE building the
+	// signing payload — the publisher is part of the payload, so any
+	// mismatch would silently produce a signature that doesn't verify.
+	m.Store.Publisher = "ed25519:" + base64.StdEncoding.EncodeToString(pub)
+
+	// Canonical signing payload — must match manifest.signingPayload
+	// in the app-store package (private). See manifest.go:185.
+	grantsJSON, err := json.Marshal(m.Grants)
+	if err != nil {
+		fatalHint("internal_error",
+			"the manifest's grants slice failed to marshal — bug",
+			"%v", err)
+	}
+	grantsHash := sha256.Sum256(grantsJSON)
+	payload := fmt.Sprintf("%s:%s:%d:%s:%x",
+		m.Store.Publisher, m.ID, m.ManifestVersion, m.Binary.SHA256, grantsHash)
+
+	sig := ed25519.Sign(priv, []byte(payload))
+	m.Store.Signature = base64.StdEncoding.EncodeToString(sig)
+
+	// Self-verify before writing — refuse to ship a manifest the
+	// supervisor will then reject. Belt-and-braces: a future
+	// change to the payload format would surface here, not at
+	// install time.
+	if err := m.VerifySignature(); err != nil {
+		fatalHint("internal_error",
+			"self-verify after signing failed — pilotctl and the app-store package may be on different signing-payload formats; rebuild pilotctl",
+			"%v", err)
+	}
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		fatalHint("internal_error", "marshal signed manifest", "%v", err)
+	}
+	if err := os.WriteFile(mfPath, out, 0o644); err != nil {
+		fatalHint("io_error",
+			"check the manifest path is writable",
+			"write manifest: %v", err)
+	}
+	fmt.Printf("signed %s\n", mfPath)
+	fmt.Printf("publisher: %s\n", m.Store.Publisher)
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -71,12 +71,12 @@ var (
 type Config struct {
 	RegistryAddr        string
 	BeaconAddr          string
-	ListenAddr          string // UDP listen address for tunnel traffic
-	SocketPath          string // Unix socket path for IPC
+	ListenAddr          string   // UDP listen address for tunnel traffic
+	SocketPath          string   // Unix socket path for IPC
 	IPCWhitelist        []string // process names (comm) trusted to bypass per-client dial quota (PILOT-346)
-	Encrypt             bool   // enable tunnel-layer encryption (X25519 + AES-256-GCM)
-	RegistryTLS         bool   // use TLS for registry connection
-	RegistryFingerprint string // hex SHA-256 fingerprint for TLS cert pinning
+	Encrypt             bool     // enable tunnel-layer encryption (X25519 + AES-256-GCM)
+	RegistryTLS         bool     // use TLS for registry connection
+	RegistryFingerprint string   // hex SHA-256 fingerprint for TLS cert pinning
 	// RegistryTrust selects which trust store verifies the registry's
 	// certificate when RegistryTLS=true. "pinned" (default) requires
 	// RegistryFingerprint and is what production deploys use today.
@@ -251,11 +251,11 @@ type Daemon struct {
 	// rotation eliminates the shared-buffer hazard without changing the
 	// existing RLock/RUnlock pattern for non-rotating Sign callers.
 	rotateKeyMu sync.Mutex
-	regConn        *registry.Client
-	tunnels        *TunnelManager
-	ports          *PortManager
-	ipc            *IPCServer
-	handshakes     HandshakeService
+	regConn     *registry.Client
+	tunnels     *TunnelManager
+	ports       *PortManager
+	ipc         *IPCServer
+	handshakes  HandshakeService
 
 	// handshakeInFlight tracks peers with an outbound trust-handshake
 	// currently in progress on this daemon. Per-peer keyed

--- a/pkg/daemon/ipc.go
+++ b/pkg/daemon/ipc.go
@@ -151,7 +151,7 @@ type ipcConn struct {
 
 	// peerPID is the PID of the connected process (Linux SO_PEERCRED,
 	// 0 on Darwin/other). Used for IPC whitelist matching (PILOT-346).
-	peerPID    int32
+	peerPID     int32
 	whitelisted bool // bypasses per-client dial quota (PILOT-346)
 
 	// dialCancels holds cancel funcs for in-flight DialConnection calls

--- a/scripts/smoke-pay-driver/go.mod
+++ b/scripts/smoke-pay-driver/go.mod
@@ -1,0 +1,7 @@
+module smoke-pay-driver
+
+go 1.25.0
+
+require github.com/pilot-protocol/app-store v0.0.0
+
+replace github.com/pilot-protocol/app-store => ../../../app-store

--- a/scripts/smoke-pay-driver/main.go
+++ b/scripts/smoke-pay-driver/main.go
@@ -1,0 +1,136 @@
+// smoke-pay-driver — generic IPC driver for the smoke test.
+//
+// Talks to any installed app over its unix socket using only
+// app-store/pkg/ipc. Deliberately does NOT import wallet types — the
+// point of the app store is that apps are dynamic, discovered through
+// their manifest's `exposes` list. A third-party tool inspecting a
+// fresh install has no compile-time knowledge of the methods. JSON
+// shapes here mirror what the wallet manifest documents (and what
+// pilotctl appstore call would send).
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pilot-protocol/app-store/pkg/ipc"
+)
+
+func dial(path string) net.Conn {
+	c, err := net.DialTimeout("unix", path, 3*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dial %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	_ = c.SetDeadline(time.Now().Add(8 * time.Second))
+	return c
+}
+
+// call wraps ipc.Call so result is always a raw JSON value the test
+// can interrogate generically — no app-specific struct dependency.
+func call(conn net.Conn, method string, args map[string]any) map[string]any {
+	var raw json.RawMessage
+	if err := ipc.Call(conn, method, args, &raw); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", method, err)
+		os.Exit(1)
+	}
+	var out map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &out); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: bad json: %v\n", method, err)
+			os.Exit(1)
+		}
+	}
+	return out
+}
+
+func main() {
+	payerSock := flag.String("payer", "", "payer wallet unix socket")
+	merchantSock := flag.String("merchant", "", "merchant wallet unix socket")
+	amount := flag.Uint64("amount", 50, "USDC amount to pay")
+	flag.Parse()
+	if *payerSock == "" || *merchantSock == "" {
+		fmt.Fprintln(os.Stderr, "need -payer and -merchant")
+		os.Exit(1)
+	}
+
+	payer := dial(*payerSock)
+	defer payer.Close()
+	merchant := dial(*merchantSock)
+	defer merchant.Close()
+
+	call(payer, "wallet.topup", map[string]any{
+		"asset": "USDC", "amount": 100, "source": "smoke:faucet",
+	})
+	fmt.Println("topup OK")
+
+	req := call(merchant, "wallet.request", map[string]any{
+		"amount": *amount, "asset": "USDC",
+		"expires_in_seconds": 60, "memo": "smoke",
+	})
+	challenge, ok := req["challenge"].(map[string]any)
+	if !ok {
+		body, _ := json.Marshal(req)
+		fmt.Fprintf(os.Stderr, "no challenge in request resp: %s\n", body)
+		os.Exit(1)
+	}
+	fmt.Println("challenge OK")
+
+	pay := call(payer, "wallet.pay", map[string]any{"challenge": challenge})
+	auth, ok := pay["signed_auth"].(map[string]any)
+	if !ok {
+		body, _ := json.Marshal(pay)
+		fmt.Fprintf(os.Stderr, "no signed_auth in pay resp: %s\n", body)
+		os.Exit(1)
+	}
+	fmt.Println("pay OK")
+
+	ver := call(merchant, "wallet.verify", map[string]any{
+		"challenge": challenge, "signed_auth": auth,
+	})
+	if ver["ok"] != true {
+		fmt.Fprintln(os.Stderr, "verify ok != true on fresh auth")
+		os.Exit(1)
+	}
+
+	settle := call(merchant, "wallet.settle", map[string]any{
+		"challenge": challenge, "signed_auth": auth,
+	})
+	tx, _ := settle["transaction"].(map[string]any)
+	if tx == nil {
+		fmt.Fprintln(os.Stderr, "settle did not return a transaction")
+		os.Exit(1)
+	}
+	// json.Unmarshal decodes numbers into float64 — the IPC
+	// transparently round-trips uint, so a small whole number always
+	// fits without precision loss.
+	got, _ := tx["amount"].(float64)
+	if uint64(got) != *amount {
+		fmt.Fprintf(os.Stderr, "settle amount = %v, want %d\n", tx["amount"], *amount)
+		os.Exit(1)
+	}
+	fmt.Println("settle OK")
+
+	// Replay-guard: a second settle of the same SignedAuth must be
+	// rejected. The wallet's anti-double-spend invariant; without it
+	// a malicious merchant could claim the same payment twice.
+	var ignore json.RawMessage
+	replayErr := ipc.Call(merchant, "wallet.settle", map[string]any{
+		"challenge": challenge, "signed_auth": auth,
+	}, &ignore)
+	if replayErr == nil {
+		fmt.Fprintln(os.Stderr, "replay not rejected — anti-double-spend broken")
+		os.Exit(1)
+	}
+	if !strings.Contains(replayErr.Error(), "already settled") {
+		fmt.Fprintf(os.Stderr, "unexpected replay error: %v\n", replayErr)
+		os.Exit(1)
+	}
+	fmt.Println("replay-guard OK")
+	fmt.Println("PAY_OK")
+}

--- a/scripts/smoke-test-appstore.sh
+++ b/scripts/smoke-test-appstore.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# smoke-test-appstore.sh — live end-to-end smoke test for the app
+# store flow. This is the executable spec: every step a real new user
+# runs, in the order they run it, with assertions that fail loudly.
+#
+# What it proves:
+#
+#  1. The pilot daemon ships with the app-store supervisor always on
+#     (no flag).
+#  2. `pilotctl appstore gen-key` produces a working ed25519 publisher
+#     keypair.
+#  3. `pilotctl appstore sign` produces a signature the supervisor
+#     accepts.
+#  4. A signed wallet bundle, packaged as a tarball + sha256 in a
+#     staging catalogue, installs cleanly via
+#     `pilotctl appstore install io.pilot.wallet`.
+#  5. The daemon picks it up within seconds and exposes its IPC.
+#  6. A second wallet process can act as a merchant; a 50 USDC payment
+#     flows request → pay → verify → settle, then replay is rejected.
+#  7. `pilotctl appstore uninstall` tears it all down; the daemon
+#     cancels the supervise goroutine.
+#  8. The host returns to fresh-user state — no artifacts left over.
+#
+# Usage:
+#   scripts/smoke-test-appstore.sh           # against repo HEAD
+#   PILOT_DEBUG=1 scripts/smoke-test-appstore.sh   # keep tmpdir on exit
+#
+# Requirements:
+#   - go toolchain (any version the repos pin)
+#   - The wallet repo at ../wallet relative to this web4 checkout.
+#   - macOS or Linux. /tmp must be writable.
+#
+# Exit codes:
+#   0   all steps green
+#   1   a step failed (line number + step name printed)
+
+set -euo pipefail
+
+# ── plumbing ──────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WEB4_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WALLET_DIR="$(cd "$WEB4_DIR/.." && pwd)/wallet"
+if [ ! -d "$WALLET_DIR" ]; then
+    echo "FAIL: wallet repo not at $WALLET_DIR" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d -t pilot-smoke-XXXXXX)"
+PILOT_HOME_BAK=""
+DAEMON_PID=""
+MERCHANT_PID=""
+
+step()  { printf "\n[step %s] %s\n" "$1" "$2"; }
+ok()    { printf "  OK %s\n" "$1"; }
+fail()  { printf "  FAIL %s\n" "$1" >&2; exit 1; }
+
+cleanup() {
+    set +e
+    [ -n "$MERCHANT_PID" ] && kill "$MERCHANT_PID" 2>/dev/null
+    [ -n "$DAEMON_PID" ]   && kill "$DAEMON_PID"   2>/dev/null
+    if [ -n "$PILOT_HOME_BAK" ] && [ -d "$PILOT_HOME_BAK" ]; then
+        rm -rf "$HOME/.pilot/apps"
+        if [ -d "$PILOT_HOME_BAK/apps" ]; then
+            mv "$PILOT_HOME_BAK/apps" "$HOME/.pilot/apps"
+        fi
+    fi
+    if [ "${PILOT_DEBUG:-}" = "1" ]; then
+        echo "[debug] keeping work dir: $WORK"
+    else
+        rm -rf "$WORK"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Preserve any pre-existing apps so an operator running the smoke
+# test on their dev box doesn't lose their installed wallet.
+if [ -d "$HOME/.pilot/apps" ]; then
+    PILOT_HOME_BAK="$WORK/pilot-home-backup"
+    mkdir -p "$PILOT_HOME_BAK"
+    mv "$HOME/.pilot/apps" "$PILOT_HOME_BAK/apps"
+fi
+
+# ── step 1: build pilotctl + daemon + wallet from HEAD ────────────────
+
+step 1 "build pilotctl, daemon, wallet"
+( cd "$WEB4_DIR" && go build -o "$WORK/pilotctl" ./cmd/pilotctl ) || fail "build pilotctl"
+( cd "$WEB4_DIR" && go build -o "$WORK/pilot-daemon" ./cmd/daemon ) || fail "build daemon"
+( cd "$WALLET_DIR" && go build -o "$WORK/wallet" ./cmd/wallet ) || fail "build wallet"
+ok "pilotctl + daemon + wallet built"
+
+# ── step 2: generate publisher key + sign a wallet bundle ─────────────
+
+step 2 "generate publisher key + sign wallet manifest"
+"$WORK/pilotctl" appstore gen-key "$WORK/publisher.key" > "$WORK/gen-key.out" 2>&1 \
+    || { cat "$WORK/gen-key.out"; fail "gen-key"; }
+grep -q "ed25519:" "$WORK/gen-key.out" || fail "gen-key didn't print publisher line"
+ok "publisher key written ($(stat -f %A "$WORK/publisher.key" 2>/dev/null || stat -c %a "$WORK/publisher.key") perms)"
+
+BUNDLE="$WORK/bundle"
+mkdir -p "$BUNDLE/bin"
+cp "$WORK/wallet" "$BUNDLE/bin/wallet"
+WALLET_SHA="$(shasum -a 256 "$BUNDLE/bin/wallet" | awk '{print $1}')"
+python3 -c "
+import json,sys
+with open('$WALLET_DIR/manifest.json') as f: m = json.load(f)
+m['binary']['sha256'] = '$WALLET_SHA'
+with open('$BUNDLE/manifest.json','w') as f: json.dump(m, f, indent=2)
+"
+"$WORK/pilotctl" appstore sign --key "$WORK/publisher.key" "$BUNDLE/manifest.json" > "$WORK/sign.out" 2>&1 \
+    || { cat "$WORK/sign.out"; fail "sign"; }
+ok "manifest signed, binary sha pinned"
+
+# ── step 3: stage a catalogue pointing at the local bundle ────────────
+
+step 3 "stage a catalogue file pointing at the bundle tarball"
+( cd "$BUNDLE" && tar czf "$WORK/io.pilot.wallet-test.tar.gz" manifest.json bin/wallet )
+BUNDLE_SHA="$(shasum -a 256 "$WORK/io.pilot.wallet-test.tar.gz" | awk '{print $1}')"
+cat > "$WORK/catalogue.json" <<EOF
+{
+  "version": 1,
+  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "apps": [
+    {
+      "id": "io.pilot.wallet",
+      "version": "0.3.0",
+      "description": "smoke-test build",
+      "bundle_url": "file://$WORK/io.pilot.wallet-test.tar.gz",
+      "bundle_sha256": "$BUNDLE_SHA"
+    }
+  ]
+}
+EOF
+export PILOT_APPSTORE_CATALOG_URL="file://$WORK/catalogue.json"
+ok "catalogue staged at \$PILOT_APPSTORE_CATALOG_URL"
+
+# ── step 4: start the daemon (which always loads the app-store) ───────
+
+step 4 "start the daemon (app-store supervisor unconditional)"
+"$WORK/pilot-daemon" \
+    -identity "$HOME/.pilot/identity.json" \
+    -socket "$WORK/pilot.sock" \
+    -listen :0 \
+    -hostname smoke-test \
+    -log-level info \
+    > "$WORK/daemon.log" 2>&1 &
+DAEMON_PID=$!
+sleep 2
+ps -p "$DAEMON_PID" >/dev/null 2>&1 || { tail -20 "$WORK/daemon.log"; fail "daemon died"; }
+grep -q "appstore" "$WORK/daemon.log" || fail "no appstore log line — supervisor didn't register"
+ok "daemon up (PID $DAEMON_PID), app-store supervisor registered"
+
+# ── step 5: catalogue + install by ID ─────────────────────────────────
+
+step 5 "browse catalogue and install by ID"
+"$WORK/pilotctl" appstore catalogue > "$WORK/cat.out" 2>&1 \
+    || { cat "$WORK/cat.out"; fail "catalogue"; }
+grep -q "io.pilot.wallet" "$WORK/cat.out" || fail "catalogue missing wallet entry"
+ok "catalogue lists wallet"
+
+"$WORK/pilotctl" appstore install io.pilot.wallet > "$WORK/install.out" 2>&1 \
+    || { cat "$WORK/install.out"; fail "install"; }
+grep -q "sha256 OK" "$WORK/install.out" || fail "install didn't verify sha256"
+ok "wallet installed (sha256 verified)"
+
+# ── step 6: wait for the daemon to spawn the wallet ───────────────────
+
+step 6 "daemon discovers + spawns the app"
+i=0
+while [ ! -S "$HOME/.pilot/apps/io.pilot.wallet/app.sock" ] && [ $i -lt 15 ]; do
+    sleep 1; i=$((i+1))
+done
+[ -S "$HOME/.pilot/apps/io.pilot.wallet/app.sock" ] || { tail -10 "$WORK/daemon.log"; fail "wallet socket missing after 15s"; }
+ok "wallet socket ready after ${i}s"
+
+ADDR_OUT="$("$WORK/pilotctl" appstore call io.pilot.wallet wallet.address)"
+echo "$ADDR_OUT" | grep -q '"address"' || fail "wallet.address didn't return"
+ok "wallet.address responded ($(echo $ADDR_OUT | tr -d '\n'))"
+
+# ── step 7: live payment from wallet → merchant ───────────────────────
+
+step 7 "live 50 USDC payment (wallet → merchant)"
+MERCHANT_DIR="$WORK/merchant"
+mkdir -p "$MERCHANT_DIR"
+"$WORK/wallet" \
+    -addr 0:0002.0000.0000 \
+    -db "$MERCHANT_DIR/data.db" \
+    -socket "$MERCHANT_DIR/wallet.sock" \
+    -identity "$MERCHANT_DIR/identity.json" \
+    > "$MERCHANT_DIR/wallet.log" 2>&1 &
+MERCHANT_PID=$!
+sleep 1
+[ -S "$MERCHANT_DIR/wallet.sock" ] || fail "merchant socket missing"
+
+( cd "$WEB4_DIR/scripts/smoke-pay-driver" && go build -o "$WORK/smoke-pay-driver" . ) \
+    || fail "build smoke-pay-driver"
+"$WORK/smoke-pay-driver" \
+    -payer "$HOME/.pilot/apps/io.pilot.wallet/app.sock" \
+    -merchant "$MERCHANT_DIR/wallet.sock" \
+    -amount 50 > "$WORK/pay.out" 2>&1 \
+    || { cat "$WORK/pay.out"; fail "live payment"; }
+grep -q "PAY_OK" "$WORK/pay.out" || { cat "$WORK/pay.out"; fail "no PAY_OK marker"; }
+ok "payment settled, replay rejected"
+
+# ── step 8: uninstall + verify clean ──────────────────────────────────
+
+step 8 "uninstall + verify clean"
+"$WORK/pilotctl" appstore uninstall io.pilot.wallet --yes > "$WORK/uninstall.out" 2>&1 \
+    || { cat "$WORK/uninstall.out"; fail "uninstall"; }
+sleep 3
+[ -d "$HOME/.pilot/apps/io.pilot.wallet" ] && fail "io.pilot.wallet dir still present after uninstall"
+grep -q "removed from disk" "$WORK/daemon.log" || fail "daemon didn't log the uninstall"
+ok "wallet removed, daemon noticed"
+
+echo ""
+printf "==== SMOKE TEST PASSED ====\n"
+printf "daemon log: %s\n" "$WORK/daemon.log"
+if [ "${PILOT_DEBUG:-}" = "1" ]; then
+    echo "(PILOT_DEBUG=1 — work dir preserved at $WORK)"
+fi


### PR DESCRIPTION
**Stacked on #232 → #231.** Review #231 → #232 first.

## Summary

Closes the new-user gap. Instead of \"find a bundle tarball, untar it, pass the path to install\", a user runs:

\`\`\`bash
pilotctl appstore catalogue
pilotctl appstore install io.pilot.wallet
\`\`\`

The tool fetches the bundle from the URL pinned in the catalogue, sha-checks it, extracts it, and hands it to the existing install path (which validates the manifest + verifies the embedded ed25519 signature). The supervisor's rescan picks it up within 2 s.

## What ships

- **\`catalogue/catalogue.json\`** — canonical list of installable apps. Schema-versioned (\`version=1\`). Each entry pins \`bundle_url\` + \`bundle_sha256\`. Pilotctl refuses unknown schema versions so a future migration can't silently misbehave on old binaries.
- **\`catalogue/README.md\`** — schema doc + how-to-publish-a-new-version flow + trust model table.
- **\`cmd/pilotctl/appstore_catalogue.go\`** — loads catalogue from \`\$PILOT_APPSTORE_CATALOG_URL\` (env override) or default raw GitHub URL for \`catalogue/catalogue.json\` on main. Supports \`file://\`, \`https://\`, and \`http://\` on loopback only. Refuses plaintext install artifacts from anywhere else.
- **\`cmd/pilotctl/appstore.go\`** — \`install\` now accepts a catalogue ID alongside a bundle dir; \`catalogue\`/\`catalog\` subcommand dispatches to the new lister.

## Chain of trust

| Layer | Verifies |
|---|---|
| User trusts pilotctl | Release-pipeline-signed binary |
| pilotctl trusts the catalogue | URL hardcoded in this binary (auditable in this repo). Future: signed catalogue against \`EmbeddedCatalogPubkey\` |
| pilotctl trusts the bundle | Pinned \`bundle_sha256\` — CDN substitute aborts install |
| Daemon trusts the manifest | Embedded ed25519 publisher pubkey verifies signature (every install + every rescan) |

Defence-in-depth: tarball-unpack refuses any entry with \`../\` traversal, mirroring the supervisor's \`manifest.binary.path\` guard.

## Live smoke test (\`scripts/smoke-test-appstore.sh\`)

End-to-end, **8 steps each with explicit assertions**:

1. Build pilotctl + daemon + wallet from HEAD
2. \`gen-key\` + \`sign\` wallet manifest
3. Stage catalogue file pointing at local tarball (via \`\$PILOT_APPSTORE_CATALOG_URL\`)
4. Start the daemon (app-store supervisor unconditional per #231)
5. \`pilotctl appstore catalogue\` + \`install io.pilot.wallet\`
6. Daemon discovers + spawns, \`wallet.address\` reachable
7. **Live 50 USDC payment** through two wallet processes — request → pay → verify → settle → **replay rejected**
8. Uninstall + verify clean

Each step fails loudly on its own line if anything goes wrong. Preserves any pre-existing \`~/.pilot/apps\` and restores it on exit.

**\`scripts/smoke-pay-driver/\`** — wallet-side IPC client. **Does NOT import the wallet package**; talks to any installed app over raw \`ipc.Call\` with \`map[string]any\` payloads. Proves the appstore stays dynamic: a third-party tool needs zero compile-time knowledge of the app to drive its exposed methods.

## Test plan

- [x] \`go vet ./cmd/pilotctl\` clean
- [x] \`go build ./cmd/pilotctl ./scripts/smoke-pay-driver\` clean
- [x] \`scripts/smoke-test-appstore.sh\` PASSED green (all 8 steps) against this branch
- [ ] After merge: replace \`bundle_url\` placeholder with a real GitHub Release artifact URL + the matching \`bundle_sha256\` (publisher CI follow-up)