### PR TITLE
fix: inject nodeID into telemetry events and add catalogue_viewed payload

### DIFF
--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -248,8 +248,9 @@ func cmdAppStoreCatalogue(_ []string) {
 		identityPath := configDir() + "/identity.json"
 		client := telemetry.NewClientFromIdentity(url, identityPath, 0)
 		err := client.Send(telemetry.Event{
-			Kind: "catalogue_viewed",
-			TS:   time.Now().UTC().Format(time.RFC3339),
+			Kind:    "catalogue_viewed",
+			TS:      time.Now().UTC().Format(time.RFC3339),
+			Payload: json.RawMessage(`{"surface":"catalogue"}`),
 		})
 		if err != nil {
 			slog.Warn("telemetry send failed, catalogue still rendered", "err", err)

--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -98,6 +98,7 @@ func (c *Client) Send(events ...Event) error {
 	url := c.url
 	sign := c.sign
 	pubKeyB := c.pubKeyB
+	nodeID := c.nodeID
 	c.mu.Unlock()
 
 	if disabled || url == "" {
@@ -111,6 +112,15 @@ func (c *Client) Send(events ...Event) error {
 
 	if len(events) == 0 {
 		return nil
+	}
+
+	// Inject node ID into events that don't supply their own.
+	if nodeID != 0 {
+		for i := range events {
+			if events[i].NodeID == 0 {
+				events[i].NodeID = nodeID
+			}
+		}
 	}
 
 	body, err := json.Marshal(events)


### PR DESCRIPTION
## Summary
- **NodeID always 0 fixed**: `Client.Send()` now injects `c.nodeID` into outgoing events where the caller left `NodeID == 0`. Previously the `nodeID` field stored at construction time was never written into the event struct before marshaling.
- **catalogue_viewed empty payload fixed**: `appstore_catalogue.go` now sends `{"surface":"catalogue"}` in the event payload so the server has context for the event.

## Test plan
- [ ] `go build ./...` — no compilation errors (pre-commit hook passed)
- [ ] `go vet ./...` — no issues (pre-commit hook passed)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)