### PR TITLE
catalogue: bump io.pilot.wallet 0.3.0 → 0.3.1

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "updated_at": "2026-06-08T08:00:00Z",
+  "updated_at": "2026-06-08T08:50:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
-      "version": "0.3.0",
-      "description": "On-overlay USDC payments — ed25519 + EIP-3009 receipts.",
-      "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/wallet-v0.3.0/io.pilot.wallet-0.3.0.tar.gz",
-      "bundle_sha256": "99a1168589b79d3cb715557207e607eeddd63110189f0a43a4281374c8106c3d"
+      "version": "0.3.1",
+      "description": "On-overlay USDC payments \u2014 ed25519 + EIP-3009 receipts.",
+      "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/wallet-v0.3.1/io.pilot.wallet-0.3.1.tar.gz",
+      "bundle_sha256": "2080dea45b41f3bd7be04ec7cd06bf8971299eda63f469acb46d7125c108cb8c"
     }
   ]
 }


### PR DESCRIPTION
Points at the v0.3.1 wallet release which wires the EVM methods. SHA verified end-to-end.