### PR TITLE
fix(install): support PILOT_TRANSPORT env var for compat mode (PILOT-222)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,16 @@ set -e
 # Usage:
 #   Install:    curl -fsSL https://pilotprotocol.network/install.sh | sh
 #   RC build:   PILOT_RC=1 curl -fsSL https://pilotprotocol.network/install.sh | sh
+#   Compat:     PILOT_TRANSPORT=compat curl -fsSL https://pilotprotocol.network/install.sh | sh
 #   Uninstall:  curl -fsSL https://pilotprotocol.network/install.sh | sh -s uninstall
+#
+#
+# ENVIRONMENT VARIABLES:
+#   PILOT_TRANSPORT     Set "compat" to force WSS/443 transport for UDP-blocked networks.
+#   PILOT_RC            Set to 1 to install the latest pre-release (RC build).
+#   PILOT_EMAIL         Skip the email prompt by providing it inline.
+#   PILOT_HOSTNAME      Set a custom hostname for the daemon.
+#   PILOT_PUBLIC        Set to 1 to register the daemon as a public node.
 #
 # WHAT THIS SCRIPT DOES (read before piping to sh):
 #   1. Detects OS/arch (Linux/Darwin × amd64/arm64)
@@ -456,6 +465,10 @@ if [ "$OS" = "linux" ] && command -v systemctl >/dev/null 2>&1; then
     if [ -n "$PILOT_PUBLIC" ]; then
         PUBLIC_FLAG="-public"
     fi
+    TRANSPORT_FLAG=""
+    if [ -n "$PILOT_TRANSPORT" ]; then
+        TRANSPORT_FLAG="-transport $PILOT_TRANSPORT"
+    fi
     sudo tee /etc/systemd/system/pilot-daemon.service >/dev/null <<SVC
 [Unit]
 Description=Pilot Protocol Daemon
@@ -472,7 +485,7 @@ ExecStart=${BIN_DIR}/pilot-daemon \\
   -socket /tmp/pilot.sock \\
   -identity ${PILOT_DIR}/identity.json \\
   -email ${EMAIL} \\
-  -encrypt ${HOSTNAME_FLAG} ${PUBLIC_FLAG}
+  -encrypt ${HOSTNAME_FLAG} ${PUBLIC_FLAG} ${TRANSPORT_FLAG}
 Restart=always
 RestartSec=5
 
@@ -533,6 +546,11 @@ if [ "$OS" = "darwin" ]; then
     fi
     if [ -n "$PILOT_PUBLIC" ]; then
         EXTRA_ARGS="${EXTRA_ARGS}        <string>-public</string>
+"
+    fi
+    if [ -n "$PILOT_TRANSPORT" ]; then
+        EXTRA_ARGS="${EXTRA_ARGS}        <string>-transport</string>
+        <string>${PILOT_TRANSPORT}</string>
 "
     fi
     cat > "$PLIST" <<PLIST


### PR DESCRIPTION
## What changed

The daemon already auto-probes UDP reachability and falls back to compat (WSS/443) transport when UDP is blocked (PR #314, commit f0c422f). This change adds `PILOT_TRANSPORT` env var support to `install.sh` for users who want to explicitly force a transport mode on systems where UDP may be unavailable.

## What was failing

`install.sh` did not pass `-transport` to the systemd unit or LaunchAgent plist, and had no documentation for the `PILOT_TRANSPORT` env var. Users on UDP-blocked hosts had no way to force compat mode through the installer — they had to manually edit the service file or the plist after install.

## Fix

1. **Documentation** — Added `PILOT_TRANSPORT=compat` to the Usage examples and a new ENVIRONMENT VARIABLES header block
2. **Systemd unit** — Pass `-transport $PILOT_TRANSPORT` in ExecStart when the env var is set (following the same pattern as `PILOT_HOSTNAME` / `PILOT_PUBLIC`)
3. **LaunchAgent plist** — Add `-transport` + value strings when the env var is set (same EXTRA_ARGS pattern)

## Verification

- `bash -n install.sh` — syntax OK
- `dash -n install.sh` — syntax OK (POSIX sh compat)

Closes https://vulturelabs.atlassian.net/browse/PILOT-222