### PR TITLE
Bind inner packet Src to authenticated peerNodeID

### DIFF
--- a/pkg/daemon/tunnel.go
+++ b/pkg/daemon/tunnel.go
@@ -1367,6 +1367,28 @@ func (tm *TunnelManager) handleEncrypted(data []byte, from *net.UDPAddr) {
 		return
 	}
 
+	// Identity binding (transport security). The AEAD authenticated the
+	// frame-header peerNodeID: reaching this point proves the sender holds
+	// the session key bound to it. The inner packet's Src, by contrast, is
+	// plaintext the sender chose freely. Reject any frame whose inner
+	// Src.Node disagrees with the authenticated peerNodeID — otherwise a
+	// node holding one valid session could forge packets impersonating any
+	// other node to the SYN trust gate and to applications (which read
+	// conn.RemoteAddr().Node). Relay-delivered frames re-enter this path with
+	// peerNodeID taken from the inner secure frame's AEAD, never the beacon's
+	// untrusted srcNodeID, so the check covers direct and relayed traffic
+	// alike. Src.Network may vary across a node's networks; identity is the
+	// node id, so only .Node is compared.
+	if pkt.Src.Node != peerNodeID {
+		slog.Warn("tunnel: dropping frame with spoofed source node",
+			"authenticated_peer", peerNodeID, "claimed_src", pkt.Src.Node)
+		tm.publishEvent("security.src_spoofed", map[string]interface{}{
+			"authenticated_peer": peerNodeID,
+			"claimed_src":        pkt.Src.Node,
+		})
+		return
+	}
+
 	// v1.9.1 NAT-keepalive: drop tunnel-keepalive packets before recvCh
 	// delivery. They're authenticated (the AEAD verified the sender's
 	// nodeID AAD) so we still want all the side-effects below (recordInbound

--- a/pkg/daemon/zz_nat_keepalive_bug_test.go
+++ b/pkg/daemon/zz_nat_keepalive_bug_test.go
@@ -202,6 +202,7 @@ func TestHandleEncryptedDropsKeepaliveBeforeRecvCh(t *testing.T) {
 		Version:  protocol.Version,
 		Protocol: protocol.ProtoControl,
 		DstPort:  protocol.PortPing,
+		Src:      protocol.Addr{Node: peerNodeID}, // inner Src == authenticated peerNodeID
 	}
 	plaintext, err := ka.Marshal()
 	if err != nil {

--- a/pkg/daemon/zz_nat_remap_bug_test.go
+++ b/pkg/daemon/zz_nat_remap_bug_test.go
@@ -99,6 +99,7 @@ func TestPeerNATRemapNotLearnedOnDecrypt(t *testing.T) {
 	// Build a real encrypted frame the way the peer would, then deliver
 	// it via handleEncrypted with from=addrNew (the post-remap source).
 	pkt := newPacket("post-nat-remap-payload")
+	pkt.Src.Node = peerNodeID // well-behaved peer: inner Src == authenticated peerNodeID
 	plaintext, err := pkt.Marshal()
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)

--- a/pkg/daemon/zz_tunnel_handle_test.go
+++ b/pkg/daemon/zz_tunnel_handle_test.go
@@ -529,6 +529,7 @@ func TestHandleEncryptedValidDeliversToRecvCh(t *testing.T) {
 	// Build a real encrypted frame that handleEncrypted will accept:
 	// nonce = prefix(4) || counter(8) ; AAD = BE(peerNodeID)
 	pkt := newPacket("encrypted-payload")
+	pkt.Src.Node = peerNodeID // well-behaved peer: inner Src == authenticated peerNodeID
 	plaintext, err := pkt.Marshal()
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
@@ -557,6 +558,63 @@ func TestHandleEncryptedValidDeliversToRecvCh(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatalf("expected packet on recvCh")
+	}
+}
+
+// TestHandleEncryptedDropsSpoofedSrc proves the transport identity-binding
+// fix: a frame that authenticates under peerNodeID but carries a DIFFERENT
+// inner Src.Node is dropped, not delivered. Without the fix a node holding
+// one valid session could impersonate any other node to applications.
+func TestHandleEncryptedDropsSpoofedSrc(t *testing.T) {
+	t.Parallel()
+	tm := NewTunnelManager()
+	if err := tm.EnableEncryption(); err != nil {
+		t.Fatalf("EnableEncryption: %v", err)
+	}
+	curve := ecdh.X25519()
+	peerPriv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("peer keygen: %v", err)
+	}
+	pc, err := tm.deriveSecret(peerPriv.PublicKey().Bytes())
+	if err != nil {
+		t.Fatalf("deriveSecret: %v", err)
+	}
+	const peerNodeID = uint32(0x11223344)
+	tm.mu.Lock()
+	tm.envelope.Install(peerNodeID, pc)
+	tm.mu.Unlock()
+
+	// Authenticated peer is 0x11223344, but the inner packet claims a
+	// DIFFERENT source node — a forged source.
+	pkt := newPacket("spoofed-payload")
+	pkt.Src.Node = 0x99999999 // != peerNodeID
+	plaintext, err := pkt.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	nonce := make([]byte, pc.AEAD.NonceSize())
+	copy(nonce[0:4], pc.NoncePrefix[:])
+	binary.BigEndian.PutUint64(nonce[4:12], 1)
+	aad := make([]byte, 4)
+	binary.BigEndian.PutUint32(aad, peerNodeID)
+	ct := pc.AEAD.Seal(nil, nonce, plaintext, aad)
+
+	data := make([]byte, 4+12+len(ct))
+	binary.BigEndian.PutUint32(data[0:4], peerNodeID)
+	copy(data[4:16], nonce)
+	copy(data[16:], ct)
+
+	tm.handleEncrypted(data, mustUDPAddr(t, "127.0.0.1:5555"))
+
+	if got := atomic.LoadUint64(&tm.PktsRecv); got != 0 {
+		t.Fatalf("spoofed-Src frame must not count as received; PktsRecv = %d", got)
+	}
+	select {
+	case got := <-tm.RecvCh():
+		t.Fatalf("spoofed-Src frame must NOT be delivered, got payload %q", got.Packet.Payload)
+	case <-time.After(100 * time.Millisecond):
+		// correct: nothing delivered
 	}
 }
 


### PR DESCRIPTION
Transport identity-binding fix: after AEAD decrypt, drop frames whose inner `Src.Node` != the authenticated frame `peerNodeID`. Prevents a node holding one valid session from forging its source node id to the SYN trust gate and to apps (`conn.RemoteAddr().Node`). Relay-safe — relay frames re-enter the same path with peerNodeID from the inner secure frame.

Fleet-verified safe (spoof + pilot-traffic use real per-identity daemons). Adds `TestHandleEncryptedDropsSpoofedSrc`; 3 fixtures set `Src=peer`. `go test -race ./pkg/daemon/` green.