### PR TITLE
daemon: drop PILOT_TRUSTED_PUBLISHERS wiring (catalogue is the trust anchor)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -25,7 +25,6 @@ import (
 	// L11 plugin imports — cmd/daemon (L12) is the only place these
 	// are allowed. The daemon proper imports only pkg/coreapi
 	// interfaces.
-	"github.com/pilot-protocol/app-store/pkg/manifest"
 	"github.com/pilot-protocol/app-store/plugin/appstore"
 	"github.com/pilot-protocol/dataexchange"
 	"github.com/pilot-protocol/eventstream"
@@ -349,19 +348,6 @@ func main() {
 	}
 	if r := os.Getenv("PILOT_APPSTORE_ROOT"); r != "" {
 		appstoreInstallRoot = r
-	}
-	// Trust anchor (G4′): the supervisor refuses to spawn a non-sideloaded app
-	// whose publisher is not on manifest.TrustedPublishers. Nothing populated it
-	// before, so enforcement skipped every catalogue app. Wire it from
-	// PILOT_TRUSTED_PUBLISHERS (comma-separated ed25519:<b64> ids) — in
-	// production this list is the reviewed publisher registry.
-	if tp := strings.TrimSpace(os.Getenv("PILOT_TRUSTED_PUBLISHERS")); tp != "" {
-		for _, p := range strings.Split(tp, ",") {
-			if p = strings.TrimSpace(p); p != "" {
-				manifest.TrustedPublishers = append(manifest.TrustedPublishers, p)
-			}
-		}
-		log.Printf("appstore: %d trusted publisher(s) loaded from PILOT_TRUSTED_PUBLISHERS", len(manifest.TrustedPublishers))
 	}
 	// The app-usage telemetry emitter shares the daemon's identity file
 	// and telemetry URL. When consent is off (empty URL) the client is

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.11
 
 require (
 	github.com/coder/websocket v1.8.15
-	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622180016-07b4170265dc
+	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622235003-2f290c314a42
 	github.com/pilot-protocol/beacon v0.2.6
 	github.com/pilot-protocol/common v0.5.5
 	github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260615113607-fac933edea98

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNU
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622180016-07b4170265dc h1:Ze7h3rEPMhFaAyjNH9riySBs8HEeeoB3wODwtoLQ4Eo=
-github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622180016-07b4170265dc/go.mod h1:leZPtX43gE2JB7xeljexXri81g6qhdZfYExLtzI+bhg=
+github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622235003-2f290c314a42 h1:5Yns67RaNxd2xwVJj7VY2+vXzo9zTbMgPM+CXgwiW1M=
+github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260622235003-2f290c314a42/go.mod h1:leZPtX43gE2JB7xeljexXri81g6qhdZfYExLtzI+bhg=
 github.com/pilot-protocol/beacon v0.2.6 h1:grxwaVyPRUT0W6coyjYfNkO0rpzOIrwrKn94S21DuVE=
 github.com/pilot-protocol/beacon v0.2.6/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
 github.com/pilot-protocol/common v0.5.5 h1:mnv3q84alVaotGD+Qxfo4ECFEquqsUwrI3mjKIGUKFY=


### PR DESCRIPTION
## Drop `PILOT_TRUSTED_PUBLISHERS` wiring — the catalogue is the trust anchor

This is the **only daemon change needed for v1.12.4** so that all catalogue apps
(cosift, sixtyfour, wallet) **and** Smol Machines install and run with **zero
config** on every host.

- removes the `PILOT_TRUSTED_PUBLISHERS` block + the now-unused `manifest` import
- bumps `github.com/pilot-protocol/app-store` to `…-2f290c314a42`, the commit that
  has **both** `proc.exec` (#24) **and** the trust-anchor removal
- keeps `PILOT_APPSTORE_ROOT` honoring

### app-store #25 is NOT a blocker
This `go.mod` pins the app-store commit directly, so the bits are correct whether
or not #25 is merged. **Caveat:** that commit currently lives only on the
`remove-redundant-trust-anchor` branch — keep that branch alive until #25 lands,
then a follow-up re-pins `go.mod` to the merged-on-`main` commit.

### Verified (fresh node, NO env)
```
pilotctl appstore install io.pilot.smolmachines   # real catalogue → sha256 OK → installed
daemon spawn: app=io.pilot.smolmachines sideloaded=false   (no "not trusted" skip)
smolmachines.exec machine run … alpine …  → exit 0, alpine 3.24.1
```

### After merge
Tag **v1.12.4** → `release.yml` publishes → `pilot-updater` rolls it out,
**superseding the bricking v1.12.3** (which enforced the anchor + needed the env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
