### PR TITLE
catalogue: io.pilot.docker v29.6.1

### DIFF
--- a/catalogue/apps/io.pilot.docker/metadata.json
+++ b/catalogue/apps/io.pilot.docker/metadata.json
@@ -68,15 +68,15 @@
     },
     {
       "name": "docker.pull",
-      "summary": "Pull an image from a registry. This is `docker pull \u003cimage\u003e`."
+      "summary": "Pull an image from a registry. This is `docker pull <image>`."
     },
     {
       "name": "docker.run",
-      "summary": "Run a container from `image` with its default command and remove it on exit (`docker run --rm \u003cimage\u003e`). For flags/commands (detached, ports, volumes, a custom command) use docker.exec, e.g. {\"args\":[\"run\",\"-d\",\"-p\",\"8080:80\",\"nginx\"]}."
+      "summary": "Run a container from `image` with its default command and remove it on exit (`docker run --rm <image>`). For flags/commands (detached, ports, volumes, a custom command) use docker.exec, e.g. {\"args\":[\"run\",\"-d\",\"-p\",\"8080:80\",\"nginx\"]}."
     },
     {
       "name": "docker.logs",
-      "summary": "Fetch the logs of a container. This is `docker logs \u003ccontainer\u003e`."
+      "summary": "Fetch the logs of a container. This is `docker logs <container>`."
     },
     {
       "name": "docker.exec",
@@ -108,5 +108,54 @@
       "label": "Website",
       "url": "https://www.docker.com"
     }
-  ]
+  ],
+  "product_demo": {
+    "skill": "io.pilot.docker",
+    "title": "Full usage demo",
+    "when_to_use": "When you need to run real OCI containers on a Linux host — pull images and run/build/exec containers via a local Docker Engine — without Docker Desktop.",
+    "metered": false,
+    "quickstart": {
+      "goal": "Boot a local Docker Engine",
+      "command": "pilotctl appstore call io.pilot.docker docker.engine_start '{}'",
+      "expect": "engine ready on a private socket under DOCKER_DIR (default /tmp/pilot-docker)"
+    },
+    "examples": [
+      {
+        "title": "Client + server versions",
+        "command": "pilotctl appstore call io.pilot.docker docker.version '{}'",
+        "expect": "docker version text (Client + Server sections)"
+      },
+      {
+        "title": "Pull an image",
+        "command": "pilotctl appstore call io.pilot.docker docker.pull '{\"image\":\"hello-world\"}'",
+        "expect": "pull progress ending in Status: Downloaded newer image for hello-world:latest"
+      },
+      {
+        "title": "Run a container (--rm, default cmd)",
+        "command": "pilotctl appstore call io.pilot.docker docker.run '{\"image\":\"hello-world\"}'",
+        "expect": "\"Hello from Docker!\" banner; container is removed on exit"
+      },
+      {
+        "title": "Any docker command via verbatim argv",
+        "goal": "Run nginx detached with a published port",
+        "command": "pilotctl appstore call io.pilot.docker docker.exec '{\"args\":[\"run\",\"-d\",\"-p\",\"8080:80\",\"nginx\"]}'",
+        "expect": "the new container id on stdout"
+      },
+      {
+        "title": "List containers",
+        "command": "pilotctl appstore call io.pilot.docker docker.ps '{}'",
+        "expect": "table of containers (running + stopped), this is docker ps -a"
+      }
+    ],
+    "gotchas": [
+      "LINUX-ONLY: there is no native macOS dockerd (Docker Desktop hides a Linux VM), so this app cannot start an engine on macOS.",
+      "docker.engine_start needs root — dockerd manages namespaces/cgroups; run on a Linux host/VM/privileged container.",
+      "Call docker.engine_start once before other methods, or set DOCKER_HOST to target an existing daemon and skip it.",
+      "docker.run uses --rm and the image's default command; for flags, ports, detached, or build/exec use docker.exec.",
+      "On a non-zero exit the reply is {stdout, stderr, exit}."
+    ],
+    "next": [
+      "io.pilot.docker docker.help '{}'"
+    ]
+  }
 }

--- a/catalogue/catalogue.json
+++ b/catalogue/catalogue.json
@@ -316,37 +316,6 @@
       "publisher": "ed25519:goaIo9+EvuMcRZnkum08HY83QScUWLRtqe0KG/uGljs="
     },
     {
-      "id": "io.pilot.docker",
-      "version": "29.6.1",
-      "description": "Docker 29.6.1 as a native CLI for agents (Linux): delivers the Docker Engine (dockerd + containerd + runc) and the docker CLI, sha-pinned. Start a local engine (docker.engine_start), then pull images and run containers — run/ps/images/pull/logs, plus build, exec, networks, volumes, and any docker command via a verbatim-argv passthrough. Real containers on a real Linux host, no Docker Desktop.",
-      "display_name": "Docker",
-      "vendor": "Pilot Protocol",
-      "license": "Apache-2.0",
-      "source_url": "https://github.com/moby/moby",
-      "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-amd64.tar.gz",
-      "bundle_sha256": "410dd4bf4747ca4518ec98962c93e6be8f598ee93c87773b332d86514acb593e",
-      "bundle_size": 5352665,
-      "bundles": {
-        "linux/amd64": {
-          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-amd64.tar.gz",
-          "bundle_sha256": "410dd4bf4747ca4518ec98962c93e6be8f598ee93c87773b332d86514acb593e"
-        },
-        "linux/arm64": {
-          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-arm64.tar.gz",
-          "bundle_sha256": "2349cda00272b282a86c4c1000405afd0d7bee9522b137177c7e2a0772a9f5cc"
-        }
-      },
-      "categories": [
-        "devops",
-        "containers",
-        "runtime",
-        "data"
-      ],
-      "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/io.pilot.docker/metadata.json",
-      "metadata_sha256": "887e3e9697e56146b01594d8b18595b5d6bb3e503d2728e38a5370c50e41e482",
-      "publisher": "ed25519:pzka4ROsoHKaQLgBQG+WlUGgtAVzgNy4WUvKzoysLRo="
-    },
-    {
       "id": "io.pilot.redis",
       "version": "8.6.2",
       "description": "Redis 8.6.2 as a native CLI for agents: stand up a local in-memory data store (redis.start) and talk to it with redis-cli — SET/GET, PING, INFO, DBSIZE, and ANY Redis command (lists, hashes, sets, sorted sets, streams, pub/sub, transactions) via a verbatim-argv passthrough. Server lifecycle (start/stop), health checks, and the full redis-cli/redis-server toolchain (redis-benchmark, redis-check-rdb, ...). No server to provision — runs locally on this host.",
@@ -776,6 +745,32 @@
         }
       },
       "publisher": "ed25519:BAsg7bdd2t0V9tFCkXRCWRgIdEuuWtJVEjjZp8HBgEg="
+    },
+    {
+      "id": "io.pilot.docker",
+      "version": "29.6.1",
+      "description": "Docker 29.6.1 as a native CLI for agents (Linux): delivers the Docker Engine (dockerd + containerd + runc) and the docker CLI, sha-pinned. Start a local engine (docker.engine_start), then pull images and run containers — run/ps/images/pull/logs, plus build, exec, networks, volumes, and any docker command via a verbatim-argv passthrough. Real containers on a real Linux host, no Docker Desktop.",
+      "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-amd64.tar.gz",
+      "bundle_sha256": "410dd4bf4747ca4518ec98962c93e6be8f598ee93c87773b332d86514acb593e",
+      "display_name": "Docker",
+      "vendor": "Pilot Protocol",
+      "categories": [],
+      "bundle_size": 5352665,
+      "source_url": "https://github.com/pilot-protocol/app-template/tree/main/submissions/io.pilot.docker",
+      "license": "",
+      "metadata_url": "https://raw.githubusercontent.com/pilot-protocol/pilotprotocol/main/catalogue/apps/io.pilot.docker/metadata.json",
+      "metadata_sha256": "896d2142e0b2cc7aa4ae585ad2cdc66d94af449fc2b83450b9d94d5fd96b5886",
+      "bundles": {
+        "linux/amd64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-amd64.tar.gz",
+          "bundle_sha256": "410dd4bf4747ca4518ec98962c93e6be8f598ee93c87773b332d86514acb593e"
+        },
+        "linux/arm64": {
+          "bundle_url": "https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-arm64.tar.gz",
+          "bundle_sha256": "2349cda00272b282a86c4c1000405afd0d7bee9522b137177c7e2a0772a9f5cc"
+        }
+      },
+      "publisher": "ed25519:pzka4ROsoHKaQLgBQG+WlUGgtAVzgNy4WUvKzoysLRo="
     }
   ]
 }

--- a/catalogue/catalogue.json.sig
+++ b/catalogue/catalogue.json.sig
@@ -1,1 +1,1 @@
-IcWEYl+PRCPCU/osMH3fk+Xop6Hax+htirANCxPmpBcldHjWJwrnTZjBNy5/ueJEvLERAwFBuVrMvcIAv0QXCg==
+eYEQAfa3rihYGOkAF5MZUoFJrw9sdZd2JgsjCEoJTwqhylBS0wl4bd6rlwsHU0Q7ESnbmxSUImVz36VYbHl9DA==


### PR DESCRIPTION
Automated catalogue update for **io.pilot.docker v29.6.1** (rich submission, bundles already on R2). Primary: https://pub-f09f9a4ea848491198d48e329ba030e3.r2.dev/bundles/io.pilot.docker/29.6.1/io.pilot.docker-29.6.1-linux-amd64.tar.gz (sha256 410dd4bf4747ca4518ec98962c93e6be8f598ee93c87773b332d86514acb593e). Platforms: . Publisher: ed25519:pzka4ROsoHKaQLgBQG+WlUGgtAVzgNy4WUvKzoysLRo=. catalogue.json re-signed with CATALOG_SIGN_KEY. CI verifies; human approves per APP-PUBLISHING-SPEC §7.2.