### PR TITLE
Pin app-store to v1.0.1 release tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.11
 
 require (
 	github.com/coder/websocket v1.8.15
-	github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260623120425-df0e4a35d764
+	github.com/pilot-protocol/app-store v1.0.1
 	github.com/pilot-protocol/beacon v0.2.6
 	github.com/pilot-protocol/common v0.5.5
 	github.com/pilot-protocol/dataexchange v0.2.1-beta.1.0.20260615113607-fac933edea98

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNU
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260623120425-df0e4a35d764 h1:JA/7wAihWse11g/FI2i7EuCQVhDfj+3l1UC+vF3bOUk=
-github.com/pilot-protocol/app-store v1.0.1-beta.1.0.20260623120425-df0e4a35d764/go.mod h1:deltPnaQkiTgMcxWU+honz3+Bl2R1cthhuZra4pQ4PI=
+github.com/pilot-protocol/app-store v1.0.1 h1:17VPa02PhRRHAcspCg/CG+bBo5qUPrZQFi8hz66kAjE=
+github.com/pilot-protocol/app-store v1.0.1/go.mod h1:deltPnaQkiTgMcxWU+honz3+Bl2R1cthhuZra4pQ4PI=
 github.com/pilot-protocol/beacon v0.2.6 h1:grxwaVyPRUT0W6coyjYfNkO0rpzOIrwrKn94S21DuVE=
 github.com/pilot-protocol/beacon v0.2.6/go.mod h1:I/UhEv097g1z/qtAVDZbEhf3R5tzM0Dp71vGHah52A4=
 github.com/pilot-protocol/common v0.5.5 h1:mnv3q84alVaotGD+Qxfo4ECFEquqsUwrI3mjKIGUKFY=


### PR DESCRIPTION
Replaces the pseudo-version `v1.0.1-beta.1.0.20260623120425-df0e4a35d764` introduced in #317 with the clean **v1.0.1** release tag that app-store just published.

## Why
app-store cut a real `v1.0.1` tag at the exact commit web4 already pins (`df0e4a35`). This swaps the messy pseudo-version for the proper semver tag so the next pilotctl release ships against a real version string.

## What's included in v1.0.1
- `proc.exec` capability (app-store #24)
- trust-anchor fix (app-store #23)

Both were already built against via the pseudo-version, so this is a **version-string-only change** — no code differences.

## Verification
- Tag `v1.0.1` resolves to commit `df0e4a35d7642bc395f4e3e53e2d65e124c57eaf` — identical to the pseudo-version's `df0e4a35d764`.
- Extracted module source trees for the two versions are byte-identical (`diff -r` clean); the `/go.mod` hash in go.sum is unchanged.
- `GOWORK=off go build ./...` — clean
- `GOWORK=off go vet ./...` — clean
- `GOWORK=off go test ./cmd/pilotctl/...` — pass, including `TestProcExecCapabilityAccepted`
- `gofmt` — clean
- `govulncheck ./...` — No vulnerabilities found

Diff is limited to go.mod / go.sum.