### PR TITLE
catalogue: add io.pilot.plainweb v1.0.0

### DIFF
--- a/catalogue/apps/io.pilot.plainweb/metadata.json
+++ b/catalogue/apps/io.pilot.plainweb/metadata.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "id": "io.pilot.plainweb",
+  "display_name": "Plainweb",
+  "tagline": "Any web page as clean Markdown — no HTML, no JS, one call",
+  "description_md": "Plainweb is a Pilot-owned URL→Markdown service: give it any web page and get back clean, accurate Markdown — no HTML, no JavaScript, just plain text structured as Markdown.\n\nWhat an agent gets:\n- **One call** — `plainweb.fetch(url)` fetches the page and returns it as Markdown (GFM tables, fenced code with language, task lists). The target URL goes straight in the path.\n- **Accurate extraction** — a cost-aware static→headless-Chrome fetch ladder (most pages never launch Chrome), go-readability primary (preserves code blocks and tables) with go-trafilatura fallback, converted via html-to-markdown v2.\n- **Scheme-less OK** — bare hosts like `example.com` are sanitized to `https://`.\n\nGood to know:\n- **Free and open — no API key required.** Public endpoints are open to every caller.\n- **Rate limit:** anonymous callers get **1000 requests/second** (burst 2000); a master key only elevates a caller past that limit.\n- The reply is `text/markdown`, returned by the adapter as `{ \"content_type\", \"content\" }` (the Markdown is in `content`).\n- In-house Pilot Protocol tool, deployed on Cloud Run.",
+  "vendor": {
+    "name": "Pilot Protocol",
+    "url": "https://pilotprotocol.network",
+    "publisher_pubkey": "ed25519:9oZGhTSuJJ5xaePW89I9QSOnyp8p83igvGj0jEUuLoE="
+  },
+  "homepage": "https://pilotprotocol.network",
+  "source_url": "https://github.com/pilot-protocol/plainweb",
+  "license": "Proprietary",
+  "categories": [
+    "web",
+    "content",
+    "markdown"
+  ],
+  "keywords": [
+    "plainweb",
+    "markdown",
+    "web",
+    "fetch",
+    "scrape",
+    "extract",
+    "readability",
+    "html",
+    "url",
+    "content"
+  ],
+  "size": {
+    "bundle_bytes": 5035085,
+    "installed_bytes": 9030752
+  },
+  "compat": {
+    "min_pilot_version": "1.0.0",
+    "runtimes": [
+      "go"
+    ]
+  },
+  "methods": [
+    {
+      "name": "plainweb.fetch",
+      "summary": "Fetch any web page and return it as clean Markdown — no HTML, no JavaScript. Pass the full target URL as `url`; it is placed verbatim in the request path (GET /\u003curl\u003e). Scheme-less hosts (e.g. example.com) are sanitized to https://. The reply is `{\"content_type\":\"text/markdown; charset=utf-8\",\"content\":\"\u003cmarkdown\u003e\"}`. Open and free — no API key needed."
+    },
+    {
+      "name": "plainweb.help",
+      "summary": "Discovery: every method with params, kind, and latency class."
+    }
+  ],
+  "changelog": [
+    {
+      "version": "1.0.0",
+      "notes": [
+        "Released v1.0.0"
+      ]
+    }
+  ],
+  "links": [
+    {
+      "label": "Source",
+      "url": "https://github.com/pilot-protocol/plainweb"
+    },
+    {
+      "label": "Website",
+      "url": "https://pilotprotocol.network"
+    }
+  ]
+}

--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -201,6 +201,38 @@
       "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/io.pilot.otto/metadata.json",
       "metadata_sha256": "75371512242220f1c6cd99867c0e15ffaa2457ee00a0685c9f81037180ab79a8",
       "publisher": "ed25519:mTyrd5ZG/tl76CLpdUEaaGvCjrnE6QLHPVm7XrduH/w="
+    },
+    {
+      "id": "io.pilot.plainweb",
+      "version": "1.0.0",
+      "description": "Plainweb - retrieve any web page in plain text: no HTML or JS returned, simply plain Markdown",
+      "display_name": "Plainweb",
+      "vendor": "Pilot Protocol",
+      "license": "Proprietary",
+      "source_url": "https://github.com/pilot-protocol/plainweb",
+      "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.plainweb/1.0.0/io.pilot.plainweb-1.0.0-linux-amd64.tar.gz",
+      "bundle_sha256": "1ea656cfd3561cb458e3e924001cb0f6ce9509c56a858b96478dc1c7e1fa9f41",
+      "bundles": {
+        "darwin/arm64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.plainweb/1.0.0/io.pilot.plainweb-1.0.0-darwin-arm64.tar.gz",
+          "bundle_sha256": "a857b4a6d2128a6030e3f0aa7f6e2cd4c67896e0ae5f4c7962350663e3289ac1"
+        },
+        "darwin/amd64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.plainweb/1.0.0/io.pilot.plainweb-1.0.0-darwin-amd64.tar.gz",
+          "bundle_sha256": "5ff73c98a4db92bd31b4b6b0237ce89eb33d2aa8875cbbfaf3bb486f15811f06"
+        },
+        "linux/arm64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.plainweb/1.0.0/io.pilot.plainweb-1.0.0-linux-arm64.tar.gz",
+          "bundle_sha256": "cfbf133a871336df0020b4508aac83e6aa52f6b91ca883f7747a1e56bf76a90b"
+        },
+        "linux/amd64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.plainweb/1.0.0/io.pilot.plainweb-1.0.0-linux-amd64.tar.gz",
+          "bundle_sha256": "1ea656cfd3561cb458e3e924001cb0f6ce9509c56a858b96478dc1c7e1fa9f41"
+        }
+      },
+      "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/io.pilot.plainweb/metadata.json",
+      "metadata_sha256": "8e46e027b1159df28230b8144bbebfbece51a2b3fa9ce7681f4a001a1216dc31",
+      "publisher": "ed25519:9oZGhTSuJJ5xaePW89I9QSOnyp8p83igvGj0jEUuLoE="
     }
   ]
 }

--- a/catalogue/catalogue.json.sig
+++ b/catalogue/catalogue.json.sig
@@ -1,1 +1,1 @@
-Ba/oklWdJ9NBPXtMfxN4L9Dzv2OxySFJRBmjlnoNv9sQCPXAdZiezllmV0QnLDIEg/5cx928thNsytwF7ddgBg==
+VOXX5fXrPc+201Fdwfb/Rghlx3W5ienxkisnKGbL7nKaAQZ4sQg13VE7sWNdikAcFcGg5ykguIauoL5+rgJJBw==


### PR DESCRIPTION
Adds **io.pilot.plainweb v1.0.0** to the prod app-store catalogue.

Plainweb is an HTTP adapter (no CLI binary) that retrieves any web page as clean Markdown — no HTML, no JS — via a single `plainweb.fetch(url)` call.

**What's included**
- `catalogue/catalogue.json` — new `io.pilot.plainweb` entry (4-platform bundles, R2 prod URLs + sha256, metadata pointer, publisher pin)
- `catalogue/catalogue.json.sig` — re-signed with the release key
- `catalogue/apps/io.pilot.plainweb/metadata.json` — catalogue-v2 metadata (long description)

**Bundles** are hosted on R2 prod (`pilot-artifacts-prod`) for all 4 platforms (darwin/linux × arm64/amd64), each verified HTTP 200.

**Verified**
- Built from the merged app-template submission with the stable publisher key; PIN `ed25519:9oZGhTSuJJ5xaePW89I9QSOnyp8p83igvGj0jEUuLoE=`
- `appstore install` against the hosted bundle → sha256 OK
- `plainweb.fetch {"url":"https://example.com"}` via the installed app → returned `{content_type:"text/markdown; charset=utf-8", content:"…"}`
- Catalogue signature verifies and `plainweb` lists under the release pin
