### PR TITLE
test(daemon): isolate HOME to fix flaky ~/.pilot test contention

### DIFF
--- a/pkg/daemon/zz_testmain_test.go
+++ b/pkg/daemon/zz_testmain_test.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates HOME for the entire package test binary.
+//
+// Many tests here construct a daemon with New(Config{}) (empty
+// IdentityPath). Such a daemon resolves its on-disk state — managed-engine
+// files (~/.pilot/managed_<netID>.json), the hostname cache, the network
+// snapshot — under os.UserHomeDir(). Without isolation those tests read and
+// write the *real* home concurrently: both within this package's parallel
+// tests and across the packages that `go test ./...` runs in parallel on a
+// shared CI runner. That races on the same files and flakes (observed
+// reddening macOS CI on the snapshot / hostname-cache / managed-engine
+// tests, which pass in isolation).
+//
+// Pointing HOME (and USERPROFILE, for os.UserHomeDir on Windows) at a
+// throwaway directory before any test runs makes every test in this
+// package hermetic. Tests that set their own HOME via t.Setenv still work —
+// they override and restore relative to this base.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "pilot-daemon-test-home-")
+	if err != nil {
+		panic("daemon test: create temp HOME: " + err.Error())
+	}
+	_ = os.Setenv("HOME", tmp)
+	_ = os.Setenv("USERPROFILE", tmp)
+
+	code := m.Run()
+
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary

Fixes a real, intermittent CI flake: `pkg/daemon` snapshot / hostname-cache
/ managed-engine tests fail on macOS runs (and locally under load) while
passing in isolation.

## Root cause
Many tests here build `New(Config{})` with an empty `IdentityPath`, so the
daemon resolves its on-disk state — `~/.pilot/managed_<netID>.json`, the
hostname cache, the network snapshot — under `os.UserHomeDir()`, i.e. the
**real home**. Run in parallel (within the package *and* across the
packages `go test ./...` runs concurrently on one CI runner) these tests
read/write the same `~/.pilot` files and race. It's timing-sensitive, so it
reddens macOS while ubuntu usually squeaks by.

Confirmed directly: before this change a test run leaves a stray
`~/.pilot/managed_1.json` in the real home.

## Fix
Add a `TestMain` that points `HOME` (and `USERPROFILE`) at a throwaway dir
before any test runs, making the whole package hermetic. Tests that set
their own `HOME` via `t.Setenv` still work (override + restore relative to
the base).

## Testing
- `go test -short ./pkg/daemon/` green; repeated concurrent `./pkg/...`
  runs show no daemon-class failures.
- Verified the real `~/.pilot` is no longer written by the test run.
