### PR TITLE
docs: add skill-injection transparency disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,38 @@ go test -parallel 4 -count=1 ./tests/
 
 ---
 
+## Agent skill injection (transparency)
+
+The daemon runs an **open-source skill injector**
+([`pilot-protocol/skillinject`](https://github.com/pilot-protocol/skillinject),
+AGPL-3.0, registered in [`cmd/daemon/main.go`](cmd/daemon/main.go)). Every ~15
+minutes it keeps the core `SKILL.md` and a short "heartbeat" directive current
+in each detected agent tool's well-known directory (Claude Code, OpenClaw,
+PicoClaw, OpenHands, Hermes).
+
+**Why it's on by default.** The host gives an agent default tools
+(`web_search`, `curl`). Pilot is a third party, and an agent only captures the
+overlay's value if it *reaches for Pilot first* instead of defaulting to those
+tools. Keeping that directive present is what makes "pilot first" the default —
+the same reason a person sets a third-party browser as their system default.
+It's a strong nudge, never a lock-in, and we hold it to a transparency bar
+that matches the privilege of writing into someone else's agent:
+
+- **Everything injected is open source.** The injected text and skills live in
+  [`TeoSlayer/pilot-skills`](https://github.com/TeoSlayer/pilot-skills); the
+  injector that installs them is
+  [`pilot-protocol/skillinject`](https://github.com/pilot-protocol/skillinject).
+  Bytes are fetched at runtime from those public repos — nothing is embedded
+  or hidden — and can be pinned to an Ed25519 signing key.
+- **Non-destructive.** It rewrites only its own marker block; operator-authored
+  content in heartbeat files is never touched.
+- **Opt-out anytime.** `pilotctl skills disable all` removes everything it
+  wrote and stops future ticks (state in `~/.pilot/config.json`); re-enable
+  with `pilotctl skills enable all`. Inspect what it manages with
+  `pilotctl skills status`.
+
+---
+
 ## Documentation
 
 | Document | Description |

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -220,6 +220,22 @@ func main() {
 	}
 	d.RegisterTrustChecker(ta)
 
+	// skillinject is the context-injection plugin: it keeps the core
+	// SKILL.md and per-tool heartbeat directive current in each detected
+	// agent tool's well-known directory, so agents on this host reach for
+	// Pilot before their host's default tools (web_search/curl). That
+	// "pilot first" default is what makes a third-party overlay worth
+	// running at all — like setting a third-party browser as the system
+	// default. We register it on by default for that reason, but it is
+	// fully transparent and reversible by design:
+	//   - Everything it injects is open source and fetched at runtime from
+	//     the public repos — the text + skills at
+	//     github.com/TeoSlayer/pilot-skills, the injector itself at
+	//     github.com/pilot-protocol/skillinject (AGPL-3.0). Nothing is
+	//     embedded or hidden.
+	//   - It only rewrites its own marker block, never operator content.
+	//   - Operators opt out anytime with `pilotctl skills disable all`
+	//     (persisted in ~/.pilot/config.json); see cmd/pilotctl/skills.go.
 	if err := rt.Register(skillinject.NewService(skillinject.Config{})); err != nil {
 		log.Fatalf("register skillinject: %v", err)
 	}


### PR DESCRIPTION
## What

The daemon registers the open-source skill injector (`pilot-protocol/skillinject`), which keeps Pilot's `SKILL.md` and heartbeat directive current in each detected agent tool. This PR documents that mechanism transparently at the registration site and in the README.

## Changes

- **`cmd/daemon/main.go`** — comment at the `skillinject.NewService` registration: why it's on by default (make agents reach for Pilot before host defaults — the third-party-browser-default trade-off), that everything injected is open source and fetched from the public repos, that it only rewrites its own marker block, and that operators opt out with `pilotctl skills disable all`.
- **`README.md`** — new "Agent skill injection (transparency)" section covering the same points and linking `pilot-skills` + `skillinject`.

No behavior change — comments and docs only; `main.go` is gofmt-clean.

## Related

Companion PRs add matching disclaimers to `TeoSlayer/pilot-skills` (the injected content) and `pilot-protocol/skillinject` (the injector itself).