### PR TITLE
appstore: per-platform bundles (v3 catalogue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,6 @@ jobs:
         # PR #120). Integration is now exclusively in nightly.yml.
         # -short skips 3 known-slow stress tests in pkg/daemon and
         # pkg/daemon/udpio; everything else runs.
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: go test -short -count=1 -timeout 600s ./pkg/... ./cmd/... ./internal/...

--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -32,6 +32,13 @@ ignores the v2 fields. **Always set `"version": 2` when using any v2 field.**
       "bundle_url": "https://<host>/<path>.tar.gz",
       "bundle_sha256": "<hex sha256 of the tarball>",
 
+      "bundles": {
+        "linux/amd64":  {"bundle_url": "https://<host>/<path>-linux-amd64.tar.gz",  "bundle_sha256": "<hex>"},
+        "linux/arm64":  {"bundle_url": "https://<host>/<path>-linux-arm64.tar.gz",  "bundle_sha256": "<hex>"},
+        "darwin/arm64": {"bundle_url": "https://<host>/<path>-darwin-arm64.tar.gz", "bundle_sha256": "<hex>"},
+        "darwin/amd64": {"bundle_url": "https://<host>/<path>-darwin-amd64.tar.gz", "bundle_sha256": "<hex>"}
+      },
+
       "display_name": "<human name, optional>",
       "vendor": "<vendor name, optional>",
       "categories": ["<optional>", "<tags>"],
@@ -50,6 +57,14 @@ Everything from `display_name` down is optional (`omitempty`). The five v1
 fields stay required. `pilotctl` decodes the index directly into
 `catalogueEntry` in `cmd/pilotctl/appstore_catalogue.go` — any field added
 here must also land there.
+
+`bundles` (v3) is the per-platform map keyed by `"os/arch"`. When present,
+`install` picks the host's entry and **errors** if the host platform isn't
+listed (rather than installing a binary that can't exec). `bundle_url` /
+`bundle_sha256` stay as the back-compat primary (linux/amd64) that pre-v3
+clients fetch, so a `bundles`-bearing entry still installs on old `pilotctl`
+for that one platform. An entry that omits `bundles` behaves exactly as v1/v2
+(single-platform, top-level `bundle_url`).
 
 ## Detail schema (`apps/<id>/metadata.json`)
 

--- a/cmd/pilotctl/appstore_catalogue.go
+++ b/cmd/pilotctl/appstore_catalogue.go
@@ -48,6 +48,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -87,6 +89,14 @@ type catalogueEntry struct {
 	BundleURL   string `json:"bundle_url"`
 	BundleSHA   string `json:"bundle_sha256"`
 
+	// --- v3 per-platform bundles ---
+	// Bundles maps "os/arch" (e.g. "darwin/arm64") → that platform's
+	// tarball + sha256. When present, install picks the host's entry;
+	// BundleURL/BundleSHA above are the back-compat primary (linux/amd64)
+	// that pre-v3 clients still fetch. A v1/v2 entry omits this map and
+	// install uses BundleURL as before.
+	Bundles map[string]bundleVariant `json:"bundles,omitempty"`
+
 	// --- v2 teaser fields (cheap, shown in the catalogue listing) ---
 	DisplayName string   `json:"display_name,omitempty"`
 	Vendor      string   `json:"vendor,omitempty"`
@@ -102,6 +112,34 @@ type catalogueEntry struct {
 	// manifest.
 	MetadataURL string `json:"metadata_url,omitempty"`
 	MetadataSHA string `json:"metadata_sha256,omitempty"`
+}
+
+// bundleVariant is one platform's downloadable tarball + its pinned sha256.
+type bundleVariant struct {
+	BundleURL string `json:"bundle_url"`
+	BundleSHA string `json:"bundle_sha256"`
+}
+
+// resolveBundle returns the tarball URL + sha256 to install on THIS host.
+// A v3 entry (Bundles populated) is strict: it picks the host's os/arch and
+// errors if that platform wasn't published, rather than silently fetching a
+// binary that can't exec. A v1/v2 entry (no Bundles) uses the single
+// top-level BundleURL/BundleSHA, exactly as before.
+func (e catalogueEntry) resolveBundle() (url, sha string, err error) {
+	if len(e.Bundles) == 0 {
+		return e.BundleURL, e.BundleSHA, nil
+	}
+	plat := runtime.GOOS + "/" + runtime.GOARCH
+	if v, ok := e.Bundles[plat]; ok && v.BundleURL != "" {
+		return v.BundleURL, v.BundleSHA, nil
+	}
+	avail := make([]string, 0, len(e.Bundles))
+	for k := range e.Bundles {
+		avail = append(avail, k)
+	}
+	sort.Strings(avail)
+	return "", "", fmt.Errorf("%s has no bundle for this platform (%s); published platforms: %s",
+		e.ID, plat, strings.Join(avail, ", "))
 }
 
 // catalogueURL returns the URL pilotctl should fetch the catalogue
@@ -328,13 +366,17 @@ func resolveInstallTarget(target string) (string, installSource, error) {
 // CDN substitute), and unpacks it into a tempdir whose path is
 // returned for the install path to consume.
 func fetchAndUnpackBundle(e catalogueEntry) (string, error) {
-	if e.BundleSHA == "" || e.BundleSHA == "REPLACE_AT_RELEASE_TIME" {
+	bundleURL, bundleSHA, err := e.resolveBundle()
+	if err != nil {
+		return "", err
+	}
+	if bundleSHA == "" || bundleSHA == "REPLACE_AT_RELEASE_TIME" {
 		return "", fmt.Errorf("catalogue entry %s has placeholder sha256 — the release pipeline hasn't filled this in yet", e.ID)
 	}
-	fmt.Printf("fetching %s ...\n", e.BundleURL)
-	body, err := openURL(e.BundleURL)
+	fmt.Printf("fetching %s ...\n", bundleURL)
+	body, err := openURL(bundleURL)
 	if err != nil {
-		return "", fmt.Errorf("fetch %s: %w", e.BundleURL, err)
+		return "", fmt.Errorf("fetch %s: %w", bundleURL, err)
 	}
 	defer body.Close()
 
@@ -352,8 +394,8 @@ func fetchAndUnpackBundle(e catalogueEntry) (string, error) {
 		return "", err
 	}
 	got := hex.EncodeToString(h.Sum(nil))
-	if got != e.BundleSHA {
-		return "", fmt.Errorf("bundle sha256 mismatch: want=%s got=%s — the cdn served different bytes than the catalogue pinned", e.BundleSHA, got)
+	if got != bundleSHA {
+		return "", fmt.Errorf("bundle sha256 mismatch: want=%s got=%s — the cdn served different bytes than the catalogue pinned", bundleSHA, got)
 	}
 	fmt.Printf("sha256 OK (%s)\n", got)
 

--- a/cmd/pilotctl/zz_appstore_resolvebundle_test.go
+++ b/cmd/pilotctl/zz_appstore_resolvebundle_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// v1/v2 entry (no Bundles map) falls back to the single top-level bundle_url.
+func TestResolveBundle_LegacySinglePlatform(t *testing.T) {
+	e := catalogueEntry{ID: "io.pilot.x", BundleURL: "https://h/x.tar.gz", BundleSHA: "abc"}
+	url, sha, err := e.resolveBundle()
+	if err != nil || url != "https://h/x.tar.gz" || sha != "abc" {
+		t.Fatalf("legacy fallback: url=%q sha=%q err=%v", url, sha, err)
+	}
+}
+
+// v3 entry picks the host's os/arch from the Bundles map.
+func TestResolveBundle_PicksHostPlatform(t *testing.T) {
+	host := runtime.GOOS + "/" + runtime.GOARCH
+	e := catalogueEntry{
+		ID:        "io.pilot.x",
+		BundleURL: "https://h/x-linux-amd64.tar.gz", // primary, should be ignored on non-linux/amd64 hosts when host has its own
+		BundleSHA: "primary",
+		Bundles: map[string]bundleVariant{
+			host:           {BundleURL: "https://h/host.tar.gz", BundleSHA: "hostsha"},
+			"plan9/risatx": {BundleURL: "https://h/other.tar.gz", BundleSHA: "x"},
+		},
+	}
+	url, sha, err := e.resolveBundle()
+	if err != nil || url != "https://h/host.tar.gz" || sha != "hostsha" {
+		t.Fatalf("host pick: url=%q sha=%q err=%v", url, sha, err)
+	}
+}
+
+// v3 entry that omits the host platform errors (no silent broken install),
+// and lists what IS available.
+func TestResolveBundle_MissingHostPlatformErrors(t *testing.T) {
+	e := catalogueEntry{
+		ID:        "io.pilot.x",
+		BundleURL: "https://h/x.tar.gz",
+		BundleSHA: "abc",
+		Bundles: map[string]bundleVariant{
+			"plan9/risatx": {BundleURL: "https://h/other.tar.gz", BundleSHA: "x"},
+		},
+	}
+	_, _, err := e.resolveBundle()
+	if err == nil {
+		t.Fatal("expected error for unsupported host platform")
+	}
+	if !strings.Contains(err.Error(), "plan9/risatx") {
+		t.Fatalf("error should list available platforms, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

A published app ships **one** binary for whatever host built it. cosift was built on a Mac (Mach-O arm64) so it only runs on Apple Silicon; sixtyfour was built on the Linux VM (ELF x86-64) so it only runs on Linux. On any other platform the daemon spawn fails with `exec format error`. There is no multi-platform support today — the manifest is single-binary and the catalogue entry has a single `bundle_url`.

## Fix (client side)

Catalogue entries may now carry a `bundles` map keyed by `"os/arch"`:

```json
"bundles": {
  "linux/amd64":  {"bundle_url": "...-linux-amd64.tar.gz",  "bundle_sha256": "..."},
  "darwin/arm64": {"bundle_url": "...-darwin-arm64.tar.gz", "bundle_sha256": "..."}
}
```

`install` resolves `runtime.GOOS+"/"+runtime.GOARCH`, fetches that platform's tarball, sha-checks it as before, and **errors (listing published platforms)** when the host platform isn't published — instead of fetching a binary that can't exec.

## Compatibility

- `bundle_url`/`bundle_sha256` stay as the back-compat **primary (linux/amd64)**, so a v3 entry still installs on pre-v3 `pilotctl` (for that one platform).
- Entries with no `bundles` map behave exactly as v1/v2 (single-platform).
- No manifest-schema change, no daemon/supervisor change: each per-platform bundle is still a normal single-binary signed bundle; the daemon runs whatever binary is in the installed bundle.

The publisher side (build all 4 + write the map + upload all assets) is in pilot-protocol/app-template; this PR is the consumer half. Adds `TestResolveBundle_*` and updates `catalogue/README.md`.