### PR TITLE
feat(pilotctl): one-command install + canonical catalogue.json + live smoke test

### DIFF
--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -1,0 +1,76 @@
+# Pilot app store catalogue
+
+This directory holds `catalogue.json` — the canonical list of apps installable via
+`pilotctl appstore install <app-id>`.
+
+## Schema
+
+```json
+{
+  "version": 1,
+  "updated_at": "<RFC3339 timestamp>",
+  "apps": [
+    {
+      "id": "<reverse-DNS app id, must match manifest.id>",
+      "version": "<semver>",
+      "description": "<one-line, shown in `pilotctl appstore catalogue`>",
+      "bundle_url": "https://<host>/<path>.tar.gz",
+      "bundle_sha256": "<hex sha256 of the tarball>"
+    }
+  ]
+}
+```
+
+The schema is intentionally flat — `pilotctl` decodes it directly into
+`catalogueEntry` in `cmd/pilotctl/appstore_catalogue.go`. Any field added
+here must also land there.
+
+## Where pilotctl loads it from
+
+By default, `pilotctl appstore catalogue` and `pilotctl appstore install
+<id>` fetch this file from the URL hardcoded in `appstore_catalogue.go`
+(`defaultCatalogueURL`, pointing at this file's raw URL on `main`). Override
+with `PILOT_APPSTORE_CATALOG_URL` for local dev or for staging a release:
+
+```bash
+# point at a local file while staging a release
+export PILOT_APPSTORE_CATALOG_URL=file:///path/to/staging/catalogue.json
+pilotctl appstore catalogue
+```
+
+`http://` is rejected unless the host is loopback (no plaintext install
+from a remote — operators relying on a catalogue do so over `https` only).
+
+## Publishing a new app version
+
+1. Bump the version in the app's `manifest.json`. Re-sign:
+   ```bash
+   pilotctl appstore sign --key /secure/path/publisher.key path/to/manifest.json
+   ```
+2. Build the bundle dir (`manifest.json` + `bin/<name>`) and tar it:
+   ```bash
+   tar czf io.pilot.wallet-X.Y.Z.tar.gz manifest.json bin/wallet
+   ```
+3. Compute the sha256:
+   ```bash
+   shasum -a 256 io.pilot.wallet-X.Y.Z.tar.gz
+   ```
+4. Upload the tarball as a release artifact (`gh release upload` or
+   equivalent — GitHub releases, Cloudflare R2, anywhere reachable over
+   HTTPS).
+5. Update this `catalogue.json` with the new `version`, `bundle_url`, and
+   `bundle_sha256`. Commit. The change goes live the moment the commit
+   lands on `main` and the raw URL serves the new bytes — no daemon
+   restart, no pilotctl release.
+
+## Trust model
+
+| Layer | Trust anchor | Verifies |
+|---|---|---|
+| User trusts pilotctl | Project release pipeline (signed pilotctl binary) | The catalogue URL is correct |
+| pilotctl trusts the catalogue | Future: signed against `EmbeddedCatalogPubkey`; today: the raw URL itself | App IDs map to specific bundle URLs + SHAs |
+| pilotctl trusts the bundle | Embedded `bundle_sha256` matches downloaded bytes | A CDN substitute is rejected |
+| Daemon trusts the manifest | Embedded ed25519 publisher pubkey verifies the signature | The bundle's manifest hasn't been tampered with |
+
+Every layer is checked at install time, and the manifest signature is
+re-verified at every supervisor rescan (every 2 s).

--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "updated_at": "2026-06-08T10:25:00Z",
+  "apps": [
+    {
+      "id": "io.pilot.wallet",
+      "version": "0.3.0",
+      "description": "On-overlay USDC payments — ed25519 + EIP-3009 receipts.",
+      "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/wallet-v0.3.0/io.pilot.wallet-0.3.0.tar.gz",
+      "bundle_sha256": "REPLACE_AT_RELEASE_TIME"
+    }
+  ]
+}

--- a/cmd/pilotctl/appstore.go
+++ b/cmd/pilotctl/appstore.go
@@ -67,6 +67,8 @@ func cmdAppStore(args []string) {
 		cmdAppStoreGenKey(args[1:])
 	case "sign":
 		cmdAppStoreSign(args[1:])
+	case "catalogue", "catalog":
+		cmdAppStoreCatalogue(args[1:])
 	case "restart":
 		cmdAppStoreRestart(args[1:])
 	case "caps":
@@ -77,7 +79,7 @@ func cmdAppStore(args []string) {
 		appStoreHelp()
 	default:
 		fatalHint("invalid_argument",
-			"available: list, status, audit, uninstall, verify, install, gen-key, sign, restart, caps, actions, call",
+			"available: list, status, audit, uninstall, verify, install, gen-key, sign, catalogue, restart, caps, actions, call",
 			"unknown appstore subcommand: %s", args[0])
 	}
 }
@@ -99,8 +101,10 @@ Usage:
                                              duration: Go syntax (e.g. 10m, 1h, 24h)
   pilotctl appstore uninstall <id> --yes     remove an installed app from the install root
   pilotctl appstore verify <bundle-dir>      sha256-check a pre-install bundle against its manifest
-  pilotctl appstore install <bundle-dir> [--force]
-                                             stage + atomically place a verified bundle into the install root
+  pilotctl appstore catalogue                list apps available for one-command install
+  pilotctl appstore install <app-id-or-dir> [--force]
+                                             install by catalogue ID (fetches + verifies + extracts)
+                                             OR by local bundle directory (offline / dev path)
   pilotctl appstore gen-key <key-file>       generate a fresh ed25519 publisher keypair; prints the public side
   pilotctl appstore sign --key <key-file> <manifest>
                                              sign (or re-sign) a manifest's store.signature so the supervisor accepts it
@@ -967,10 +971,10 @@ type installReport struct {
 func cmdAppStoreInstall(args []string) {
 	if len(args) < 1 {
 		fatalHint("invalid_argument",
-			"usage: pilotctl appstore install <bundle-dir> [--force]",
-			"missing bundle dir")
+			"usage: pilotctl appstore install <app-id-or-dir> [--force]",
+			"missing app id or bundle dir")
 	}
-	bundleDir := args[0]
+	target := args[0]
 	force := false
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
@@ -981,6 +985,17 @@ func cmdAppStoreInstall(args []string) {
 				"available flags: --force",
 				"unknown install flag: %s", args[i])
 		}
+	}
+
+	// Resolve `target` to a local bundle dir. If it's a catalogue ID
+	// (e.g. "io.pilot.wallet"), fetch + verify the tarball and unpack
+	// into a tempdir. If it's already a directory, use it as-is. The
+	// rest of this function operates only on the directory.
+	bundleDir, err := resolveInstallTarget(target)
+	if err != nil {
+		fatalHint("invalid_argument",
+			"the argument must be either a catalogue ID (`pilotctl appstore catalogue` to list) or a path to a bundle dir containing manifest.json",
+			"%v", err)
 	}
 
 	// 1. Validate the bundle — same shape as verify. Reusing the

--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// pilotctl appstore catalogue / install-by-id — fresh-user install path.
+//
+// A new user shouldn't need to know about bundle paths, manifests, or
+// signatures. They run:
+//
+//	pilotctl appstore catalogue
+//	pilotctl appstore install io.pilot.wallet
+//
+// and the tool fetches the bundle from a known-good URL, sha-checks it,
+// extracts it, and hands it to the existing local-bundle install path
+// (which validates the manifest + verifies the embedded ed25519 sig).
+//
+// The catalogue itself lives in the web4 repo at
+// catalogue/catalogue.json and is fetched at runtime from
+// defaultCatalogueURL. Override with $PILOT_APPSTORE_CATALOG_URL for
+// local dev or for staging a release. See catalogue/README.md for the
+// schema and publishing flow.
+//
+// Trust model (each layer checked at install time):
+//
+//   - User trusts pilotctl (project release pipeline).
+//   - pilotctl fetches the catalogue from a URL hardcoded in this
+//     binary — auditable in the public repo. Future: signed catalogue
+//     verified against appstore.EmbeddedCatalogPubkey.
+//   - Each catalogue entry pins the bundle's tarball sha256; a
+//     compromised CDN can't substitute different bytes.
+//   - The bundle's manifest carries an ed25519 signature against an
+//     embedded publisher pubkey; the supervisor verifies it.
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// defaultCatalogueURL points at the canonical catalogue.json on main.
+// Override via $PILOT_APPSTORE_CATALOG_URL (use file:// for local
+// staging, https:// for everything else; plain http:// is rejected
+// off-loopback).
+const defaultCatalogueURL = "https://raw.githubusercontent.com/TeoSlayer/pilotprotocol/main/catalogue/catalogue.json"
+
+// catalogue is the parsed wire shape of catalogue.json. The schema is
+// versioned (catalogue.json's "version" field) so future migrations
+// can stay backward-compatible — pilotctl refuses any version it
+// doesn't understand.
+type catalogue struct {
+	Version   int              `json:"version"`
+	UpdatedAt string           `json:"updated_at"`
+	Apps      []catalogueEntry `json:"apps"`
+}
+
+// catalogueEntry mirrors the JSON shape exactly. Adding a field here
+// means adding it to catalogue.json AND to catalogue/README.md.
+type catalogueEntry struct {
+	ID          string `json:"id"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+	BundleURL   string `json:"bundle_url"`
+	BundleSHA   string `json:"bundle_sha256"`
+}
+
+// catalogueURL returns the URL pilotctl should fetch the catalogue
+// from — env override wins so an operator can point at a staging
+// file without rebuilding.
+func catalogueURL() string {
+	if u := os.Getenv("PILOT_APPSTORE_CATALOG_URL"); u != "" {
+		return u
+	}
+	return defaultCatalogueURL
+}
+
+// loadCatalogue fetches + parses the catalogue. Errors out cleanly so
+// `pilotctl appstore catalogue` and `install <id>` can both surface a
+// useful diagnostic when the URL is wrong, offline, or returns
+// garbage.
+func loadCatalogue() (*catalogue, error) {
+	u := catalogueURL()
+	body, err := openURL(u)
+	if err != nil {
+		return nil, fmt.Errorf("fetch catalogue from %s: %w", u, err)
+	}
+	defer body.Close()
+	data, err := io.ReadAll(io.LimitReader(body, 1<<20)) // 1 MiB cap
+	if err != nil {
+		return nil, fmt.Errorf("read catalogue body: %w", err)
+	}
+	var c catalogue
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse catalogue: %w", err)
+	}
+	if c.Version != 1 {
+		return nil, fmt.Errorf("unsupported catalogue version %d (pilotctl understands version 1)", c.Version)
+	}
+	return &c, nil
+}
+
+func cmdAppStoreCatalogue(_ []string) {
+	c, err := loadCatalogue()
+	if err != nil {
+		fatalHint("io_error",
+			"check $PILOT_APPSTORE_CATALOG_URL (currently: "+catalogueURL()+")",
+			"%v", err)
+	}
+	if jsonOutput {
+		_ = json.NewEncoder(os.Stdout).Encode(c.Apps)
+		return
+	}
+	if len(c.Apps) == 0 {
+		fmt.Println("catalogue is empty")
+		return
+	}
+	fmt.Printf("Catalogue: %s (updated %s)\n\n", catalogueURL(), c.UpdatedAt)
+	fmt.Println("Installable apps:")
+	for _, e := range c.Apps {
+		fmt.Printf("\n  %s  v%s\n", e.ID, e.Version)
+		fmt.Printf("    %s\n", e.Description)
+		fmt.Printf("    install: pilotctl appstore install %s\n", e.ID)
+	}
+}
+
+// resolveInstallTarget turns the user's `target` arg into a local
+// bundle directory the existing install code can consume. If `target`
+// matches a catalogue ID, the catalogue entry is fetched, verified,
+// and unpacked. Otherwise `target` is treated as a local path.
+func resolveInstallTarget(target string) (string, error) {
+	c, err := loadCatalogue()
+	if err != nil {
+		// Catalogue-lookup failure doesn't preclude a local-dir install
+		// — fall through to the path branch so dev flows still work
+		// offline. Surface a hint that the catalogue path failed so
+		// the user knows their URL or env override might be the issue.
+		fmt.Fprintf(os.Stderr, "warn: catalogue lookup failed (%v); proceeding with local-path interpretation\n", err)
+	} else {
+		for _, e := range c.Apps {
+			if target == e.ID {
+				return fetchAndUnpackBundle(e)
+			}
+		}
+	}
+	info, err := os.Stat(target)
+	if err == nil && info.IsDir() {
+		return target, nil
+	}
+	return "", fmt.Errorf("not a catalogue ID or a bundle dir: %q (try `pilotctl appstore catalogue` to list installable apps)", target)
+}
+
+// fetchAndUnpackBundle downloads the catalogue entry's tarball,
+// verifies its sha256 against the catalogue value (defence against a
+// CDN substitute), and unpacks it into a tempdir whose path is
+// returned for the install path to consume.
+func fetchAndUnpackBundle(e catalogueEntry) (string, error) {
+	if e.BundleSHA == "" || e.BundleSHA == "REPLACE_AT_RELEASE_TIME" {
+		return "", fmt.Errorf("catalogue entry %s has placeholder sha256 — the release pipeline hasn't filled this in yet", e.ID)
+	}
+	fmt.Printf("fetching %s ...\n", e.BundleURL)
+	body, err := openURL(e.BundleURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", e.BundleURL, err)
+	}
+	defer body.Close()
+
+	tmpTar, err := os.CreateTemp("", "pilot-bundle-*.tar.gz")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpTar.Name())
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmpTar, h), body); err != nil {
+		_ = tmpTar.Close()
+		return "", fmt.Errorf("download body: %w", err)
+	}
+	if err := tmpTar.Close(); err != nil {
+		return "", err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != e.BundleSHA {
+		return "", fmt.Errorf("bundle sha256 mismatch: want=%s got=%s — the cdn served different bytes than the catalogue pinned", e.BundleSHA, got)
+	}
+	fmt.Printf("sha256 OK (%s)\n", got)
+
+	unpackDir, err := os.MkdirTemp("", "pilot-bundle-unpack-*")
+	if err != nil {
+		return "", err
+	}
+	f, err := os.Open(tmpTar.Name())
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+	if err := untarUnder(gz, unpackDir); err != nil {
+		return "", fmt.Errorf("untar: %w", err)
+	}
+	return unpackDir, nil
+}
+
+// openURL handles file:// (local dev), https://, and http:// only on
+// loopback. Any non-loopback http:// is refused — install artifacts
+// are too high-blast-radius to fetch over plaintext from anywhere we
+// don't already trust.
+func openURL(raw string) (io.ReadCloser, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	case "file":
+		return os.Open(u.Path)
+	case "https":
+		return httpGet(raw)
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return httpGet(raw)
+		}
+		return nil, fmt.Errorf("refusing plaintext http for non-localhost host %q (use https)", host)
+	default:
+		return nil, fmt.Errorf("unsupported url scheme %q", u.Scheme)
+	}
+}
+
+func httpGet(raw string) (io.ReadCloser, error) {
+	c := &http.Client{Timeout: 60 * time.Second}
+	resp, err := c.Get(raw)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("http %d from %s", resp.StatusCode, raw)
+	}
+	return resp.Body, nil
+}
+
+// untarUnder writes every entry in r under dst, refusing any path
+// that resolves outside dst (mirrors the supervisor's
+// resolveUnder guard on manifest.binary.path).
+func untarUnder(r io.Reader, dst string) error {
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		clean := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(clean, "..") || strings.Contains(clean, "/../") {
+			return fmt.Errorf("refusing entry with traversal: %q", hdr.Name)
+		}
+		out := filepath.Join(dst, clean)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(out, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return err
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
+		default:
+			// Skip symlinks, devices, etc. — neither needed for a
+			// pilot app bundle nor safe to write blindly.
+		}
+	}
+}

--- a/scripts/smoke-pay-driver/go.mod
+++ b/scripts/smoke-pay-driver/go.mod
@@ -1,0 +1,7 @@
+module smoke-pay-driver
+
+go 1.25.0
+
+require github.com/pilot-protocol/app-store v0.0.0
+
+replace github.com/pilot-protocol/app-store => ../../../app-store

--- a/scripts/smoke-pay-driver/main.go
+++ b/scripts/smoke-pay-driver/main.go
@@ -1,0 +1,136 @@
+// smoke-pay-driver — generic IPC driver for the smoke test.
+//
+// Talks to any installed app over its unix socket using only
+// app-store/pkg/ipc. Deliberately does NOT import wallet types — the
+// point of the app store is that apps are dynamic, discovered through
+// their manifest's `exposes` list. A third-party tool inspecting a
+// fresh install has no compile-time knowledge of the methods. JSON
+// shapes here mirror what the wallet manifest documents (and what
+// pilotctl appstore call would send).
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pilot-protocol/app-store/pkg/ipc"
+)
+
+func dial(path string) net.Conn {
+	c, err := net.DialTimeout("unix", path, 3*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dial %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	_ = c.SetDeadline(time.Now().Add(8 * time.Second))
+	return c
+}
+
+// call wraps ipc.Call so result is always a raw JSON value the test
+// can interrogate generically — no app-specific struct dependency.
+func call(conn net.Conn, method string, args map[string]any) map[string]any {
+	var raw json.RawMessage
+	if err := ipc.Call(conn, method, args, &raw); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", method, err)
+		os.Exit(1)
+	}
+	var out map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &out); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: bad json: %v\n", method, err)
+			os.Exit(1)
+		}
+	}
+	return out
+}
+
+func main() {
+	payerSock := flag.String("payer", "", "payer wallet unix socket")
+	merchantSock := flag.String("merchant", "", "merchant wallet unix socket")
+	amount := flag.Uint64("amount", 50, "USDC amount to pay")
+	flag.Parse()
+	if *payerSock == "" || *merchantSock == "" {
+		fmt.Fprintln(os.Stderr, "need -payer and -merchant")
+		os.Exit(1)
+	}
+
+	payer := dial(*payerSock)
+	defer payer.Close()
+	merchant := dial(*merchantSock)
+	defer merchant.Close()
+
+	call(payer, "wallet.topup", map[string]any{
+		"asset": "USDC", "amount": 100, "source": "smoke:faucet",
+	})
+	fmt.Println("topup OK")
+
+	req := call(merchant, "wallet.request", map[string]any{
+		"amount": *amount, "asset": "USDC",
+		"expires_in_seconds": 60, "memo": "smoke",
+	})
+	challenge, ok := req["challenge"].(map[string]any)
+	if !ok {
+		body, _ := json.Marshal(req)
+		fmt.Fprintf(os.Stderr, "no challenge in request resp: %s\n", body)
+		os.Exit(1)
+	}
+	fmt.Println("challenge OK")
+
+	pay := call(payer, "wallet.pay", map[string]any{"challenge": challenge})
+	auth, ok := pay["signed_auth"].(map[string]any)
+	if !ok {
+		body, _ := json.Marshal(pay)
+		fmt.Fprintf(os.Stderr, "no signed_auth in pay resp: %s\n", body)
+		os.Exit(1)
+	}
+	fmt.Println("pay OK")
+
+	ver := call(merchant, "wallet.verify", map[string]any{
+		"challenge": challenge, "signed_auth": auth,
+	})
+	if ver["ok"] != true {
+		fmt.Fprintln(os.Stderr, "verify ok != true on fresh auth")
+		os.Exit(1)
+	}
+
+	settle := call(merchant, "wallet.settle", map[string]any{
+		"challenge": challenge, "signed_auth": auth,
+	})
+	tx, _ := settle["transaction"].(map[string]any)
+	if tx == nil {
+		fmt.Fprintln(os.Stderr, "settle did not return a transaction")
+		os.Exit(1)
+	}
+	// json.Unmarshal decodes numbers into float64 — the IPC
+	// transparently round-trips uint, so a small whole number always
+	// fits without precision loss.
+	got, _ := tx["amount"].(float64)
+	if uint64(got) != *amount {
+		fmt.Fprintf(os.Stderr, "settle amount = %v, want %d\n", tx["amount"], *amount)
+		os.Exit(1)
+	}
+	fmt.Println("settle OK")
+
+	// Replay-guard: a second settle of the same SignedAuth must be
+	// rejected. The wallet's anti-double-spend invariant; without it
+	// a malicious merchant could claim the same payment twice.
+	var ignore json.RawMessage
+	replayErr := ipc.Call(merchant, "wallet.settle", map[string]any{
+		"challenge": challenge, "signed_auth": auth,
+	}, &ignore)
+	if replayErr == nil {
+		fmt.Fprintln(os.Stderr, "replay not rejected — anti-double-spend broken")
+		os.Exit(1)
+	}
+	if !strings.Contains(replayErr.Error(), "already settled") {
+		fmt.Fprintf(os.Stderr, "unexpected replay error: %v\n", replayErr)
+		os.Exit(1)
+	}
+	fmt.Println("replay-guard OK")
+	fmt.Println("PAY_OK")
+}

--- a/scripts/smoke-test-appstore.sh
+++ b/scripts/smoke-test-appstore.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# smoke-test-appstore.sh — live end-to-end smoke test for the app
+# store flow. This is the executable spec: every step a real new user
+# runs, in the order they run it, with assertions that fail loudly.
+#
+# What it proves:
+#
+#  1. The pilot daemon ships with the app-store supervisor always on
+#     (no flag).
+#  2. `pilotctl appstore gen-key` produces a working ed25519 publisher
+#     keypair.
+#  3. `pilotctl appstore sign` produces a signature the supervisor
+#     accepts.
+#  4. A signed wallet bundle, packaged as a tarball + sha256 in a
+#     staging catalogue, installs cleanly via
+#     `pilotctl appstore install io.pilot.wallet`.
+#  5. The daemon picks it up within seconds and exposes its IPC.
+#  6. A second wallet process can act as a merchant; a 50 USDC payment
+#     flows request → pay → verify → settle, then replay is rejected.
+#  7. `pilotctl appstore uninstall` tears it all down; the daemon
+#     cancels the supervise goroutine.
+#  8. The host returns to fresh-user state — no artifacts left over.
+#
+# Usage:
+#   scripts/smoke-test-appstore.sh           # against repo HEAD
+#   PILOT_DEBUG=1 scripts/smoke-test-appstore.sh   # keep tmpdir on exit
+#
+# Requirements:
+#   - go toolchain (any version the repos pin)
+#   - The wallet repo at ../wallet relative to this web4 checkout.
+#   - macOS or Linux. /tmp must be writable.
+#
+# Exit codes:
+#   0   all steps green
+#   1   a step failed (line number + step name printed)
+
+set -euo pipefail
+
+# ── plumbing ──────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WEB4_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WALLET_DIR="$(cd "$WEB4_DIR/.." && pwd)/wallet"
+if [ ! -d "$WALLET_DIR" ]; then
+    echo "FAIL: wallet repo not at $WALLET_DIR" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d -t pilot-smoke-XXXXXX)"
+PILOT_HOME_BAK=""
+DAEMON_PID=""
+MERCHANT_PID=""
+
+step()  { printf "\n[step %s] %s\n" "$1" "$2"; }
+ok()    { printf "  OK %s\n" "$1"; }
+fail()  { printf "  FAIL %s\n" "$1" >&2; exit 1; }
+
+cleanup() {
+    set +e
+    [ -n "$MERCHANT_PID" ] && kill "$MERCHANT_PID" 2>/dev/null
+    [ -n "$DAEMON_PID" ]   && kill "$DAEMON_PID"   2>/dev/null
+    if [ -n "$PILOT_HOME_BAK" ] && [ -d "$PILOT_HOME_BAK" ]; then
+        rm -rf "$HOME/.pilot/apps"
+        if [ -d "$PILOT_HOME_BAK/apps" ]; then
+            mv "$PILOT_HOME_BAK/apps" "$HOME/.pilot/apps"
+        fi
+    fi
+    if [ "${PILOT_DEBUG:-}" = "1" ]; then
+        echo "[debug] keeping work dir: $WORK"
+    else
+        rm -rf "$WORK"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Preserve any pre-existing apps so an operator running the smoke
+# test on their dev box doesn't lose their installed wallet.
+if [ -d "$HOME/.pilot/apps" ]; then
+    PILOT_HOME_BAK="$WORK/pilot-home-backup"
+    mkdir -p "$PILOT_HOME_BAK"
+    mv "$HOME/.pilot/apps" "$PILOT_HOME_BAK/apps"
+fi
+
+# ── step 1: build pilotctl + daemon + wallet from HEAD ────────────────
+
+step 1 "build pilotctl, daemon, wallet"
+( cd "$WEB4_DIR" && go build -o "$WORK/pilotctl" ./cmd/pilotctl ) || fail "build pilotctl"
+( cd "$WEB4_DIR" && go build -o "$WORK/pilot-daemon" ./cmd/daemon ) || fail "build daemon"
+( cd "$WALLET_DIR" && go build -o "$WORK/wallet" ./cmd/wallet ) || fail "build wallet"
+ok "pilotctl + daemon + wallet built"
+
+# ── step 2: generate publisher key + sign a wallet bundle ─────────────
+
+step 2 "generate publisher key + sign wallet manifest"
+"$WORK/pilotctl" appstore gen-key "$WORK/publisher.key" > "$WORK/gen-key.out" 2>&1 \
+    || { cat "$WORK/gen-key.out"; fail "gen-key"; }
+grep -q "ed25519:" "$WORK/gen-key.out" || fail "gen-key didn't print publisher line"
+ok "publisher key written ($(stat -f %A "$WORK/publisher.key" 2>/dev/null || stat -c %a "$WORK/publisher.key") perms)"
+
+BUNDLE="$WORK/bundle"
+mkdir -p "$BUNDLE/bin"
+cp "$WORK/wallet" "$BUNDLE/bin/wallet"
+WALLET_SHA="$(shasum -a 256 "$BUNDLE/bin/wallet" | awk '{print $1}')"
+python3 -c "
+import json,sys
+with open('$WALLET_DIR/manifest.json') as f: m = json.load(f)
+m['binary']['sha256'] = '$WALLET_SHA'
+with open('$BUNDLE/manifest.json','w') as f: json.dump(m, f, indent=2)
+"
+"$WORK/pilotctl" appstore sign --key "$WORK/publisher.key" "$BUNDLE/manifest.json" > "$WORK/sign.out" 2>&1 \
+    || { cat "$WORK/sign.out"; fail "sign"; }
+ok "manifest signed, binary sha pinned"
+
+# ── step 3: stage a catalogue pointing at the local bundle ────────────
+
+step 3 "stage a catalogue file pointing at the bundle tarball"
+( cd "$BUNDLE" && tar czf "$WORK/io.pilot.wallet-test.tar.gz" manifest.json bin/wallet )
+BUNDLE_SHA="$(shasum -a 256 "$WORK/io.pilot.wallet-test.tar.gz" | awk '{print $1}')"
+cat > "$WORK/catalogue.json" <<EOF
+{
+  "version": 1,
+  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "apps": [
+    {
+      "id": "io.pilot.wallet",
+      "version": "0.3.0",
+      "description": "smoke-test build",
+      "bundle_url": "file://$WORK/io.pilot.wallet-test.tar.gz",
+      "bundle_sha256": "$BUNDLE_SHA"
+    }
+  ]
+}
+EOF
+export PILOT_APPSTORE_CATALOG_URL="file://$WORK/catalogue.json"
+ok "catalogue staged at \$PILOT_APPSTORE_CATALOG_URL"
+
+# ── step 4: start the daemon (which always loads the app-store) ───────
+
+step 4 "start the daemon (app-store supervisor unconditional)"
+"$WORK/pilot-daemon" \
+    -identity "$HOME/.pilot/identity.json" \
+    -socket "$WORK/pilot.sock" \
+    -listen :0 \
+    -hostname smoke-test \
+    -log-level info \
+    > "$WORK/daemon.log" 2>&1 &
+DAEMON_PID=$!
+sleep 2
+ps -p "$DAEMON_PID" >/dev/null 2>&1 || { tail -20 "$WORK/daemon.log"; fail "daemon died"; }
+grep -q "appstore" "$WORK/daemon.log" || fail "no appstore log line — supervisor didn't register"
+ok "daemon up (PID $DAEMON_PID), app-store supervisor registered"
+
+# ── step 5: catalogue + install by ID ─────────────────────────────────
+
+step 5 "browse catalogue and install by ID"
+"$WORK/pilotctl" appstore catalogue > "$WORK/cat.out" 2>&1 \
+    || { cat "$WORK/cat.out"; fail "catalogue"; }
+grep -q "io.pilot.wallet" "$WORK/cat.out" || fail "catalogue missing wallet entry"
+ok "catalogue lists wallet"
+
+"$WORK/pilotctl" appstore install io.pilot.wallet > "$WORK/install.out" 2>&1 \
+    || { cat "$WORK/install.out"; fail "install"; }
+grep -q "sha256 OK" "$WORK/install.out" || fail "install didn't verify sha256"
+ok "wallet installed (sha256 verified)"
+
+# ── step 6: wait for the daemon to spawn the wallet ───────────────────
+
+step 6 "daemon discovers + spawns the app"
+i=0
+while [ ! -S "$HOME/.pilot/apps/io.pilot.wallet/app.sock" ] && [ $i -lt 15 ]; do
+    sleep 1; i=$((i+1))
+done
+[ -S "$HOME/.pilot/apps/io.pilot.wallet/app.sock" ] || { tail -10 "$WORK/daemon.log"; fail "wallet socket missing after 15s"; }
+ok "wallet socket ready after ${i}s"
+
+ADDR_OUT="$("$WORK/pilotctl" appstore call io.pilot.wallet wallet.address)"
+echo "$ADDR_OUT" | grep -q '"address"' || fail "wallet.address didn't return"
+ok "wallet.address responded ($(echo $ADDR_OUT | tr -d '\n'))"
+
+# ── step 7: live payment from wallet → merchant ───────────────────────
+
+step 7 "live 50 USDC payment (wallet → merchant)"
+MERCHANT_DIR="$WORK/merchant"
+mkdir -p "$MERCHANT_DIR"
+"$WORK/wallet" \
+    -addr 0:0002.0000.0000 \
+    -db "$MERCHANT_DIR/data.db" \
+    -socket "$MERCHANT_DIR/wallet.sock" \
+    -identity "$MERCHANT_DIR/identity.json" \
+    > "$MERCHANT_DIR/wallet.log" 2>&1 &
+MERCHANT_PID=$!
+sleep 1
+[ -S "$MERCHANT_DIR/wallet.sock" ] || fail "merchant socket missing"
+
+( cd "$WEB4_DIR/scripts/smoke-pay-driver" && go build -o "$WORK/smoke-pay-driver" . ) \
+    || fail "build smoke-pay-driver"
+"$WORK/smoke-pay-driver" \
+    -payer "$HOME/.pilot/apps/io.pilot.wallet/app.sock" \
+    -merchant "$MERCHANT_DIR/wallet.sock" \
+    -amount 50 > "$WORK/pay.out" 2>&1 \
+    || { cat "$WORK/pay.out"; fail "live payment"; }
+grep -q "PAY_OK" "$WORK/pay.out" || { cat "$WORK/pay.out"; fail "no PAY_OK marker"; }
+ok "payment settled, replay rejected"
+
+# ── step 8: uninstall + verify clean ──────────────────────────────────
+
+step 8 "uninstall + verify clean"
+"$WORK/pilotctl" appstore uninstall io.pilot.wallet --yes > "$WORK/uninstall.out" 2>&1 \
+    || { cat "$WORK/uninstall.out"; fail "uninstall"; }
+sleep 3
+[ -d "$HOME/.pilot/apps/io.pilot.wallet" ] && fail "io.pilot.wallet dir still present after uninstall"
+grep -q "removed from disk" "$WORK/daemon.log" || fail "daemon didn't log the uninstall"
+ok "wallet removed, daemon noticed"
+
+echo ""
+printf "==== SMOKE TEST PASSED ====\n"
+printf "daemon log: %s\n" "$WORK/daemon.log"
+if [ "${PILOT_DEBUG:-}" = "1" ]; then
+    echo "(PILOT_DEBUG=1 — work dir preserved at $WORK)"
+fi


### PR DESCRIPTION
Reopened (after #232/#234 base auto-deleted on merge of #231). Rebased on main.

## Summary

Closes the new-user gap. Instead of \"find a bundle tarball, untar it, pass the path to install\", a user runs:

\`\`\`bash
pilotctl appstore catalogue
pilotctl appstore install io.pilot.wallet
\`\`\`

The tool fetches the bundle from the URL pinned in the catalogue, sha-checks it, extracts it, and hands it to the existing install path (which validates the manifest + verifies the embedded ed25519 signature). The supervisor's rescan picks it up within 2 s.

## What ships

- **\`catalogue/catalogue.json\`** — canonical list of installable apps, schema-versioned. Each entry pins \`bundle_url\` + \`bundle_sha256\`.
- **\`catalogue/README.md\`** — schema doc + how-to-publish-a-new-version flow + trust model table.
- **\`cmd/pilotctl/appstore_catalogue.go\`** — loads catalogue from \`\$PILOT_APPSTORE_CATALOG_URL\` (env override) or default raw GitHub URL for \`catalogue/catalogue.json\` on main. Supports \`file://\`, \`https://\`, \`http://\` on loopback only.
- **\`cmd/pilotctl/appstore.go\`** — \`install\` now accepts a catalogue ID alongside a bundle dir; \`catalogue\` subcommand.

## Chain of trust

| Layer | Verifies |
|---|---|
| User trusts pilotctl | Release-pipeline-signed binary |
| pilotctl trusts the catalogue | URL hardcoded in this binary (auditable in this repo) |
| pilotctl trusts the bundle | Pinned \`bundle_sha256\` — CDN substitute aborts install |
| Daemon trusts the manifest | Embedded ed25519 publisher pubkey verifies signature (every install + every rescan) |

Defence-in-depth: tarball-unpack refuses \`../\` path traversal.

## Live smoke test

\`scripts/smoke-test-appstore.sh\` — 8-step end-to-end test (build, sign, stage catalogue, start daemon, install by ID, daemon spawns, **live 50 USDC payment + replay-guard**, uninstall, verify clean).

\`scripts/smoke-pay-driver/\` — **does NOT import the wallet package**; talks to any installed app over raw \`ipc.Call\` with \`map[string]any\`. Proves apps stay dynamic.

## Test plan

- [x] go vet / build clean
- [x] Smoke test passed live, 8/8 steps green
- [ ] After merge: replace \`bundle_sha256\` placeholder with real value (companion follow-up)