### PR TITLE
catalogue: io.pilot.aegis v0.1.3 (AEGIS — runtime firewall)

### DIFF
--- a/catalogue/apps/io.pilot.aegis/metadata.json
+++ b/catalogue/apps/io.pilot.aegis/metadata.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "id": "io.pilot.aegis",
+  "display_name": "AEGIS",
+  "tagline": "Runtime firewall for AI agents — blocks prompt injection before your agent reads it",
+  "description_md": "# AEGIS — runtime firewall for AI agents\n\nAEGIS inspects untrusted content reaching your agent — inbox messages, tool results, web fetches, MCP responses, skill files, memory notes — and blocks **prompt injection, jailbreaks, and impersonation** before the agent ever sees it. Genuine status messages pass straight through.\n\n## How it works\n\nTwo layers. **L1** is Aho-Corasick pattern matching in pure Rust — microseconds, ~120 known attack families with homoglyph and leetspeak normalization and a sliding-window scan. **L2** is an optional local Qwen3-1.7B judge via llama.cpp — fully offline, no network. On a held-out labeled set: **90% recall, 95% precision, 92% F1**. An 880 KB binary with an HMAC-chained audit log at `~/.aegis/audit.jsonl`.\n\n## Using it\n\n- `aegis.scan \u003cpath\u003e` — one-shot scan of a file or directory.\n- `aegis.exec {\"args\":[\"scan-cmd\"],\"stdin\":...}` — the PreToolUse blocking gate (exit 0 allow / 2 block).\n- `aegis.exec {\"args\":[\"scan-result\"],\"stdin\":...}` — the PostToolUse non-blocking check (warns).\n- `aegis.status` / `aegis.targets` / `aegis.config` — audit log, protected surfaces, and configuration.\n\nThe L2 judge model (~1.8 GB) is optional — L1 patterns work without it.",
+  "vendor": {
+    "name": "Pilot Protocol",
+    "url": "https://aegis.pilotprotocol.network",
+    "contact": "apps@pilotprotocol.network",
+    "publisher_pubkey": "ed25519:+nt58BA0gpPYuyaeG2GwfTI79j8IHP+zra5GvRQv0N0="
+  },
+  "homepage": "https://aegis.pilotprotocol.network",
+  "source_url": "https://github.com/pilot-protocol/aegis",
+  "license": "MIT",
+  "categories": [
+    "security",
+    "firewall",
+    "guardrail"
+  ],
+  "keywords": [
+    "security",
+    "firewall",
+    "prompt-injection",
+    "jailbreak",
+    "guardrail",
+    "defense",
+    "offline"
+  ],
+  "size": {
+    "bundle_bytes": 5351198,
+    "installed_bytes": 9621928
+  },
+  "compat": {
+    "min_pilot_version": "1.0.0",
+    "runtimes": [
+      "go"
+    ]
+  },
+  "methods": [
+    {
+      "name": "aegis.scan",
+      "summary": "One-shot scan of one or more files or directories for prompt injection, jailbreaks, homoglyph/leetspeak obfuscation, and impersonation. Returns the verdict per path. This is `aegis scan \u003cpath\u003e...`."
+    },
+    {
+      "name": "aegis.status",
+      "summary": "Tail the HMAC-chained audit log of recent verdicts. This is `aegis status`."
+    },
+    {
+      "name": "aegis.targets",
+      "summary": "List the agent surfaces AEGIS is protecting (inbox, tool results, skill files, memory, ...). This is `aegis targets`."
+    },
+    {
+      "name": "aegis.config",
+      "summary": "Show the effective AEGIS configuration (rules, thresholds, watch targets). This is `aegis config`."
+    },
+    {
+      "name": "aegis.version",
+      "summary": "Print the AEGIS version. This is `aegis version`."
+    },
+    {
+      "name": "aegis.exec",
+      "summary": "Run any AEGIS subcommand with a verbatim argv — the full surface beyond the curated methods. Payload is {\"args\":[\u003csubcommand\u003e, ...]} with optional {\"stdin\":\"...\"}. This is how you use the blocking gates: the PreToolUse gate {\"args\":[\"scan-cmd\"],\"stdin\":\"{\\\"tool_input\\\":{\\\"command\\\":\\\"...\\\"}}\"} exits 0 (allow) or 2 (block); the PostToolUse gate {\"args\":[\"scan-result\"],\"stdin\":\"{...}\"} warns without blocking. Also reaches init/daemon/install-models/install-hooks."
+    },
+    {
+      "name": "aegis.help",
+      "summary": "Print the AEGIS usage and subcommand list. This is `aegis --help`."
+    },
+    {
+      "name": "aegis.help",
+      "summary": "Discovery: every method with params, kind, and latency class."
+    }
+  ],
+  "changelog": [
+    {
+      "version": "0.1.3",
+      "notes": [
+        "Released v0.1.3"
+      ]
+    }
+  ],
+  "links": [
+    {
+      "label": "Source",
+      "url": "https://github.com/pilot-protocol/aegis"
+    },
+    {
+      "label": "Website",
+      "url": "https://aegis.pilotprotocol.network"
+    }
+  ]
+}

--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated_at": "2026-06-30T00:00:00Z",
+  "updated_at": "2026-07-02T00:00:00Z",
   "apps": [
     {
       "id": "io.pilot.wallet",
@@ -384,6 +384,40 @@
       "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/io.pilot.redis/metadata.json",
       "metadata_sha256": "7a2737afad2fe994f5deee9810557650727d5dd43c69e0f4018ea04a4fe14961",
       "publisher": "ed25519:QXvscnyXJ5L/Bmy7oCo5dPC1HrEOGa7WFWBfH5ktejM="
+    },
+    {
+      "id": "io.pilot.aegis",
+      "version": "0.1.3",
+      "description": "AEGIS 0.1.3 — a runtime firewall for AI agents (native CLI): scan files, commands, and tool results for prompt injection, jailbreaks, homoglyph/leetspeak obfuscation, and impersonation before your agent acts on them. L1 Aho-Corasick patterns plus an optional local Qwen3-1.7B judge, fully offline; an 880 KB binary. The scan-cmd/scan-result blocking gates run via aegis.exec (allow 0 / block 2); plus aegis.scan / status / targets / config.",
+      "display_name": "AEGIS",
+      "vendor": "Pilot Protocol",
+      "license": "MIT",
+      "source_url": "https://github.com/pilot-protocol/aegis",
+      "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.aegis/0.1.3/io.pilot.aegis-0.1.3-linux-amd64.tar.gz",
+      "bundle_sha256": "ae40da40610e3d57fccb90365c7ccc45f64b7baa93b5eb7baa9b233003513eb6",
+      "bundle_size": 5351198,
+      "bundles": {
+        "linux/amd64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.aegis/0.1.3/io.pilot.aegis-0.1.3-linux-amd64.tar.gz",
+          "bundle_sha256": "ae40da40610e3d57fccb90365c7ccc45f64b7baa93b5eb7baa9b233003513eb6"
+        },
+        "linux/arm64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.aegis/0.1.3/io.pilot.aegis-0.1.3-linux-arm64.tar.gz",
+          "bundle_sha256": "ad2b5c81feca75fee144b995f857b208d2cd4d772ede2e06fea6b94b02074bed"
+        },
+        "darwin/arm64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.aegis/0.1.3/io.pilot.aegis-0.1.3-darwin-arm64.tar.gz",
+          "bundle_sha256": "e582c8e72d2024794d635fe23a1216cd83ee0fe6daabc462a84f5eddd4c1e65f"
+        }
+      },
+      "categories": [
+        "security",
+        "firewall",
+        "guardrail"
+      ],
+      "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/io.pilot.aegis/metadata.json",
+      "metadata_sha256": "ca71da633a5608af201ba08409f4376c672d92fa6adc570c41d409d51967ffc3",
+      "publisher": "ed25519:+nt58BA0gpPYuyaeG2GwfTI79j8IHP+zra5GvRQv0N0="
     }
   ]
 }

--- a/catalogue/catalogue.json.sig
+++ b/catalogue/catalogue.json.sig
@@ -1,1 +1,1 @@
-LicyGN5duHpCvoe6NzRKZzzZKKJcKjgE8Vbuv9R13vsqdHcJAzSP0LJTMlA6p3ZDRebdEJe6JRCo/7VJa8qBCQ==
+jRQC6FndHZ2Y3E6yUFAyqsoqfnvGlpTGjo9XgPHaumh4Dqo5B2AyUcZlpTEmh/aoQrZBjb3iuazehdJiZQnoDw==


### PR DESCRIPTION
Adds **io.pilot.aegis v0.1.3** to the signed catalogue — a runtime firewall for AI agents that scans files, commands, and tool results for prompt injection, jailbreaks, and impersonation before the agent acts on them. Native CLI, category **security**, **MIT**, fully offline (880 KB binary + optional local judge).

## What's in this PR
- `catalogue/catalogue.json` — one new entry (14 apps total), `updated_at` bumped. Fields match the existing apps: R2 `bundle_url`/`bundle_sha256`/`bundle_size`, per-platform `bundles{}`, `metadata_url`+`metadata_sha256`, and a `publisher` pin.
- `catalogue/catalogue.json.sig` — re-signed; **verifies against the catalogue trust anchor** (`iHdB…ZMdI=`).
- `catalogue/apps/io.pilot.aegis/metadata.json` — the store-page record.

## Bundles
Adapter bundles were built + signed by the publisher key `ed25519:+nt58BA0gpPYuyaeG2GwfTI79j8IHP+zra5GvRQv0N0=`, hosted on the Pilot R2 bundles registry (`pub-f09f9a4ea848…/bundles/io.pilot.aegis/0.1.3/`), and each passes `pilot-app verify` (manifest validates, sha pins match, signature verifies, `.help` discovery, native install.json). **3 platforms**: linux/amd64, linux/arm64, darwin/arm64 — no Intel-mac (darwin/amd64) binary is published upstream for v0.1.3.

Submission: pilot-protocol/app-template#59 (merged). Source: https://github.com/pilot-protocol/aegis