### PR TITLE
catalogue: add io.pilot.cosift v0.1.0

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-08T09:25:00Z",
+  "updated_at": "2026-06-09T18:35:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
@@ -8,6 +8,13 @@
       "description": "On-overlay USDC payments \u2014 multichain (Base + Ethereum + Polygon).",
       "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/wallet-v0.3.3/io.pilot.wallet-0.3.3.tar.gz",
       "bundle_sha256": "8d30b4331bc025c327dd2d8610362984cc9365843176e21b96a2637d8e18ff54"
+    },
+    {
+      "id": "io.pilot.cosift",
+      "version": "0.1.0",
+      "description": "cosift search / answer / research over the public web corpus.",
+      "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/cosift-v0.1.0/io.pilot.cosift-0.1.0.tar.gz",
+      "bundle_sha256": "599045d26d9ffb1c9a9d105247241245310e774dda8d30e9d5923436fb0e53b4"
     }
   ]
 }


### PR DESCRIPTION
Adds the cosift search/answer/research adapter to the app-store catalogue.

- Release: cosift-v0.1.0 (io.pilot.cosift-0.1.0.tar.gz)
- bundle_sha256 pinned; manifest ed25519-signed
- Source: pilot-protocol/cosift-app

Install once merged: `pilotctl appstore install io.pilot.cosift`