### PR TITLE
PILOT-65: fix pilotctl --json version to emit JSON

### DIFF
--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -1633,7 +1633,7 @@ dispatch:
 		goto dispatch
 
 	case "version":
-		fmt.Println(version)
+		output(version)
 		return
 
 	case "quickstart":


### PR DESCRIPTION
## Fix

`pilotctl --json version` was returning plaintext (`v1.12.4`) instead of JSON.

**Root cause:** The `version` dispatch case called `fmt.Println(version)` unconditionally, ignoring the `--json` flag.

**Fix:** Replace `fmt.Println(version)` with `output(version)` which respects the `jsonOutput` flag and emits the standard `{"status":"ok","data":"v1.12.4"}` envelope when `--json` is set.

**Before:**
```
$ pilotctl --json version
v1.12.4
```

**After:**
```
$ pilotctl --json version
{"status":"ok","data":"v1.12.4"}
```

Found by PILOT-65 Phase 1 functional test runner (44/45 tests passing; this was the sole failure).