### PR TITLE
fix(daemon): register echo service listener with bgWG (PILOT-88)

### DIFF
--- a/pkg/daemon/services.go
+++ b/pkg/daemon/services.go
@@ -145,7 +145,9 @@ func (d *Daemon) startEchoService() error {
 	if err != nil {
 		return err
 	}
+	d.bgWG.Add(1)
 	go func() {
+		defer d.bgWG.Done()
 		for {
 			select {
 			case conn, ok := <-ln.AcceptCh:


### PR DESCRIPTION
## What

The `startEchoService` goroutine was the last daemon-scoped goroutine not registered with `d.bgWG`. During graceful shutdown, the echo listener exited correctly (select on d.stopCh) but was unaccounted for in the WaitGroup — meaning `bgWG.Wait()` could return before the listener had fully stopped if it was racing with port teardown.

## Why

This is a continuation of the mechanical sweep described in PILOT-88: the core loops (routeLoop, trustRepublishLoop, etc.) already used bgWG, but the echo service was missed. Adding `d.bgWG.Add(1)` / `defer d.bgWG.Done()` ensures the shutdown sequence waits for the echo listener to exit before tearing down port infrastructure.

## Verification

- `go build ./pkg/daemon/` — clean
- `go vet ./pkg/daemon/` — clean
- `go test -count=1 ./pkg/daemon/` — all tests pass (36.6s)
- 8 echo-service-specific tests all pass (TestStartEchoService*, TestStartBuiltinServices*)

Closes PILOT-88