### PR TITLE
cascade: secrets inherit (App-token bump PRs)

### DIFF
--- a/.github/workflows/cascade.yml
+++ b/.github/workflows/cascade.yml
@@ -41,3 +41,4 @@ jobs:
       version: ${{ inputs.version || github.event.client_payload.version }}
       is_prerelease: ${{ inputs.is_prerelease == true || github.event.client_payload.is_prerelease == true }}
       stable_only: true
+    secrets: inherit


### PR DESCRIPTION
Passes the org-scoped pilot-release-bot credentials to the reusable bump workflow (pilot-protocol/release#23) so bump PRs are created as the App and trigger CI. `inherit` also keeps CHANGELOG_SECRET flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)