### PR TITLE
go.mod: bump app-store to the proc.exec version

### DIFF
--- a/cmd/pilotctl/zz_procexec_test.go
+++ b/cmd/pilotctl/zz_procexec_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pilot-protocol/app-store/pkg/manifest"
+)
+
+// TestProcExecCapabilityAccepted pins that this daemon's pinned app-store knows
+// the proc.exec capability. CLI apps ship a proc.exec grant scoped to one
+// command; before the app-store bump the daemon validated every manifest with a
+// vocabulary that lacked proc.exec and would reject them as "not a known
+// capability". This is the regression guard for the bump.
+func TestProcExecCapabilityAccepted(t *testing.T) {
+	mk := func(grants []any) *manifest.Manifest {
+		raw, _ := json.Marshal(map[string]any{
+			"id":               "io.pilot.gh",
+			"app_version":      "0.1.0",
+			"manifest_version": 1,
+			"binary":           map[string]any{"runtime": "go", "path": "bin/app", "sha256": strings.Repeat("a", 64)},
+			"grants":           grants,
+			"protection":       "guarded",
+			"store":            map[string]any{"publisher": "ed25519:AAAAB3NzaC1yc2EAAAADAQABAAABAQDXX0000000", "signature": "deadbeef"},
+		})
+		m, err := manifest.Parse(raw)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return m
+	}
+
+	// A CLI app's manifest (proc.exec scoped to the command) must validate.
+	ok := mk([]any{
+		map[string]any{"cap": "proc.exec", "target": "gh"},
+		map[string]any{"cap": "audit.log", "target": "*"},
+	})
+	if errs := ok.Validate(); len(errs) != 0 {
+		t.Fatalf("proc.exec manifest must validate against the pinned app-store: %v", errs)
+	}
+
+	// The hardened target still rejects a wildcard ("run anything").
+	bad := mk([]any{
+		map[string]any{"cap": "proc.exec", "target": "*"},
+		map[string]any{"cap": "audit.log", "target": "*"},
+	})
+	if errs := bad.Validate(); len(errs) == 0 {
+		t.Fatal("proc.exec target '*' must be rejected by the pinned app-store (hardened target)")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.11
 
 require (
 	github.com/coder/websocket v1.8.15
-	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260616142430-8edfed7efa72
+	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622180016-07b4170265dc
 	github.com/pilot-protocol/beacon v0.2.6
 	github.com/pilot-protocol/common v0.5.5
 	github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260615113607-fac933edea98

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNU
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260616142430-8edfed7efa72 h1:vDiQ7ZheKIzlNqfviu5zeQzGVTMP63k1hC5HodEuyeQ=
-github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260616142430-8edfed7efa72/go.mod h1:leZPtX43gE2JB7xeljexXri81g6qhdZfYExLtzI+bhg=
+github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622180016-07b4170265dc h1:Ze7h3rEPMhFaAyjNH9riySBs8HEeeoB3wODwtoLQ4Eo=
+github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622180016-07b4170265dc/go.mod h1:leZPtX43gE2JB7xeljexXri81g6qhdZfYExLtzI+bhg=
 github.com/pilot-protocol/beacon v0.2.6 h1:grxwaVyPRUT0W6coyjYfNkO0rpzOIrwrKn94S21DuVE=
 github.com/pilot-protocol/beacon v0.2.6/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
 github.com/pilot-protocol/common v0.5.5 h1:mnv3q84alVaotGD+Qxfo4ECFEquqsUwrI3mjKIGUKFY=


### PR DESCRIPTION
Repoints the pinned `github.com/pilot-protocol/app-store` dependency to the commit that adds the **`proc.exec`** capability, so the daemon's manifest validation accepts CLI apps (which ship a `proc.exec` grant scoped to one command). Without the bump, the deployed daemon validates against a capability vocabulary that lacks `proc.exec` and rejects them.

Depends on **pilot-protocol/app-store#24**; re-pin to the merged SHA once it lands.

## Footprint: zero business logic
This is deliberately a **dependency-pointer + test** change only. The `proc.exec` logic lives entirely in the app-store dependency — `pilotctl`/supervisor already delegate validation to `app-store`'s `manifest.Validate()`, so nothing in this repo duplicates or implements capability logic. Diff is `go.mod` + `go.sum` + one test.

## Test
`cmd/pilotctl` regression test asserting a `proc.exec` manifest validates against the pinned app-store (and that a wildcard `*` target is still rejected by the hardened validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)