### PR TITLE
Bump updater to v0.2.3 for fail-closed attestation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pilot-protocol/runtime v0.3.1
 	github.com/pilot-protocol/skillinject v0.2.3
 	github.com/pilot-protocol/trustedagents v0.2.3
-	github.com/pilot-protocol/updater v0.2.2
+	github.com/pilot-protocol/updater v0.2.3
 	github.com/pilot-protocol/webhook v0.2.0
 	golang.org/x/sys v0.46.0
 )

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/pilot-protocol/skillinject v0.2.3 h1:Bf0tqRe7tqYY27X5RGCOf4LGjtWpyQvN
 github.com/pilot-protocol/skillinject v0.2.3/go.mod h1:fCzivA/bjkXRgGjp6yd7nqfaIETtU+lQRocBu0J/O9g=
 github.com/pilot-protocol/trustedagents v0.2.3 h1:QQJHYqzPrECJwkCev0xIDBMjd92uhtcxcCMc2aOrRHc=
 github.com/pilot-protocol/trustedagents v0.2.3/go.mod h1:gDgEOC9lHmXSS9v45h80XxlmUS861soIrA0AsbXiSV4=
-github.com/pilot-protocol/updater v0.2.2 h1:uA+Gmbs3/sMoumtjwCMXUHo3TAKg51VRch88m0wUtZA=
-github.com/pilot-protocol/updater v0.2.2/go.mod h1:wn+HkjgChZ1QCCkOHBolAol42mxyyW/iz7oOFJLciT4=
+github.com/pilot-protocol/updater v0.2.3 h1:9+Y2XvyEnfxjbguho8AIKLdEK+Gzj2I7lkad2qIu6JY=
+github.com/pilot-protocol/updater v0.2.3/go.mod h1:wn+HkjgChZ1QCCkOHBolAol42mxyyW/iz7oOFJLciT4=
 github.com/pilot-protocol/webhook v0.2.0 h1:3UFU9X2yBb0iKlPbzVcism+Z6yCrBBaOgdo9+vd4Wf4=
 github.com/pilot-protocol/webhook v0.2.0/go.mod h1:WVXhHFg+o0pHHk+4nXMCh1zl/ZAyZ3AXrtx6mNuZS6g=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=


### PR DESCRIPTION
## What

Bumps `github.com/pilot-protocol/updater` from **v0.2.2** to **v0.2.3** in `go.mod`/`go.sum`.

## Why

`cmd/updater` builds the auto-updater binary shipped to client daemons (Homebrew + auto-update). updater **v0.2.3** makes SLSA attestation verification of `checksums.txt` **fail closed** when the `gh` CLI is absent — previously this was a silent no-op ("gh absent => pass"), which disabled the entire provenance gate on headless production hosts (install.sh never installs gh). That gap collapsed auto-update integrity to "anyone with GitHub repo-write access can ship a malicious release."

This bump is what actually ships the **H5 fail-closed behavior** to client daemons. The `--skip-attestation` flag (added in #307) was already wired to `updater.Config.SkipAttestation`, but the field was a passive opt-out until v0.2.3 introduced the fail-closed default.

## Verification

- `GOWORK=off go get github.com/pilot-protocol/updater@v0.2.3 && go mod tidy` — go.mod now pins v0.2.3, go.sum updated.
- `GOWORK=off go build ./cmd/updater/...` — OK
- `go vet ./cmd/updater/...` — OK
- `go test ./cmd/updater/...` — PASS
- `gofmt -l cmd/updater/` — clean
- Exported (non-test) API surface of the updater module is **identical** between v0.2.2 and v0.2.3 (same `Config`/`Updater`/`New` signatures; `SkipAttestation bool` field unchanged). The only deltas are added test functions exercising the fail-closed path. No other change to `cmd/updater` required.

## Scope

Dependency bump only — go.mod + go.sum (3 insertions, 3 deletions). No source changes.