### PR TITLE
fix(security): add decompression bomb protection to untarUnder (PILOT-418)

### DIFF
--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -417,7 +417,10 @@ func httpGet(raw string) (io.ReadCloser, error) {
 
 // untarUnder writes every entry in r under dst, refusing any path
 // that resolves outside dst (mirrors the supervisor's
-// resolveUnder guard on manifest.binary.path).
+// resolveUnder guard on manifest.binary.path). Each extracted file
+// is capped at maxExtractBytes to prevent decompression bomb attacks.
+const maxExtractBytes = 64 << 20 // 64 MiB per-file cap
+
 func untarUnder(r io.Reader, dst string) error {
 	tr := tar.NewReader(r)
 	for {
@@ -446,7 +449,7 @@ func untarUnder(r io.Reader, dst string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(f, tr); err != nil {
+			if _, err := io.Copy(f, io.LimitReader(tr, maxExtractBytes)); err != nil {
 				_ = f.Close()
 				return err
 			}


### PR DESCRIPTION
## What

The `untarUnder` function in `cmd/pilotctl/appstore_catalogue.go` extracts tar entries from app store catalogue bundles without a per-file size limit.

## Why

While the HTTP download is already capped at 1 MiB (`io.LimitReader(body, 1<<20)`), a maliciously crafted tar.gz with an extreme compression ratio could bypass this cap and fill disk through decompression.

## Fix

Wrap the tar entry extraction with `io.LimitReader(tr, 64<<20)` — a 64 MiB per-file maximum. This matches the size limit used by similar extraction functions in the codebase.

## Verification

- `go build ./cmd/pilotctl/` — passes
- `go vet ./cmd/pilotctl/...` — clean
- Only 1 file changed: `cmd/pilotctl/appstore_catalogue.go` (+5/-2 lines)

Closes [PILOT-418](https://vulturelabs.atlassian.net/browse/PILOT-418)