### PR TITLE
fix(pilotctl): reject non-all skill ids in disable/enable (PILOT-394)

### DIFF
--- a/cmd/pilotctl/skills.go
+++ b/cmd/pilotctl/skills.go
@@ -253,6 +253,11 @@ func cmdSkillsDisable(args []string) {
 			"usage: pilotctl skills disable <skill-id|all>",
 			"skill id required")
 	}
+	if args[0] != "all" {
+		fatalHint("invalid_argument",
+			"only 'all' is supported; per-skill disable is not yet implemented",
+			"unknown skill id: %s", args[0])
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		fatalCode("internal", "home dir: %v", err)
@@ -343,6 +348,11 @@ func cmdSkillsEnable(args []string) {
 		fatalHint("invalid_argument",
 			"usage: pilotctl skills enable <skill-id|all>",
 			"skill id required")
+	}
+	if args[0] != "all" {
+		fatalHint("invalid_argument",
+			"only 'all' is supported; per-skill enable is not yet implemented",
+			"unknown skill id: %s", args[0])
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/cmd/pilotctl/zz_skills_test.go
+++ b/cmd/pilotctl/zz_skills_test.go
@@ -153,3 +153,32 @@ func TestCLISkillsDisable_RejectsNoArgs(t *testing.T) {
 		t.Errorf("expected 'usage' or 'skill id required' in stderr, got: %s", stderr)
 	}
 }
+
+// TestCLISkillsDisable_RejectsNonAll pins the PILOT-394 fix: pre-fix the
+// command accepted any <skill-id> but silently ran a global disable.
+// Now only "all" is accepted; anything else prints an error.
+func TestCLISkillsDisable_RejectsNonAll(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"skills", "disable", "foo"}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for 'disable foo', got 0\nstderr=%s", stderr)
+	}
+	low := strings.ToLower(stderr)
+	if !strings.Contains(low, "only 'all' is supported") {
+		t.Errorf("expected 'only all is supported' in stderr, got: %s", stderr)
+	}
+}
+
+// TestCLISkillsEnable_RejectsNonAll pins the PILOT-394 fix for the
+// enable side: only "all" is accepted; anything else prints an error.
+func TestCLISkillsEnable_RejectsNonAll(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runCLI(t, []string{"skills", "enable", "bar"}, nil)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for 'enable bar', got 0\nstderr=%s", stderr)
+	}
+	low := strings.ToLower(stderr)
+	if !strings.Contains(low, "only 'all' is supported") {
+		t.Errorf("expected 'only all is supported' in stderr, got: %s", stderr)
+	}
+}


### PR DESCRIPTION
## What failed

`pilotctl skills disable` and `pilotctl skills enable` accept `<skill-id|all>` but ignore the argument — both commands silently run the global Uninstall / re-enable. `disable foo` and `disable all` do the same thing.

## Why this fix

Since only one shared SKILL.md exists today, the pragmatic answer is to reject any id except `all` with a clear error. Per-skill enable/disable can be added in a future ticket when the skillinject library supports per-skill state.

## Changes

- **cmdSkillsDisable**: validate `args[0] == "all"`, print error otherwise
- **cmdSkillsEnable**: validate `args[0] == "all"`, print error otherwise
- Two new tests pinning the fix for non-all rejection

## Verification

- `go build ./cmd/pilotctl/` — clean
- `go vet ./cmd/pilotctl/` — clean
- `go test -count=1 ./cmd/pilotctl/` — all pass (9.65s)
- `make build` — all 8 binaries build cleanly
- New tests `TestCLISkillsDisable_RejectsNonAll` and `TestCLISkillsEnable_RejectsNonAll` added

Closes [PILOT-394](https://vulturelabs.atlassian.net/browse/PILOT-394)