### PR TITLE
fix(appstore): always show view pointer in catalogue listing (PILOT-405)

### DIFF
--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -274,10 +274,9 @@ func cmdAppStoreCatalogue(_ []string) {
 			fmt.Printf("    %s\n", strings.Join(bits, " · "))
 		}
 		fmt.Printf("    %s\n", e.Description)
-		// Point at the new detail view when extended metadata is published.
-		if e.MetadataURL != "" {
-			fmt.Printf("    view:    pilotctl appstore view %s\n", e.ID)
-		}
+		// Always point at the detail view; `pilotctl appstore view <id>` works
+		// from the catalogue entry alone (rich metadata is optional).
+		fmt.Printf("    view:    pilotctl appstore view %s\n", e.ID)
 		fmt.Printf("    install: pilotctl appstore install %s\n", e.ID)
 	}
 }


### PR DESCRIPTION
## What changed

The `pilotctl appstore catalogue` list now **always** prints the `view: pilotctl appstore view <id>` pointer for every entry, regardless of whether the catalogue entry has extended metadata pinned.

## Why

Previously the view pointer was conditional on `e.MetadataURL != ""`, which meant entries without a detail-doc pin silently omitted the "view" option. The `view` command works from the catalogue entry alone (showing teaser fields) and degrades gracefully — it should always be discoverable.

## Verification
- `go build ./cmd/pilotctl/` — clean
- `go vet ./cmd/pilotctl/` — clean  
- `go test -run "AppStore|Catalogue|catalogue|cat" ./cmd/pilotctl/` — pass

Closes [PILOT-405](https://vulturelabs.atlassian.net/browse/PILOT-405)