### PR TITLE
catalogue: remove io.pilot.agentphone (non-functional — broker unregistered)

### DIFF
--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -267,36 +267,6 @@
       "publisher": "ed25519:N1uQkAJ355xY9RSj5Q8/y9Y+PIIjLzPB47PAl1vdw2U="
     },
     {
-      "id": "io.pilot.agentphone",
-      "version": "0.1.0",
-      "description": "Give your agent a real phone number: place and receive voice calls, send and receive SMS/iMessage, and hold threaded conversations — all over REST. Provision a number, create a calling agent, place a call and poll its transcript, send a text and poll for replies.",
-      "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/agentphone-v0.1.0/io.pilot.agentphone-0.1.0-linux-amd64.tar.gz",
-      "bundle_sha256": "5d1e6dbc301d42a45e4a84fda2a9a75290ac2f6d4368ba97f58f6cb7f979892a",
-      "bundles": {
-        "linux/amd64": {
-          "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/agentphone-v0.1.0/io.pilot.agentphone-0.1.0-linux-amd64.tar.gz",
-          "bundle_sha256": "5d1e6dbc301d42a45e4a84fda2a9a75290ac2f6d4368ba97f58f6cb7f979892a"
-        },
-        "linux/arm64": {
-          "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/agentphone-v0.1.0/io.pilot.agentphone-0.1.0-linux-arm64.tar.gz",
-          "bundle_sha256": "bbfff26f7ffef897773f4947e9539ff3da188cad4ec69aff29e0ed6f93596890"
-        },
-        "darwin/amd64": {
-          "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/agentphone-v0.1.0/io.pilot.agentphone-0.1.0-darwin-amd64.tar.gz",
-          "bundle_sha256": "b5bf81ee5ff440bae870c2c6a8723473475eaa20b9b8db1bc500eaf929d5496b"
-        },
-        "darwin/arm64": {
-          "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/agentphone-v0.1.0/io.pilot.agentphone-0.1.0-darwin-arm64.tar.gz",
-          "bundle_sha256": "412b44726220e7c52af5bd19955bdb6190f353c40f2a76ad0289aadf50ab428a"
-        },
-        "windows/amd64": {
-          "bundle_url": "https://github.com/pilot-protocol/catalog/releases/download/agentphone-v0.1.0/io.pilot.agentphone-0.1.0-windows-amd64.tar.gz",
-          "bundle_sha256": "66806810c5ebbe7eeea056d24b249f1440fb6021d7cf968ff43cc74defdfc884"
-        }
-      },
-      "publisher": "ed25519:mvVzYABubZwOTzWWQA/TDbRLYkKzmD/x6k/w0nz+zHc="
-    },
-    {
       "id": "io.pilot.duckdb",
       "version": "1.5.4",
       "description": "DuckDB 1.5.4 as a native CLI for agents: an in-process analytical SQL database (think \"SQLite for analytics\") with zero server and zero provisioning. Run SQL in-memory or against a DuckDB file and query CSV, Parquet, and JSON files directly with no import step — results as an aligned table, CSV, JSON, or Markdown. Schema/table introspection, run a .sql script, and the full CLI surface (every flag + dot-command) via a verbatim-argv passthrough. Ideal for sandboxed agents that need real SQL locally without an AWS/GCP account.",

--- a/catalogue/catalogue.json.sig
+++ b/catalogue/catalogue.json.sig
@@ -1,1 +1,1 @@
-dp01OFexQqbqb3aAjzIeeD6LKzA99YQryUHUbNNla1LWy1wghd6cnACzWAExLcGa4NOLewySae/FIaxlAIZ+Cw==
+ZOp79zbqMrcSSFGPlSQaB4DKg6tr7nxhMqiZ7PP+ijNUKPSO4L3VDT5m9aSfYlq/Ei+Nypo/kRSWfq+0nTaPCg==


### PR DESCRIPTION
Removes `io.pilot.agentphone` from the app-store catalogue.

**Why:** the app is published but non-functional — the broker has no registry
entry for it, so every method (`usage`, `list_voices`, `place_call`, …) returns
`404 {"error":"unknown app: io.pilot.agentphone"}` at the broker's app-lookup
step, before reaching the vendor. Verified with read-only calls only; no calls
were placed. Listing a dead app is misleading and its installs can't work.

**Scope:** surgical removal of the single catalogue entry (30 lines). All other
entries — including `io.pilot.duckdb` — are byte-unchanged. Catalogue re-signed
with the release key (`catalogue.json.sig` updated); the re-sign of the pristine
catalogue reproduced the published signature exactly, confirming the key.

Re-add once the broker-side managed registration (registry entry +
`AGENTPHONE_MASTER_KEY` + SIGHUP) is completed.
