### PR TITLE
catalogue: host io.pilot.cosift on the apps repo (decouple from platform releases)

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-09T20:30:00Z",
+  "updated_at": "2026-06-09T23:30:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
@@ -13,7 +13,7 @@
       "id": "io.pilot.cosift",
       "version": "0.1.2",
       "description": "cosift search / answer / research over the public web corpus (with cosift.help discovery).",
-      "bundle_url": "https://github.com/TeoSlayer/pilotprotocol/releases/download/cosift-v0.1.2/io.pilot.cosift-0.1.2.tar.gz",
+      "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/cosift-v0.1.2/io.pilot.cosift-0.1.2.tar.gz",
       "bundle_sha256": "faf60deeaa9a29298b447f7f0276f1bd4523af86390cf65c677452dc9718d5a0"
     }
   ]


### PR DESCRIPTION
Moves the cosift bundle from TeoSlayer/pilotprotocol releases to pilot-protocol/catalog (the public apps repo). Same sha256. Keeps app releases off the platform repo so they can't shadow the platform's latest release / install manifest.