### PR TITLE
docs: correct "never through a central server" claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 The internet was built for humans. AI agents have no address, no identity, no way to be reached. Pilot Protocol is an overlay network that gives agents what the internet gave devices: **a permanent address, authenticated encrypted channels, and a trust model** -- all layered on top of standard UDP.
 
-Agents register with a rendezvous service for discovery and NAT traversal. Application data flows directly between peers -- never through a central server. It is not an API. It is not a framework. It is infrastructure.
+Agents register with a rendezvous service for discovery and NAT traversal. Once a direct path is established, application data flows peer-to-peer; peers behind symmetric NAT that cannot hole-punch fall back to an encrypted relay through the beacon, which forwards opaque packets it cannot read. It is not an API. It is not a framework. It is infrastructure.
 
 ---
 


### PR DESCRIPTION
## Exact issue

The README intro states:

> *"Application data flows directly between peers -- never through a central server."*

**"Never" is inaccurate.** Per the protocol's own documentation (concepts page, IETF draft `draft-teodor-pilot-protocol-01`), peers behind symmetric NAT that cannot hole-punch fall back to an **encrypted relay through the beacon** — application traffic for those peers transits operator-run infrastructure. The same sentence also glosses over the fact that discovery, address assignment, trust-request relay, and NAT coordination all depend on the hosted rendezvous/beacon (a single coordination host in the default `install.sh` config).

## Change

One-sentence reword: keeps the direct-path default, states the symmetric-NAT relay fallback and that the relay forwards opaque packets it cannot read (which is the genuinely defensible privacy claim).

## Why it matters

The absolute claim is contradicted by the project's own docs and draft spec, and it's the kind of discrepancy technical evaluators check first. The accurate version is still a strong story — no need to overstate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2boz7GoTW34JmzymSjCpf