### PR TITLE
daemon: inbound-path watchdog — auto-recover the long-uptime NAT wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ Detailed per-release notes are on the
 Reliable P2P data transfer across NAT. Tag intentionally held for review.
 
 ### Added
+- **Inbound-path watchdog — the long-uptime NAT wedge now auto-recovers.**
+  A daemon could run for days transmitting into a stale NAT/relay mapping
+  while receiving nothing (2026-07-13 incident: 43.5 MB sent vs 102 KB
+  received over 2d19h, every `send-message` failing with "cannot connect
+  (data exchange port 1001)") — the registry heartbeat is TCP and kept
+  succeeding, so nothing noticed until a manual restart. The daemon now
+  watches for delivered-packet silence while transmit stays active, first
+  soft-recovers (beacon re-registration — whose discover reply doubles as
+  an active inbound probe — plus registry re-registration), and if the
+  wedge persists on a supervised daemon, exits with code 86 so
+  launchd/systemd respawns it with a fresh transport. Guarded against
+  flapping: never exits when the registry is also unreachable (machine
+  offline), when inbound never worked this process, or within 30 min of
+  start. Emits `tunnel.rx_silence` / `tunnel.rx_recovered` /
+  `tunnel.rx_wedged_exit` webhook events. Disable with `-no-rx-watchdog`.
 - **Chunked, ACK'd, resumable file transfer (`TypeFileStream`).** `pilotctl
   send-file` now streams files in 48 KiB chunks with per-chunk ACKs, an
   end-to-end SHA-256 integrity check, and automatic resume from the last
@@ -39,6 +54,12 @@ Reliable P2P data transfer across NAT. Tag intentionally held for review.
   `--motd-feed-url` / `$PILOT_MOTD_URL` as before. (motd)
 
 ### Fixed
+- **`pilotctl daemon start` no longer reports a false failure on slow boots.**
+  The launchd path waited only 10 s for the IPC socket; a daemon with
+  installed app-store apps spawns them before IPC comes up and can take
+  longer, producing "socket did not become ready within 10s" for a start
+  that succeeds moments later. The wait is now 30 s and the timeout message
+  says launchd is still supervising the boot.
 - **NAT traversal now actually establishes (and holds) a direct path.** The
   relay→direct upgrade sent a one-way probe that a stateful NAT/firewall
   always dropped, so peers stayed on the beacon relay indefinitely. The

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -94,6 +94,7 @@ func main() {
 	networks := flag.String("networks", "", "comma-separated network IDs to auto-join at startup")
 	trustAutoApprove := flag.Bool("trust-auto-approve", false, "automatically approve all incoming trust handshakes")
 	beaconRTTProbe := flag.Bool("beacon-rtt-probe", false, "probe beacon RTT before selection; override hash pick when >2× slower than best (ablation test, default off)")
+	noRxWatchdog := flag.Bool("no-rx-watchdog", false, "disable the inbound-path watchdog that soft-recovers (beacon+registry re-registration) and, on a persistent wedge, exits non-zero for supervisor respawn")
 	transportMode := flag.String("transport", "udp", "tunnel transport: 'udp' (default) or 'compat' (WSS to beacon, opt-in, for UDP-blocked environments)")
 	compatBeacon := flag.String("compat-beacon", "wss://beacon.pilotprotocol.network/v1/compat", "beacon WSS URL for -transport=compat")
 	tlsTrust := flag.String("tls-trust", "system", "TLS trust store for -transport=compat: 'system' (OS trust store; current default while compat mode uses Let's Encrypt certs on beacon.pilotprotocol.network) or 'pinned' (Pilot CA root embedded in the daemon binary; will become the default in a future release once production root ships)")
@@ -248,6 +249,7 @@ func main() {
 		Version:               version,
 		TrustAutoApprove:      *trustAutoApprove,
 		BeaconRTTProbe:        *beaconRTTProbe,
+		DisableRxWatchdog:     *noRxWatchdog,
 		TransportMode:         *transportMode,
 		CompatBeaconURL:       *compatBeacon,
 		CompatTLSTrust:        *tlsTrust,

--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -2791,8 +2791,12 @@ func cmdDaemonStart(args []string) {
 		if err := exec.Command("launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), plist).Run(); err != nil {
 			fatalCode("internal", "launchctl bootstrap: %v", err)
 		}
-		// Poll socket until daemon is responsive.
-		waitDeadline := time.Now().Add(10 * time.Second)
+		// Poll socket until daemon is responsive. 30s, not 10s: a daemon
+		// with installed app-store apps spawns them before IPC comes up,
+		// which can push readiness past 10s on a loaded machine — and a
+		// premature "not ready" here reads as a failed start even though
+		// launchd keeps supervising and the daemon finishes booting fine.
+		waitDeadline := time.Now().Add(30 * time.Second)
 		for time.Now().Before(waitDeadline) {
 			if d, err := driver.Connect(getSocket()); err == nil {
 				if _, err := d.Info(); err == nil {
@@ -2808,7 +2812,9 @@ func cmdDaemonStart(args []string) {
 			}
 			time.Sleep(200 * time.Millisecond)
 		}
-		fatalCode("timeout", "launchd loaded the agent but the socket did not become ready within 10s")
+		fatalHint("timeout",
+			"launchd is still supervising it — check `pilotctl daemon status` and the daemon log",
+			"launchd loaded the agent but the socket did not become ready within 30s")
 	}
 
 	// Check if already running

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pilot-protocol/pilotprotocol
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/coder/websocket v1.8.15

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -136,6 +136,17 @@ type Config struct {
 	// Feature flags — ablation testing. All default false (current behavior).
 	BeaconRTTProbe bool // probe beacon RTT; override hash pick when >2× slower than best
 
+	// DisableRxWatchdog turns off the inbound-path watchdog (rxwatchdog.go).
+	// The watchdog detects the long-uptime wedge where the daemon keeps
+	// transmitting but the inbound UDP path has silently died (stale NAT /
+	// relay mapping — 2026-07-13 incident: 43.5 MB sent vs 102 KB received
+	// over 2d19h, every send-message failing with "cannot connect"). It
+	// first soft-recovers (beacon + registry re-registration) and, if the
+	// wedge persists on a supervised daemon, exits non-zero so
+	// launchd/systemd respawns with a clean transport. Default false
+	// (watchdog on) — the wedge otherwise requires a manual restart.
+	DisableRxWatchdog bool
+
 	// Telemetry consent gate. When set to the telemetry endpoint URL,
 	// the daemon initialises a telemetry client that emits signed events
 	// (install, usage, view, review). When empty (default), the client
@@ -331,6 +342,13 @@ type Daemon struct {
 	// during Start; torn down before tunnels in doStop. (T4.3.)
 	netSubMu   sync.Mutex
 	netSubStop func()
+
+	// lastRegistryOKNano is the unix-nano time of the last successful
+	// registry interaction (initial registration, heartbeat, or
+	// re-registration). The rx watchdog uses it to distinguish "data
+	// plane wedged, control plane fine" (restart helps — the incident
+	// signature) from "whole network unreachable" (restart just loops).
+	lastRegistryOKNano atomic.Int64
 
 	startTime       time.Time
 	stopCh          chan struct{}         // closed on Stop() to signal goroutines
@@ -653,6 +671,12 @@ func (d *Daemon) SetRekeyWhitelist(nodeIDs []uint32) {
 }
 
 func (d *Daemon) Start() error {
+	// Stamp startTime before any background goroutine launches — the rx
+	// watchdog reads it from its own goroutine for the min-uptime guard,
+	// and the historical assignment at the bottom of Start left a window
+	// where a loop could read the zero value.
+	d.startTime = time.Now()
+
 	// Warm the hostname cache from disk before the IPC server comes up,
 	// so the first send-message after restart hits the cache instead of
 	// pounding regConn for a fresh resolve_hostname.
@@ -1056,6 +1080,7 @@ func (d *Daemon) Start() error {
 	d.addrMu.Unlock()
 
 	slog.Info("daemon registered", "node_id", d.nodeID, "addr", d.addr, "endpoint", registrationAddr)
+	d.lastRegistryOKNano.Store(time.Now().UnixNano())
 
 	// T4.1: webhook is now a bus subscriber owned by plugins/webhook.
 	// cmd/daemon (composition root) constructs the plugin and starts
@@ -1183,6 +1208,11 @@ func (d *Daemon) Start() error {
 	d.bgWG.Add(1)
 	go func() { defer d.bgWG.Done(); d.observabilityHeartbeatLoop() }()
 
+	// 8b. Start inbound-path watchdog (L4). Detects the "transmitting into
+	// a dead NAT mapping" wedge and recovers — see rxwatchdog.go.
+	d.bgWG.Add(1)
+	go func() { defer d.bgWG.Done(); d.rxWatchdogLoop() }()
+
 	// 9. Start idle connection sweeper
 	d.bgWG.Add(1)
 	go func() { defer d.bgWG.Done(); d.idleSweepLoop() }()
@@ -1260,7 +1290,6 @@ func (d *Daemon) Start() error {
 	// runtime.StartPlugins(ctx) AFTER this Start returns. This
 	// inversion is T7.1: pkg/daemon no longer imports pkg/coreapi.
 
-	d.startTime = time.Now()
 	slog.Info("daemon running", "node_id", d.nodeID, "addr", d.addr)
 	return nil
 }
@@ -4950,6 +4979,7 @@ func (d *Daemon) trustRepublishLoop() {
 				}
 				consecutiveFailures = 0
 				reregBackoff = 100 * time.Millisecond
+				d.lastRegistryOKNano.Store(time.Now().UnixNano())
 			}
 		}
 	}
@@ -5102,6 +5132,7 @@ func (d *Daemon) reRegister() {
 	nodeID := d.nodeID
 	slog.Info("re-registered", "node_id", nodeID, "addr", d.addr)
 	d.addrMu.Unlock()
+	d.lastRegistryOKNano.Store(time.Now().UnixNano())
 	d.publishEvent("node.reregistered", map[string]interface{}{
 		"address": d.addr.String(),
 	})

--- a/pkg/daemon/rxwatchdog.go
+++ b/pkg/daemon/rxwatchdog.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package daemon
+
+import (
+	"log/slog"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// Inbound-path watchdog (L4).
+//
+// Failure mode this exists for (2026-07-13 incident): a daemon with days
+// of uptime keeps transmitting — keepalives, beacon registrations, sends —
+// while the inbound UDP path is silently dead (stale NAT / relay mapping
+// the transport never re-establishes). Control plane stays healthy: the
+// registry heartbeat is TCP and keeps succeeding, so trustRepublishLoop
+// never re-registers, and every peer/service-agent contact fails with
+// "cannot connect (data exchange port 1001)" until an operator restarts
+// the daemon. Observed signature: 43.5 MB / 572K pkts sent vs 102 KB /
+// 1443 pkts received over 2d19h, 0 direct connections.
+//
+// Detection: PktsRecv (delivered tunnel packets — peer keepalives bump it,
+// so any live mutual peer feeds it) stalls for rxSilenceThreshold while
+// PktsSent keeps growing. TunnelManager.LastRecvNano (any raw datagram,
+// including beacon replies) is read alongside to tell a dead socket path
+// from a dead session layer in the logs.
+//
+// Recovery escalates:
+//  1. Soft (up to rxWatchdogSoftMax ticks): RegisterWithBeacon — the
+//     MsgDiscover reply doubles as an active inbound probe — plus
+//     reRegister with the registry. Heals transient beacon endpoint
+//     staleness without touching the transport.
+//  2. Hard: exit with rxWedgeExitCode. launchd (KeepAlive
+//     SuccessfulExit=false) and systemd (Restart=always) respawn the
+//     daemon with a fresh socket + registration — the remedy that is
+//     known to clear the wedge. Guarded so it cannot flap:
+//     only after PktsRecv has progressed at least once this process
+//     (a never-worked config soft-recovers forever instead of
+//     boot-looping), only when the registry was reachable within
+//     rxWedgeRegistryFresh (otherwise the whole network is down and a
+//     restart fixes nothing), and only after rxWedgeMinUptime.
+const (
+	// rxWatchdogTickInterval is how often the watchdog samples counters.
+	rxWatchdogTickInterval = 30 * time.Second
+
+	// rxSilenceThreshold is how long PktsRecv must stall (with tx active)
+	// before the first soft recovery fires.
+	rxSilenceThreshold = 3 * time.Minute
+
+	// rxSilenceMinSentDelta gates on tx activity: at least this many
+	// packets sent since the last rx progress. An idle daemon (no peers,
+	// nothing to send) never triggers.
+	rxSilenceMinSentDelta = 30
+
+	// rxWatchdogSoftMax is how many consecutive soft recoveries run
+	// before the watchdog considers the hard exit.
+	rxWatchdogSoftMax = 3
+
+	// rxWedgeMinUptime: never hard-exit a young process. Caps worst-case
+	// restart churn if a wedge reappears immediately after respawn.
+	rxWedgeMinUptime = 30 * time.Minute
+
+	// rxWedgeRegistryFresh: hard exit requires a successful registry
+	// interaction within this window — the wedge signature is data plane
+	// dead + control plane alive.
+	rxWedgeRegistryFresh = 5 * time.Minute
+
+	// rxWedgeExitCode is the non-zero exit status for the hard escalation.
+	// Non-zero so launchd KeepAlive/SuccessfulExit=false respawns; a
+	// distinctive value so `pilotctl`/operators can attribute the restart.
+	rxWedgeExitCode = 86
+)
+
+// rxWatchdogExit is swapped by tests to observe the hard escalation
+// without killing the test process.
+var rxWatchdogExit = func(code int) { os.Exit(code) }
+
+// rxWatchdogState carries the loop's tick-to-tick memory. Kept as a
+// struct (not loop locals) so tests can drive rxWatchdogTick directly,
+// mirroring the beaconRefreshTick pattern.
+type rxWatchdogState struct {
+	lastProgress   time.Time // when recvSeen last advanced
+	recvSeen       uint64    // PktsRecv at lastProgress
+	sentAtProgress uint64    // PktsSent at lastProgress
+	softAttempts   int       // consecutive soft recoveries this silence
+}
+
+// rxWatchdogAction names what a tick did — returned for tests and logs.
+type rxWatchdogAction string
+
+const (
+	rxActionNone         rxWatchdogAction = ""
+	rxActionProgress     rxWatchdogAction = "progress"
+	rxActionSoftRecover  rxWatchdogAction = "soft-recover"
+	rxActionExitWithheld rxWatchdogAction = "exit-withheld"
+	rxActionExit         rxWatchdogAction = "exit"
+)
+
+func (d *Daemon) rxWatchdogLoop() {
+	if d.config.DisableRxWatchdog {
+		return
+	}
+	// Independent jitter so this loop does not align with the others.
+	time.Sleep(time.Duration(rand.Int63n(int64(5 * time.Second))))
+
+	st := &rxWatchdogState{
+		lastProgress:   time.Now(),
+		recvSeen:       atomic.LoadUint64(&d.tunnels.PktsRecv),
+		sentAtProgress: atomic.LoadUint64(&d.tunnels.PktsSent),
+	}
+	ticker := time.NewTicker(rxWatchdogTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-d.stopCh:
+			return
+		case <-ticker.C:
+			d.rxWatchdogTick(st, time.Now())
+		}
+	}
+}
+
+// rxWatchdogTick runs one watchdog iteration. Extracted for testability —
+// production drives it from rxWatchdogLoop; tests drive it directly.
+//
+// L4 panic boundary (architecture-notes/03-INVARIANTS.md §8): the tick
+// calls into beacon/registry re-registration; a panic drops this tick and
+// the next one retries from clean state.
+func (d *Daemon) rxWatchdogTick(st *rxWatchdogState, now time.Time) (action rxWatchdogAction) {
+	defer recoverLayer("L4", "rxWatchdogTick", d.bus, nil)
+
+	recv := atomic.LoadUint64(&d.tunnels.PktsRecv)
+	sent := atomic.LoadUint64(&d.tunnels.PktsSent)
+
+	if recv != st.recvSeen {
+		if st.softAttempts > 0 {
+			slog.Info("inbound path recovered",
+				"silent_for", now.Sub(st.lastProgress).Truncate(time.Second).String(),
+				"soft_attempts", st.softAttempts)
+			d.publishEvent("tunnel.rx_recovered", map[string]any{
+				"silent_for_seconds": int64(now.Sub(st.lastProgress).Seconds()),
+				"soft_attempts":      st.softAttempts,
+			})
+		}
+		st.recvSeen = recv
+		st.sentAtProgress = sent
+		st.lastProgress = now
+		st.softAttempts = 0
+		return rxActionProgress
+	}
+
+	silence := now.Sub(st.lastProgress)
+	sentDelta := sent - st.sentAtProgress
+	if silence < rxSilenceThreshold || sentDelta < rxSilenceMinSentDelta {
+		return rxActionNone
+	}
+
+	// rawRxAge separates "socket path dead" (old) from "session layer
+	// dead" (fresh — datagrams arrive but nothing decrypts/delivers).
+	rawRxAge := time.Duration(0)
+	if last := d.tunnels.LastRecvTime(); !last.IsZero() {
+		rawRxAge = now.Sub(last)
+	}
+
+	if st.softAttempts < rxWatchdogSoftMax {
+		st.softAttempts++
+		slog.Warn("inbound path silent while transmitting — attempting soft recovery",
+			"silent_for", silence.Truncate(time.Second).String(),
+			"pkts_sent_during_silence", sentDelta,
+			"raw_rx_age", rawRxAge.Truncate(time.Second).String(),
+			"attempt", st.softAttempts,
+			"max_soft_attempts", rxWatchdogSoftMax)
+		d.publishEvent("tunnel.rx_silence", map[string]any{
+			"silent_for_seconds":       int64(silence.Seconds()),
+			"pkts_sent_during_silence": sentDelta,
+			"raw_rx_age_seconds":       int64(rawRxAge.Seconds()),
+			"attempt":                  st.softAttempts,
+		})
+		// The beacon's discover reply is itself an inbound datagram, so
+		// this doubles as an active probe of the rx path.
+		d.tunnels.RegisterWithBeacon()
+		if d.regConn != nil {
+			d.reRegister()
+		}
+		return rxActionSoftRecover
+	}
+
+	registryAge := time.Duration(-1)
+	if ok := d.lastRegistryOKNano.Load(); ok > 0 {
+		registryAge = now.Sub(time.Unix(0, ok))
+	}
+	uptime := now.Sub(d.startTime)
+	switch {
+	case st.recvSeen == 0:
+		// Never received a tunnel packet this process — a restart would
+		// reproduce the same state (boot loop). Keep soft-recovering.
+		slog.Warn("inbound path silent and never progressed — withholding restart, will keep soft-recovering",
+			"silent_for", silence.Truncate(time.Second).String())
+	case registryAge < 0 || registryAge > rxWedgeRegistryFresh:
+		// Registry unreachable too — likely the machine/network is
+		// offline, not a wedged transport. Restarting fixes nothing.
+		slog.Warn("inbound path silent but registry also unreachable — withholding restart",
+			"silent_for", silence.Truncate(time.Second).String(),
+			"registry_ok_age", registryAge.Truncate(time.Second).String())
+	case uptime < rxWedgeMinUptime:
+		slog.Warn("inbound path silent but process too young — withholding restart",
+			"silent_for", silence.Truncate(time.Second).String(),
+			"uptime", uptime.Truncate(time.Second).String())
+	default:
+		slog.Error("inbound path wedged — exiting for supervisor respawn",
+			"silent_for", silence.Truncate(time.Second).String(),
+			"pkts_sent_during_silence", sentDelta,
+			"raw_rx_age", rawRxAge.Truncate(time.Second).String(),
+			"soft_attempts", st.softAttempts,
+			"exit_code", rxWedgeExitCode)
+		d.publishEvent("tunnel.rx_wedged_exit", map[string]any{
+			"silent_for_seconds":       int64(silence.Seconds()),
+			"pkts_sent_during_silence": sentDelta,
+			"soft_attempts":            st.softAttempts,
+			"exit_code":                rxWedgeExitCode,
+		})
+		rxWatchdogExit(rxWedgeExitCode)
+		return rxActionExit
+	}
+	// Withheld: reset the soft counter so recovery attempts continue on
+	// later ticks instead of re-evaluating the exit every 30s.
+	st.softAttempts = 0
+	return rxActionExitWithheld
+}

--- a/pkg/daemon/rxwatchdog.go
+++ b/pkg/daemon/rxwatchdog.go
@@ -104,6 +104,8 @@ func (d *Daemon) rxWatchdogLoop() {
 		return
 	}
 	// Independent jitter so this loop does not align with the others.
+	// #nosec G404 -- startup-jitter scheduling only (same pattern as the
+	// sibling loops in daemon.go); not security-sensitive randomness
 	time.Sleep(time.Duration(rand.Int63n(int64(5 * time.Second))))
 
 	st := &rxWatchdogState{

--- a/pkg/daemon/tunnel.go
+++ b/pkg/daemon/tunnel.go
@@ -182,6 +182,14 @@ type TunnelManager struct {
 	PktsRecv    uint64
 	EncryptOK   uint64
 	EncryptFail uint64
+	// LastRecvNano is the unix-nano timestamp of the last datagram the
+	// read loop pulled off the socket — ANY datagram, including beacon
+	// replies and key-exchange frames that never reach PktsRecv. The rx
+	// watchdog reads both: PktsRecv stalling flags a wedge; LastRecvNano
+	// tells it whether the raw socket path is dead too (NAT mapping gone)
+	// or only the session layer (decrypt/key desync). Stamped at Listen /
+	// ConnectCompat so the age is measured from transport start, not epoch.
+	LastRecvNano int64
 	// P1-008: packets dropped from the per-peer pending queue while waiting
 	// for key exchange. Exposed so operators can tell a congested overlay
 	// apart from a silent crypto stall.
@@ -911,6 +919,7 @@ func (tm *TunnelManager) Listen(addr string) error {
 	}
 	tm.sock = sock
 	tm.routing.SetSocket(sock)
+	atomic.StoreInt64(&tm.LastRecvNano, time.Now().UnixNano())
 
 	tm.readWg.Add(1)
 	go tm.readLoop()
@@ -960,6 +969,7 @@ func (tm *TunnelManager) ConnectCompat(ctx context.Context, cfg ConnectCompatCon
 	}
 	tm.sock = wssTr
 	tm.routing.SetSocket(wssTr)
+	atomic.StoreInt64(&tm.LastRecvNano, time.Now().UnixNano())
 	// In compat mode every outbound L2 frame must travel beacon-wrapped:
 	// the WSS pipe terminates at the beacon, not at peers, so raw frames
 	// would be received as unknown beacon-protocol packets and dropped.
@@ -989,6 +999,17 @@ func (tm *TunnelManager) Close() error {
 		close(tm.recvCh) // unblock routeLoop (H5 fix — prevents goroutine leak)
 	})
 	return connErr
+}
+
+// LastRecvTime returns the time of the last datagram received on the
+// transport socket (any frame type), or the zero Time before Listen /
+// ConnectCompat has run.
+func (tm *TunnelManager) LastRecvTime() time.Time {
+	nano := atomic.LoadInt64(&tm.LastRecvNano)
+	if nano == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nano)
 }
 
 func (tm *TunnelManager) LocalAddr() net.Addr {
@@ -1047,6 +1068,7 @@ func (tm *TunnelManager) readLoopOneIter() (cont bool, stopped bool) {
 		}
 		return false, true
 	}
+	atomic.StoreInt64(&tm.LastRecvNano, time.Now().UnixNano())
 
 	n := len(frame)
 	if n < 1 {

--- a/pkg/daemon/zz_rx_watchdog_test.go
+++ b/pkg/daemon/zz_rx_watchdog_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package daemon
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newRxWatchdogTestDaemon builds the minimal Daemon the tick needs:
+// a TunnelManager for the counters and a startTime old enough that
+// rxWedgeMinUptime does not gate the escalation under test.
+func newRxWatchdogTestDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	return &Daemon{
+		tunnels:   NewTunnelManager(),
+		startTime: time.Now().Add(-2 * rxWedgeMinUptime),
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// wedgeState returns a state that has already burned all soft attempts:
+// silence beyond threshold, tx active, next tick evaluates the hard exit.
+func wedgeState(d *Daemon, now time.Time) *rxWatchdogState {
+	atomic.StoreUint64(&d.tunnels.PktsRecv, 100)
+	atomic.StoreUint64(&d.tunnels.PktsSent, 100+2*rxSilenceMinSentDelta)
+	return &rxWatchdogState{
+		lastProgress:   now.Add(-2 * rxSilenceThreshold),
+		recvSeen:       100,
+		sentAtProgress: 100,
+		softAttempts:   rxWatchdogSoftMax,
+	}
+}
+
+// swapExitForTest stubs the global rxWatchdogExit. Tests that call it
+// must NOT use t.Parallel(): a parallel sibling's Cleanup could restore
+// the real os.Exit while this test still fires the escalation, killing
+// the whole test binary.
+func swapExitForTest(t *testing.T) *int {
+	t.Helper()
+	var exitCode int
+	prev := rxWatchdogExit
+	rxWatchdogExit = func(code int) { exitCode = code }
+	t.Cleanup(func() { rxWatchdogExit = prev })
+	return &exitCode
+}
+
+func TestRxWatchdogNoActionWhileHealthy(t *testing.T) {
+	t.Parallel()
+	d := newRxWatchdogTestDaemon(t)
+	now := time.Now()
+
+	// Progress on every tick: recv counter keeps moving.
+	st := &rxWatchdogState{lastProgress: now.Add(-time.Hour), recvSeen: 5}
+	atomic.StoreUint64(&d.tunnels.PktsRecv, 6)
+	if got := d.rxWatchdogTick(st, now); got != rxActionProgress {
+		t.Fatalf("action = %q, want %q", got, rxActionProgress)
+	}
+	if st.softAttempts != 0 || !st.lastProgress.Equal(now) {
+		t.Fatalf("progress must reset state: %+v", st)
+	}
+
+	// Silent but idle (tx below rxSilenceMinSentDelta): no action.
+	st = &rxWatchdogState{
+		lastProgress:   now.Add(-2 * rxSilenceThreshold),
+		recvSeen:       6,
+		sentAtProgress: atomic.LoadUint64(&d.tunnels.PktsSent),
+	}
+	if got := d.rxWatchdogTick(st, now); got != rxActionNone {
+		t.Fatalf("idle-silent action = %q, want %q", got, rxActionNone)
+	}
+
+	// Silent + tx active but under the silence threshold: no action.
+	atomic.StoreUint64(&d.tunnels.PktsSent, 10*rxSilenceMinSentDelta)
+	st = &rxWatchdogState{lastProgress: now.Add(-rxSilenceThreshold / 2), recvSeen: 6}
+	if got := d.rxWatchdogTick(st, now); got != rxActionNone {
+		t.Fatalf("short-silence action = %q, want %q", got, rxActionNone)
+	}
+}
+
+func TestRxWatchdogSoftRecoveryThenReset(t *testing.T) {
+	t.Parallel()
+	d := newRxWatchdogTestDaemon(t)
+	now := time.Now()
+
+	atomic.StoreUint64(&d.tunnels.PktsRecv, 50)
+	atomic.StoreUint64(&d.tunnels.PktsSent, 50+2*rxSilenceMinSentDelta)
+	st := &rxWatchdogState{
+		lastProgress:   now.Add(-2 * rxSilenceThreshold),
+		recvSeen:       50,
+		sentAtProgress: 50,
+	}
+
+	for i := 1; i <= rxWatchdogSoftMax; i++ {
+		if got := d.rxWatchdogTick(st, now); got != rxActionSoftRecover {
+			t.Fatalf("tick %d action = %q, want %q", i, got, rxActionSoftRecover)
+		}
+		if st.softAttempts != i {
+			t.Fatalf("tick %d softAttempts = %d, want %d", i, st.softAttempts, i)
+		}
+	}
+
+	// Inbound comes back: state resets and the recovery event path runs.
+	atomic.StoreUint64(&d.tunnels.PktsRecv, 51)
+	if got := d.rxWatchdogTick(st, now); got != rxActionProgress {
+		t.Fatalf("post-recovery action = %q, want %q", got, rxActionProgress)
+	}
+	if st.softAttempts != 0 {
+		t.Fatalf("softAttempts = %d after recovery, want 0", st.softAttempts)
+	}
+}
+
+func TestRxWatchdogHardExitRequiresFreshRegistry(t *testing.T) {
+	d := newRxWatchdogTestDaemon(t)
+	exitCode := swapExitForTest(t)
+	now := time.Now()
+
+	// Registry never succeeded (lastRegistryOKNano zero): withhold.
+	st := wedgeState(d, now)
+	if got := d.rxWatchdogTick(st, now); got != rxActionExitWithheld {
+		t.Fatalf("no-registry action = %q, want %q", got, rxActionExitWithheld)
+	}
+	if *exitCode != 0 {
+		t.Fatalf("exit fired with unreachable registry (code %d)", *exitCode)
+	}
+	if st.softAttempts != 0 {
+		t.Fatalf("withheld exit must reset softAttempts, got %d", st.softAttempts)
+	}
+
+	// Registry stale: still withhold.
+	d.lastRegistryOKNano.Store(now.Add(-2 * rxWedgeRegistryFresh).UnixNano())
+	st = wedgeState(d, now)
+	if got := d.rxWatchdogTick(st, now); got != rxActionExitWithheld {
+		t.Fatalf("stale-registry action = %q, want %q", got, rxActionExitWithheld)
+	}
+
+	// Registry fresh: the wedge signature — exit fires.
+	d.lastRegistryOKNano.Store(now.UnixNano())
+	st = wedgeState(d, now)
+	if got := d.rxWatchdogTick(st, now); got != rxActionExit {
+		t.Fatalf("fresh-registry action = %q, want %q", got, rxActionExit)
+	}
+	if *exitCode != rxWedgeExitCode {
+		t.Fatalf("exit code = %d, want %d", *exitCode, rxWedgeExitCode)
+	}
+}
+
+func TestRxWatchdogHardExitWithheldWhenNeverProgressedOrYoung(t *testing.T) {
+	d := newRxWatchdogTestDaemon(t)
+	exitCode := swapExitForTest(t)
+	now := time.Now()
+	d.lastRegistryOKNano.Store(now.UnixNano())
+
+	// Never received a tunnel packet this process: withhold (boot-loop guard).
+	st := wedgeState(d, now)
+	st.recvSeen = 0
+	atomic.StoreUint64(&d.tunnels.PktsRecv, 0)
+	if got := d.rxWatchdogTick(st, now); got != rxActionExitWithheld {
+		t.Fatalf("never-progressed action = %q, want %q", got, rxActionExitWithheld)
+	}
+
+	// Young process: withhold (restart-churn guard).
+	d2 := newRxWatchdogTestDaemon(t)
+	d2.startTime = now.Add(-rxWedgeMinUptime / 2)
+	d2.lastRegistryOKNano.Store(now.UnixNano())
+	st = wedgeState(d2, now)
+	if got := d2.rxWatchdogTick(st, now); got != rxActionExitWithheld {
+		t.Fatalf("young-process action = %q, want %q", got, rxActionExitWithheld)
+	}
+
+	if *exitCode != 0 {
+		t.Fatalf("exit fired despite guards (code %d)", *exitCode)
+	}
+}


### PR DESCRIPTION
## Problem

A daemon can run for days transmitting into a stale NAT/relay mapping while receiving nothing. 2026-07-13 incident on cascade-test: **43.5 MB / 572K pkts sent vs 102 KB / 1,443 pkts received over 2d19h**, every `send-message` failing with `cannot connect (data exchange port 1001)`. The registry heartbeat is TCP and kept succeeding, so `trustRepublishLoop` never noticed — only a manual restart cleared it.

## Fix

New inbound-path watchdog (`pkg/daemon/rxwatchdog.go`), on by default:

- **Detect:** samples `PktsRecv`/`PktsSent` every 30s; wedge = 3 min of delivered-packet silence while ≥30 packets went out. New `LastRecvNano` raw-datagram timestamp distinguishes dead-socket from dead-session-layer in logs.
- **Soft recover (×3):** `RegisterWithBeacon` (the discover reply doubles as an active inbound probe) + registry `reRegister`.
- **Hard recover:** exit code 86 → launchd (`KeepAlive.SuccessfulExit=false`) / systemd (`Restart=always`) respawn with a fresh transport — the remedy that demonstrably clears the wedge.
- **Flap guards:** exit withheld when the registry is also unreachable (machine offline), when inbound never progressed this process (boot-loop guard), or within 30 min of start.
- Emits `tunnel.rx_silence` / `tunnel.rx_recovered` / `tunnel.rx_wedged_exit`. Opt out: `-no-rx-watchdog`.

Also: `pilotctl daemon start` launchd readiness wait 10s→30s (app-store apps spawn before IPC; the old timeout reported a false failure for boots that succeed moments later).

## Testing

- 4 tick-driven unit tests (healthy paths, soft-recovery cycle, exit requires fresh registry, exit withheld for never-progressed/young process) — pass with `-race -count=5`.
- Full `pkg/daemon` suite: only the two pre-existing failures (`TestWriteLoopExitsOnWriteDeadline`, `TestIPCServer_MaxClientsCap` — confirmed pre-existing via `git stash`).
- Docs synced (configuration flags table, webhooks events table, plain mirrors, CHANGELOG); website builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)