### PR TITLE
chore: update legacy TeoSlayer references to pilot-protocol org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to Pilot Protocol. This document cov
 ### Setup
 
 ```bash
-git clone git@github.com:TeoSlayer/pilotprotocol.git
+git clone git@github.com:pilot-protocol/pilotprotocol.git
 cd pilotprotocol
 go build ./...
 ```

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ curl -fsSL https://pilotprotocol.network/install.sh | PILOT_EMAIL=user@example.c
 
 **Uninstall:** `curl -fsSL https://pilotprotocol.network/install.sh | sh -s uninstall`
 
-**From source** (requires Go 1.25+): `git clone https://github.com/TeoSlayer/pilotprotocol.git && cd pilotprotocol && make build`
+**From source** (requires Go 1.25+): `git clone https://github.com/pilot-protocol/pilotprotocol.git && cd pilotprotocol && make build`
 
 </details>
 

--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -195,7 +195,7 @@ build time without a code change:
 
 ```bash
 go build -ldflags \
-  "-X github.com/TeoSlayer/pilotprotocol/internal/catalogtrust.publicKeyB64=<new-b64-pubkey>" \
+  "-X github.com/pilot-protocol/pilotprotocol/internal/catalogtrust.publicKeyB64=<new-b64-pubkey>" \
   ./cmd/pilotctl ./cmd/daemon
 ```
 


### PR DESCRIPTION
The GitHub org was renamed and the hub now lives at `pilot-protocol/pilotprotocol`. Legacy `TeoSlayer/...` references in this repo only worked via GitHub redirects; this updates the functional and user-facing ones. Links to repos that genuinely still live under `TeoSlayer` (pilot-skills, pilot-mcp, homebrew-pilot) are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)