### PR TITLE
fix(pilotctl): catalogue list shows headline only with always-on view pointer (PILOT-405)

### DIFF
--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -255,6 +255,10 @@ func cmdAppStoreCatalogue(_ []string) {
 			name = fmt.Sprintf("%s (%s)", e.DisplayName, e.ID)
 		}
 		fmt.Printf("\n  %s  v%s\n", name, e.Version)
+		// Headline: the catalogue's short one-line description acts as the
+		// headline/teaser. The full description lives in metadata.json and
+		// is shown by `pilotctl appstore view`.
+		fmt.Printf("    %s\n", e.Description)
 		// Teaser line: vendor · categories · license · size — only the
 		// parts a v2 entry actually carries. v1 entries skip it entirely.
 		var bits []string
@@ -273,11 +277,9 @@ func cmdAppStoreCatalogue(_ []string) {
 		if len(bits) > 0 {
 			fmt.Printf("    %s\n", strings.Join(bits, " · "))
 		}
-		fmt.Printf("    %s\n", e.Description)
-		// Point at the new detail view when extended metadata is published.
-		if e.MetadataURL != "" {
-			fmt.Printf("    view:    pilotctl appstore view %s\n", e.ID)
-		}
+		// Always point at the detail view — even without extended metadata
+		// the view command shows local install facts.
+		fmt.Printf("    view:    pilotctl appstore view %s\n", e.ID)
 		fmt.Printf("    install: pilotctl appstore install %s\n", e.ID)
 	}
 }


### PR DESCRIPTION
## What

The `pilotctl appstore catalogue` list was printing the short description mixed in with the teaser metadata line, and the `view:` pointer only appeared when extended metadata was published.

## Changes

1. **Move description to headline position** — the catalogue's one-line description now prints immediately after the name+version line, acting as the headline/teaser (as intended by the catalogue schema), before the vendor/categories/license/size meta row.
2. **Always show the `view:` pointer** — even without a `metadata_url` set, `pilotctl appstore view <id>` shows local install facts (installed state, integrity, permissions). The pointer should always be present.
3. **`--json` output is unchanged** — this fix only touches the human-readable text output.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./cmd/pilotctl/` — OK (9.3s)
- `--json` path untouched

Closes PILOT-405