### PR TITLE
fix(gosec): handle resp.Body.Close in catalogue httpGet (G104)

### DIFF
--- a/internal/catalogue/catalogue.go
+++ b/internal/catalogue/catalogue.go
@@ -128,7 +128,7 @@ func httpGet(raw string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		_ = resp.Body.Close() // discarding on the error path; the status error below is what matters
 		return nil, fmt.Errorf("GET %s: status %d", raw, resp.StatusCode)
 	}
 	return resp.Body, nil


### PR DESCRIPTION
Resolves the gosec **G104** (errors unhandled) finding at `internal/catalogue/catalogue.go:131`: `httpGet` ignored the `resp.Body.Close()` error on the non-200 path. Discard it explicitly (`_ =`) — the status error returned right after is the actionable one. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)