### PR TITLE
rebrand residue: install.sh pilot-mom examples + stale flag-help defaults

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -69,11 +69,11 @@ func main() {
 	identityPath := flag.String("identity", "", "path to persist Ed25519 identity (enables stable identity across restarts)")
 	email := flag.String("email", "", "email address for account identification and key recovery")
 	owner := flag.String("owner", "", "(deprecated: use -email) owner identifier for key rotation recovery")
-	keepalive := flag.Duration("keepalive", 0, "keepalive probe interval (default 30s)")
+	keepalive := flag.Duration("keepalive", 0, "keepalive probe interval (default 60s)")
 	idleTimeout := flag.Duration("idle-timeout", 0, "idle connection timeout (default 120s)")
 	synRate := flag.Int("syn-rate-limit", 0, "max SYN packets per second (default 100)")
 	maxConnsPerPort := flag.Int("max-conns-per-port", 0, "max connections per port (default 1024)")
-	maxConnsTotal := flag.Int("max-conns-total", 0, "max total connections (default 4096)")
+	maxConnsTotal := flag.Int("max-conns-total", 0, "max total connections (default 65536)")
 	// PILOT-343/344/345 rate-limit whitelists. Comma-separated trusted-peer
 	// node IDs (decimal uint32). Env fallbacks let deployments configure
 	// without editing flag strings. Empty default preserves backwards

--- a/install.sh
+++ b/install.sh
@@ -735,13 +735,13 @@ cat <<'PILOT_GET_STARTED'
      Describe the whole task in plain English; it picks the specialist
      agents + filters and returns a validated, ready-to-run plan.
      ------------------------------------------------------------------
-     pilotctl send-message pilot-director --data 'current weather and air quality for Berlin' --wait
+     pilotctl send-message pilot-mom --data 'current weather and air quality for Berlin' --wait
      jq -r '.data' "$(ls -1t ~/.pilot/inbox/*.json | head -1)"
 
      # More examples — hand it the whole sentence, don't hunt for agents yourself:
-     pilotctl send-message pilot-director --data 'summarize this season F1 drivers' --wait
-     pilotctl send-message pilot-director --data 'latest CVEs for nginx' --wait
-     pilotctl send-message pilot-director --data "what's BTC at right now in USD" --wait
+     pilotctl send-message pilot-mom --data 'summarize this season F1 drivers' --wait
+     pilotctl send-message pilot-mom --data 'latest CVEs for nginx' --wait
+     pilotctl send-message pilot-mom --data "what's BTC at right now in USD" --wait
 
 
   2) DISCOVER SERVICE AGENTS — when you already know the specialist you want.


### PR DESCRIPTION
Sweep findings: install.sh 'try it' examples still taught the dead pilot-director hostname; two cmd/daemon flag help strings claimed wrong defaults (keepalive 30s→60s, max-conns-total 4096→65536 — code/docs were right, help text was stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)