### PR TITLE
docs(changelog): release 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project uses [Semantic Versioning](https://semver.org/).
 Detailed per-release notes are on the
 [GitHub Releases page](https://github.com/TeoSlayer/pilotprotocol/releases).
 
-## [1.12.0] - 2026-06-15
+## [1.11.1] - 2026-06-15
 
 ### Added
 - **`pilotctl appstore view <id>` — a detail page for store apps.** Shows a


### PR DESCRIPTION
Corrects the unreleased CHANGELOG heading from 1.12.0 to 1.11.1 — the appstore view feature ships as a minor (last-point) release on top of v1.11.0.