### PR TITLE
catalogue: add io.pilot.slipstream v1.0.0

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated_at": "2026-06-22T21:30:00Z",
+  "updated_at": "2026-06-24T14:00:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
@@ -119,6 +119,24 @@
       "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/ideon-free-v0.3.1/io.telepat.ideon-free-0.3.1.tar.gz",
       "bundle_sha256": "dd8e37057f33eadefff6b7ff5fc99130667076ea398c10a154c345fd87dd1ad6",
       "publisher": "ed25519:5cqj+zTVecj8r0YRUShpgFi/g7TxDg1lkDKQzfNyDyc="
+    },
+    {
+      "id": "io.pilot.slipstream",
+      "version": "1.0.0",
+      "description": "SLIPSTREAM — Polymarket smart-money leaderboard, signals, tape & opportunities (Ed25519-signed API).",
+      "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/slipstream-v1.0.0/io.pilot.slipstream-1.0.0.tar.gz",
+      "bundle_sha256": "8f19c06c886b97abb1272e8f657773950bee747c58dab8493d454742313ef2f5",
+      "display_name": "Slipstream",
+      "vendor": "Pilot Protocol",
+      "categories": [
+        "finance",
+        "markets",
+        "intelligence"
+      ],
+      "bundle_size": 4674914,
+      "source_url": "https://github.com/pilot-protocol/catalog",
+      "license": "MIT",
+      "publisher": "ed25519:fc+G+FOz/LjcDXBGvguInq+w9fUCMi8JytYlOOCcCKQ="
     }
   ]
 }

--- a/catalogue/catalogue.json.sig
+++ b/catalogue/catalogue.json.sig
@@ -1,1 +1,1 @@
-8DN2+0oxrOTH/Z67t6MHvhphJYnMh5xQdIvchyhnyKER4ze5h5rU0HgqIWnxSavuj/ggbBwAPENROapndXkoBg==
+AV/kgERWYDHznmTpm8PtPzjFAxRI9QVlovSPj0lCllkO3C4uP8hmag+mpl0rrmYPNHD2dMuYirKTuh7Xfpc9Bw==


### PR DESCRIPTION
Adds **io.pilot.slipstream** to the catalogue — SLIPSTREAM, Polymarket smart-money intelligence (leaderboard, signals, tape, markets, skilled-trader filter, opportunities, stats) exposed as an Ed25519-signed Pilot app.

- Bundle: `pilot-protocol/catalog` release `slipstream-v1.0.0` (sha256 `8f19c06c…3ef2f5`)
- API gated by the pilot signature contract (same X-Pilot-* ed25519 scheme as telemetry); unsigned callers are rejected.
- Also reachable as an SSH TUI on `slipstream.pilotprotocol.network`.
- catalogue.json + catalogue.json.sig updated together (re-signed with the catalogue release key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)