### PR TITLE
fix(deps): bump rendezvous to fix accept rate-limiter data race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,23 +5,23 @@ go 1.25.10
 require (
 	github.com/coder/websocket v1.8.14
 	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260609061942-8852c785a264
-	github.com/pilot-protocol/beacon v0.2.5
+	github.com/pilot-protocol/beacon v0.2.6
 	github.com/pilot-protocol/common v0.4.8
 	github.com/pilot-protocol/dataexchange v0.2.0
 	github.com/pilot-protocol/eventstream v0.2.2
 	github.com/pilot-protocol/handshake v0.2.1
 	github.com/pilot-protocol/nameserver v0.2.1
 	github.com/pilot-protocol/policy v0.2.2
-	github.com/pilot-protocol/rendezvous v0.2.4
+	github.com/pilot-protocol/rendezvous v0.2.5-0.20260615154750-f09cf1a708b0
 	github.com/pilot-protocol/runtime v0.3.1
 	github.com/pilot-protocol/skillinject v0.2.2
 	github.com/pilot-protocol/trustedagents v0.2.3
 	github.com/pilot-protocol/updater v0.2.2-0.20260529065627-220ed5b8383f
 	github.com/pilot-protocol/webhook v0.2.0
+	golang.org/x/sys v0.45.0
 )
 
 require (
 	github.com/expr-lang/expr v1.17.8 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260609061942-8852c785a264 
 github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260609061942-8852c785a264/go.mod h1:zoCxHYoNdj0V44OkG3Yzcye0jnwZDVUcJgAvR5Z1kwc=
 github.com/pilot-protocol/beacon v0.2.5 h1:5+pkSPoA35r+u4Hfrph/ZfOltOyiy8lh1sCfK5XqXKs=
 github.com/pilot-protocol/beacon v0.2.5/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
+github.com/pilot-protocol/beacon v0.2.6 h1:grxwaVyPRUT0W6coyjYfNkO0rpzOIrwrKn94S21DuVE=
+github.com/pilot-protocol/beacon v0.2.6/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
 github.com/pilot-protocol/common v0.4.8 h1:eS2Bc+XcZWJ/qhwwOZbXwIWhtNdOijuoEp716kQE+/c=
 github.com/pilot-protocol/common v0.4.8/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
 github.com/pilot-protocol/dataexchange v0.2.0 h1:ldE6AyrES1uvdnn1NBl0KZ7C+SSWNtmeHHU3CQhwSCo=
@@ -28,6 +30,8 @@ github.com/pilot-protocol/policy v0.2.2 h1:Co8sqZ4lRQfFA0Ot8l33VhsEwfiEVqcPz+kHY
 github.com/pilot-protocol/policy v0.2.2/go.mod h1:jzsAO71uGlRVyduPrQmS/UeqSwUpeUO/CjykHm/IfXM=
 github.com/pilot-protocol/rendezvous v0.2.4 h1:nxYm12RzEUA6zzNGcnDqxNcGBSIALL5uRH9zX+Q0CSg=
 github.com/pilot-protocol/rendezvous v0.2.4/go.mod h1:w7SC0nZCmWPyc7hxdFZ200zQVA75UoaC25MznUQXNFE=
+github.com/pilot-protocol/rendezvous v0.2.5-0.20260615154750-f09cf1a708b0 h1:kKeSXIEfE677+yanooStfSnneQ3dFCb22WPJbyj+yng=
+github.com/pilot-protocol/rendezvous v0.2.5-0.20260615154750-f09cf1a708b0/go.mod h1:Gv1BwKx5oBUZCMNpCxa9enBFa6uy9hHDSI2r28QdIrg=
 github.com/pilot-protocol/runtime v0.3.0 h1:OVPv7hyaAZsw5EPWtf2XQGfCqxgaM/iANPhIYOMp+0w=
 github.com/pilot-protocol/runtime v0.3.0/go.mod h1:GfFEIji0w7H9SSNR9Wl2q72pd2OYN3PHY9Qhcbvyrqk=
 github.com/pilot-protocol/runtime v0.3.1 h1:+W9ww0dZY/FgOBtCmIOV3w5L5Z4Upt/RIsrYElXZ1zs=


### PR DESCRIPTION
## Summary

Fixes the `Architecture gates` CI failure (`TestConcurrentDialEncryptDecrypt`
under `-race`), which has been red on `main` since June 9.

The failure is a **data race in the `rendezvous` dependency**, not in this
repo: `globalRateBucket.allow()` (the process-wide accept rate limiter)
performed an unsynchronized read-modify-write on `tokens`/`lastFill` while
being called concurrently from every `Acceptor` connection handler.

This bumps `rendezvous` v0.2.4 → the mutex-guarded fix
(pilot-protocol/rendezvous#73), which pulls `beacon` v0.2.6 transitively.

## Testing
- `go test -race -count=1 -run TestConcurrentDialEncryptDecrypt ./tests`
  now **passes (104s, no DATA RACE)** — previously failed with the race.
- `go build ./...` clean.

## Notes
- Pinned to a pseudo-version of the rendezvous fix commit; switch to the
  tagged `v0.2.5` once pilot-protocol/rendezvous#73 merges + releases.
