### PR TITLE
ci: validate app-store catalogue entries on PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/catalogue.md
+++ b/.github/PULL_REQUEST_TEMPLATE/catalogue.md
@@ -1,0 +1,24 @@
+<!-- Deploy to TeoSlayer/pilotprotocol/.github/PULL_REQUEST_TEMPLATE/catalogue.md
+     (or paste into the description of any catalogue.json PR).
+     The human half of the app-store review gate (SPEC §7.2). -->
+
+## App-store catalogue change
+
+**App id:** `io.pilot.____`
+**Version:** `____`  (new app / version bump)
+**Publisher:** `____` (must appear in `pilot-protocol/catalog` `publishers/registry.json`)
+
+### Automated gate
+- [ ] `catalogue-validate` CI is green (sha, manifest, signature, `<ns>.help`, id/version, no downgrade).
+
+### Reviewer checklist (do not merge until all checked)
+- [ ] Publisher is in `publishers/registry.json` (or added in a linked PR).
+- [ ] **Grants are proportional** to the described function. Scrutinize any
+      `proc.exec`, `fs.write`, `key.sign`, or broad `net.dial` target.
+- [ ] `description` accurately reflects what the app does.
+- [ ] Backend host (for `net.dial`) is one the publisher controls.
+- [ ] Bundle is released on **`pilot-protocol/catalog`**, not `TeoSlayer/pilotprotocol`.
+- [ ] Existing catalogue entries are preserved (only the intended app changed).
+
+### Notes
+<!-- anything a reviewer should know: new caps, backend changes, etc. -->

--- a/.github/workflows/catalogue-validate.yml
+++ b/.github/workflows/catalogue-validate.yml
@@ -1,0 +1,33 @@
+# Deploy this to TeoSlayer/pilotprotocol/.github/workflows/catalogue-validate.yml
+# Gates every PR that edits the app-store catalogue index (SPEC §7.1).
+name: catalogue-validate
+
+on:
+  pull_request:
+    paths:
+      - "catalogue/catalogue.json"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the base ref for the downgrade check
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Extract base catalogue (for downgrade check)
+        run: |
+          git show "origin/${{ github.base_ref }}:catalogue/catalogue.json" > /tmp/base-catalogue.json 2>/dev/null || echo '{"apps":[]}' > /tmp/base-catalogue.json
+
+      - name: Build verifier
+        run: |
+          git clone --depth 1 https://github.com/pilot-protocol/app-template /tmp/app-template
+          (cd /tmp/app-template && go build -o /tmp/pilot-app ./cmd/pilot-app)
+
+      - name: Verify catalogue entries
+        run: |
+          PILOT_CATALOGUE_BASE=/tmp/base-catalogue.json /tmp/pilot-app verify catalogue/catalogue.json

--- a/.github/workflows/catalogue-validate.yml
+++ b/.github/workflows/catalogue-validate.yml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Build verifier
         run: |
-          git clone --depth 1 https://github.com/pilot-protocol/app-template /tmp/app-template
+          # Pin app-template to a released tag — this is a supply-chain trust gate,
+          # so the verifier it builds must not float on an unpinned upstream HEAD.
+          git clone --depth 1 --branch v0.1.0 https://github.com/pilot-protocol/app-template /tmp/app-template
           (cd /tmp/app-template && go build -o /tmp/pilot-app ./cmd/pilot-app)
 
       - name: Verify catalogue entries


### PR DESCRIPTION
Gates every `catalogue/catalogue.json` change with the app-store review gate (SPEC §7.1): builds the `pilot-protocol/app-template` verifier and checks each entry — bundle reachable, `bundle_sha256` matches, manifest validates + signature verifies, binary sha pinned, a `<ns>.help` method is exposed, id/version consistent, no version downgrade. Adds a reviewer PR template for the human checklist (§7.2).

Part of standardizing app publishing; full flow in `pilot-protocol/app-template` `docs/APP-PUBLISHING-SPEC.md`.