### PR TITLE
Bump common to v0.5.3 (pinned badge issuer key)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260616142430-8edfed7efa72
 	github.com/pilot-protocol/beacon v0.2.6
-	github.com/pilot-protocol/common v0.5.2
+	github.com/pilot-protocol/common v0.5.3
 	github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260615113607-fac933edea98
 	github.com/pilot-protocol/eventstream v0.2.2
 	github.com/pilot-protocol/handshake v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260616142430-8edfed7efa72 
 github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260616142430-8edfed7efa72/go.mod h1:leZPtX43gE2JB7xeljexXri81g6qhdZfYExLtzI+bhg=
 github.com/pilot-protocol/beacon v0.2.6 h1:grxwaVyPRUT0W6coyjYfNkO0rpzOIrwrKn94S21DuVE=
 github.com/pilot-protocol/beacon v0.2.6/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
-github.com/pilot-protocol/common v0.5.2 h1:9XfXChC/9fX+BH0TT/wBwcgOMh7m+0IDjf80pjxqiRk=
-github.com/pilot-protocol/common v0.5.2/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
+github.com/pilot-protocol/common v0.5.3 h1:CsBBmzuQn75G1MKVvKdLp77G9nf6fC7YGLZh8DVeZEI=
+github.com/pilot-protocol/common v0.5.3/go.mod h1:yrAwPXGVMbXU+SADvOCmbdXjK/wJ3uA0KshyLvRlej4=
 github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260615113607-fac933edea98 h1:Bqgnf4CZC7aZJyDzz/E7agwXotArJg2FvFlNDqouhLo=
 github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260615113607-fac933edea98/go.mod h1:tM9eyyruBdnxhhUtViasUjnAElwF/r5PQvCYKLdlTLY=
 github.com/pilot-protocol/eventstream v0.2.2 h1:E0IjveK7K+dsIbE/5hD3N821FkHzxVsx1tiAORMzt8k=


### PR DESCRIPTION
Picks up common v0.5.3, which pins the production badge issuer key (bdg-v1). With this, a locally-built `pilotctl verify status` / daemon verifies real badges offline against the pinned key instead of failing closed on the placeholder.

go.mod/go.sum only. Build green (`go build ./...`); badge handler + verify-status tests pass against the real key (a forged sig still correctly fails verification).

Note: this is the CLIENT side only. Prod rendezvous stays INERT — the registry won't accept/serve real badges until it's rebuilt on v0.5.3 and you give the go-live.