### PR TITLE
fix(install): capture tar extraction diagnostic output on darwin-arm64 (PILOT-221)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -302,18 +302,35 @@ if [ -n "$TAG" ]; then
         if tar --version 2>/dev/null | grep -q 'GNU tar'; then
             TAR_SAFE="--no-same-owner --no-same-permissions"
         fi
-        # macOS bsdtar can fail silently on GitHub gzip archives.
-        # Try tar -xzf first; fall back to gunzip|tar on failure.
-        if ! tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" $TAR_SAFE 2>/dev/null || [ ! -f "$TMPDIR/pilotctl" ]; then
+        # macOS bsdtar can fail silently on GitHub gzip archives
+        # (e.g. darwin-arm64 — bsdtar reads the gzip format header
+        # differently and may produce no output without reporting
+        # an error). Try tar -xzf first; fall back to gunzip|tar on
+        # failure. Both stderr paths are preserved in TAR_ERR so the
+        # final error message includes diagnostic output.
+        TAR_ERR=$(mktemp "${TMPDIR}/tar_err.XXXXXX")
+        EXTRACT_OK=false
+        if tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" $TAR_SAFE 2>"$TAR_ERR" && [ -f "$TMPDIR/pilotctl" ]; then
+            EXTRACT_OK=true
+        else
             echo "  tar -xzf failed or produced no output; trying gunzip fallback..."
-            gunzip -c "$TMPDIR/$ARCHIVE" | tar -x $TAR_SAFE -C "$TMPDIR"
+            if gunzip -c "$TMPDIR/$ARCHIVE" 2>"$TAR_ERR" | tar -x $TAR_SAFE -C "$TMPDIR" 2>>"$TAR_ERR"; then
+                if [ -f "$TMPDIR/pilotctl" ]; then
+                    EXTRACT_OK=true
+                fi
+            fi
         fi
-        if [ ! -f "$TMPDIR/pilotctl" ]; then
+        if [ "$EXTRACT_OK" != true ]; then
             echo "Error: failed to extract binaries from ${ARCHIVE}"
+            if [ -s "$TAR_ERR" ]; then
+                echo "  Diagnostic output from extract tool:"
+                sed 's/^/    /' "$TAR_ERR"
+            fi
             echo "Try downloading manually from:"
             echo "  ${URL}"
             exit 1
         fi
+        rm -f "$TAR_ERR"
     else
         TAG=""
     fi


### PR DESCRIPTION
## What

Fixes PILOT-221: `install.sh` tarball extraction fails silently on darwin-arm64. The `bsdtar` on macOS can produce no output when extracting GitHub gzip archives on arm64 without reporting an error. The existing code redirected stderr to `/dev/null`, leaving no diagnostic trail.

## Changes

1. **Capture stderr** from `tar` and `gunzip` into a temp file instead of discarding it — preserves diagnostic output for debugging.
2. **Explicit `EXTRACT_OK` flag** replaces the chained `! ... || ...` pattern for cleaner control flow through the two fallback attempts.
3. **Show diagnostics on total failure** — if both `tar -xzf` and `gunzip | tar -x` fail, the error message now includes tool stderr so the root cause is identifiable.

## Verification

- [x] Shell syntax validated with `bash -n` and `dash -n`
- [x] No Go changes — shell-only fix in `install.sh`
- [x] Logic covers: success → pass, silent fail → fallback, both fail → diagnostics + exit 1

Closes https://vulturelabs.atlassian.net/browse/PILOT-221