### PR TITLE
catalogue: pin io.telepat.ideon-free publisher (v1.12.3 anchor fix)

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -117,7 +117,8 @@
       "version": "0.3.1",
       "description": "Free article generation for agents: ideon-free.generate(idea) returns a jobId; ideon-free.poll(jobId) returns the finished markdown article. Thin adapter over Ideon's ideon_write — no payment.",
       "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/ideon-free-v0.3.1/io.telepat.ideon-free-0.3.1.tar.gz",
-      "bundle_sha256": "dd8e37057f33eadefff6b7ff5fc99130667076ea398c10a154c345fd87dd1ad6"
+      "bundle_sha256": "dd8e37057f33eadefff6b7ff5fc99130667076ea398c10a154c345fd87dd1ad6",
+      "publisher": "ed25519:5cqj+zTVecj8r0YRUShpgFi/g7TxDg1lkDKQzfNyDyc="
     }
   ]
 }

--- a/catalogue/catalogue.json.sig
+++ b/catalogue/catalogue.json.sig
@@ -1,1 +1,1 @@
-7bQgHV+ENB1G3zl13+rfyoe8XCwncxEwDcol+Uqq6KjXgnjT6eBGYUJ2yo5F5l1AelylDa6kX8fZQWASCbsOAQ==
+8DN2+0oxrOTH/Z67t6MHvhphJYnMh5xQdIvchyhnyKER4ze5h5rU0HgqIWnxSavuj/ggbBwAPENROapndXkoBg==


### PR DESCRIPTION
**Problem.** v1.12.3's catalogue anchor fail-closes any catalogue entry without a `publisher` pin. `io.telepat.ideon-free` is currently **unpinned** — the only such entry (the four `io.pilot.*` apps are pinned) — so it would be **refused on any host that updates to v1.12.3**.

**Fix.** Add the publisher pin to the ideon-free entry and re-sign `catalogue.json`:
```
"io.telepat.ideon-free": { …, "publisher": "ed25519:5cqj+zTVecj8r0YRUShpgFi/g7TxDg1lkDKQzfNyDyc=" }
```
- The pin **equals the bundle's `store.publisher` signing key** (verified against `manifest.json`).
- `catalogue.json.sig` re-signed; the new signature **verifies against the embedded `catalogtrust` pubkey** (`iHdBWayA…`).
- Diff is the single `publisher` line + the regenerated `.sig`; all other entries unchanged.

**Root cause (separate follow-up).** `app-template/scripts/publish-submission.sh` doesn't emit `publisher` when it generates a catalogue entry, so every newly-published app is born unpinned. A companion PR patches the script to pin from `manifest.store.publisher` automatically.