### PR TITLE
catalogue: pin io.pilot.wallet bundle_sha256 to wallet-v0.3.0 release

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "updated_at": "2026-06-08T10:25:00Z",
+  "updated_at": "2026-06-08T08:00:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
       "version": "0.3.0",
       "description": "On-overlay USDC payments — ed25519 + EIP-3009 receipts.",
       "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/wallet-v0.3.0/io.pilot.wallet-0.3.0.tar.gz",
-      "bundle_sha256": "REPLACE_AT_RELEASE_TIME"
+      "bundle_sha256": "99a1168589b79d3cb715557207e607eeddd63110189f0a43a4281374c8106c3d"
     }
   ]
 }


### PR DESCRIPTION
Replaces the REPLACE_AT_RELEASE_TIME placeholder with the real sha256 of the wallet-v0.3.0 tarball asset. End-to-end verified: gh CLI download of the asset hashes to the pinned value, so `pilotctl appstore install io.pilot.wallet` will now succeed.