### PR TITLE
fix(cli): correct stale help text that contradicts actual behavior

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -88,7 +88,7 @@ func main() {
 	hostname := flag.String("hostname", "", "hostname for discovery (lowercase alphanumeric + hyphens, max 63 chars)")
 	noEcho := flag.Bool("no-echo", false, "disable built-in echo service (port 7)")
 	noDataExchange := flag.Bool("no-dataexchange", false, "disable built-in data exchange service (port 1001)")
-	dataExchangeB64 := flag.Bool("dataexchange-b64", false, "include raw base64 payload (`data_b64`) alongside `data` in inbox messages — needed only for binary payloads (e.g. zlib-compressed envelopes)")
+	dataExchangeB64 := flag.Bool("dataexchange-b64", false, "write inbox message payloads as a raw base64 `data_b64` field in place of the UTF-8 `data` field — needed only for binary payloads (e.g. zlib-compressed envelopes)")
 	noEventStream := flag.Bool("no-eventstream", false, "disable built-in event stream service (port 1002)")
 	webhookURL := flag.String("webhook", "", "HTTP(S) endpoint for event notifications (empty = disabled)")
 	adminToken := flag.String("admin-token", "", "admin token for network operations")

--- a/cmd/pilotctl/main.go
+++ b/cmd/pilotctl/main.go
@@ -889,7 +889,7 @@ Examples:
 Measure throughput to a remote node via the echo port.
 
 Flags:
-  --timeout <dur>       overall deadline (default: 30s)
+  --timeout <dur>       overall deadline (default: 120s)
 
 Examples:
   pilotctl bench my-agent
@@ -1049,14 +1049,16 @@ Flags:
   --check     silent health check — exits 0 if daemon is responsive, 1 otherwise
               useful in scripts: pilotctl daemon status --check || pilotctl daemon start
 `,
-	"init": `Usage: pilotctl init --registry <addr> [flags]
+	"init": `Usage: pilotctl init [flags]
 
 Initialize the local pilot config at ~/.pilot/config.json.
+All flags are optional; unset values are written with their defaults.
 
 Flags:
-  --registry <addr>     registry address (required)
+  --registry <addr>     registry address (default: 34.71.57.205:9000)
   --beacon <addr>       beacon address
-  --hostname <name>     hostname to register
+  --hostname <name>     hostname to register (default: none)
+  --socket <path>       daemon socket path (default: /tmp/pilot.sock)
 `,
 	"network": `Usage: pilotctl network <subcommand> [flags]
 
@@ -1064,18 +1066,20 @@ Manage overlay networks.
 
 Subcommands:
   list                  list networks this node belongs to
-  create <name>         create a new network
+  create --name <name>  create a new network
   join <id>             join a network
   leave <id>            leave a network
   members <id>          list members of a network
   invite <id> <node>    invite a node to a network
   invites               list pending invitations
   accept <id>           accept an invitation
+  reject <id>           reject an invitation
   delete <id>           delete a network (owner only)
   rename <id> <name>    rename a network (owner only)
   promote <id> <node>   promote a member to admin
   demote <id> <node>    demote an admin to member
   kick <id> <node>      remove a member from a network
+  role <id> <node>      show a member's role in a network
   policy <id>           show or set network policy
 `,
 
@@ -1105,7 +1109,7 @@ See also: pilotctl pending   — incoming requests waiting for your approval
           pilotctl handshake — initiate trust with a new peer
           pilotctl untrust   — revoke trust with a node
 `,
-	"trusted": `Usage: pilotctl trusted
+	"trusted": `Usage: pilotctl trusted list
 
 List nodes in the embedded trusted-agents directory (service agents that are
 auto-approved on first contact, without requiring manual pilotctl approve).
@@ -1307,7 +1311,7 @@ Flags (one-shot mode):
 Show the latest Pilot Protocol changelog entries from the release feed.
 
 Flags:
-  --count <n>      number of entries to show (default: 5)
+  --count <n>      number of entries to show (default: 10)
   --scope <name>   filter by scope tag (e.g. protocol, cli, networks)
 `,
 	"context": `Usage: pilotctl context [command]
@@ -1322,16 +1326,22 @@ name. With a command name (e.g. 'pilotctl context send-message' or
 `,
 	"skills": `Usage: pilotctl skills [subcommand]
 
-Manage the SKILL.md files the daemon installs for each detected agent tool
-(Claude Code, OpenClaw, PicoClaw). The skill file teaches the agent how to
-use pilotctl without manual setup.
+Manage the SKILL.md files the daemon installs for each detected agent
+toolchain (the supported set is fetched at runtime from the pilot-skills
+repository). The skill file teaches the agent how to use pilotctl without
+manual setup.
 
 Subcommands:
   status [--verbose]   (default) per-tool install state; --verbose adds per-file detail
   paths                print install paths only — one per line, shell-friendly
   check                run one reconcile pass right now (re-installs if missing/outdated)
+  disable all          remove every managed file + persist the opt-out
+                       (only 'all' is accepted; per-skill disable is not yet implemented)
+  enable all           re-enable (auto mode) + run one reconcile pass
+                       (only 'all' is accepted; per-skill enable is not yet implemented)
+  set-mode auto|manual|disabled   persist the reconcile mode to ~/.pilot/config.json
 
-The daemon reconciles skill files every 15 minutes automatically.
+The daemon reconciles skill files every 15 minutes automatically (in auto mode).
 `,
 	"broadcast": `Usage: pilotctl broadcast <network_id> <message> [flags]
 
@@ -1356,8 +1366,9 @@ Publish a message to a topic on a remote node.
 	"send-file": `Usage: pilotctl send-file <address|hostname> <filepath> [--timeout <dur>] [--prefer-direct]
 
 Send a file to a remote node via the data-exchange stream. Files are
-capped at 256 MiB (the data-exchange frame ceiling) unless both daemons
-have raised PILOT_DATAEXCHANGE_MAX_FRAME — see the dataexchange package.
+capped at 1 GiB (the default data-exchange frame ceiling) unless both
+daemons have changed PILOT_DATAEXCHANGE_MAX_FRAME (accepted range
+64 KiB to 2 GiB) — see the dataexchange package.
 
 Flags:
   --timeout <dur>       give up if the receiver does not ACK within this
@@ -1401,11 +1412,12 @@ Reliability caveats (current implementation):
 
 	"quickstart": `Usage: pilotctl quickstart
 
-Guided 3-step getting-started walkthrough. Re-run after each step — it detects
-whether the daemon is already running and points you to the next action:
-  1. start the daemon          pilotctl daemon start
-  2. discover specialists      pilotctl send-message list-agents --data '...' --wait
-  3. handshake + query one     pilotctl handshake <hostname> ; pilotctl send-message ...
+Print a fixed 3-step getting-started cheat-sheet (DISCOVER, TRUST, TALK)
+plus the one-time setup commands (init + daemon start). Static output —
+it does not inspect daemon state:
+  1. DISCOVER — pilotctl send-message list-agents --data '...' --wait
+  2. TRUST    — pilotctl handshake <node_id>
+  3. TALK     — pilotctl send-message <node_id> --data "Hello, world!" --wait
 `,
 
 	"verify": `Usage: pilotctl verify [status] [flags]
@@ -1475,7 +1487,7 @@ Getting started:
   pilotctl quickstart             3-command getting-started flow
 
 Bootstrap:
-  pilotctl init --registry <addr> [--hostname <name>] [--beacon <addr>]
+  pilotctl init [--registry <addr>] [--hostname <name>] [--beacon <addr>] [--socket <path>]
   pilotctl config [--set key=value]
 
 Daemon lifecycle:
@@ -1503,6 +1515,7 @@ Communication commands:
   pilotctl recv <port> [--count <n>] [--timeout <dur>]
   pilotctl send-file <address|hostname> <filepath>
   pilotctl send-message <address|hostname> --data <text> [--type text|json|binary] [--count <n>] [--reuse-conn] [--wait <dur>]
+  pilotctl dgram <address|hostname> <port> --data <msg>
   pilotctl subscribe <address|hostname> <topic> [--count <n>] [--timeout <dur>]
   pilotctl publish <address|hostname> <topic> --data <message>
 
@@ -1513,7 +1526,7 @@ Trust commands:
   pilotctl untrust <node_id>
   pilotctl pending
   pilotctl trust [--search <substr>]                  live trust state (peers you trust)
-  pilotctl trusted                                    embedded directory of auto-approved service agents
+  pilotctl trusted list                               embedded directory of auto-approved service agents
   pilotctl prefer-direct <node_id|address|hostname>   prefer a direct tunnel over the relay (daemon v1.12+)
 
 Identity & recovery:
@@ -1542,6 +1555,8 @@ Agent tool discovery:
   pilotctl skills [status]            show where the daemon installs SKILL.md per detected agent tool
   pilotctl skills paths               print only the install paths (shell-friendly)
   pilotctl skills check               run one reconcile pass right now
+  pilotctl skills enable|disable all  turn skill injection on/off (only 'all' is implemented)
+  pilotctl skills set-mode auto|manual|disabled   persist the reconcile mode
 
 App store (install + call local capability apps; full help: pilotctl appstore help):
   pilotctl appstore catalogue                         list apps available for one-command install
@@ -1557,7 +1572,7 @@ Updates:
 
 Operator / admin (run 'pilotctl extras' or 'pilotctl context' for the full list):
   pilotctl extras <cmd>              network / managed / policy / member-tags / enterprise / low-level plumbing
-  pilotctl extras gateway start|stop|map|unmap|list       IP gateway (requires root for ports <1024)
+  pilotctl extras gateway start|stop|map|unmap|list       IP gateway (requires root — creates loopback interface aliases)
 
 Diagnostic commands:
   pilotctl info
@@ -2132,8 +2147,8 @@ func contextCatalog() map[string]interface{} {
 			},
 			"quickstart": map[string]interface{}{
 				"args":        []string{},
-				"description": "Guided 3-step getting-started walkthrough (start daemon → discover agents → handshake + query). Re-run after each step; detects daemon state",
-				"returns":     "quickstart [{step, title, command, description, done}]",
+				"description": "Print a fixed 3-step getting-started cheat-sheet (discover agents → handshake → send a message) plus one-time setup commands. Static output; does not inspect daemon state",
+				"returns":     "static banner text (no JSON structure)",
 			},
 			"update": map[string]interface{}{
 				"args":        []string{"[status|enable|disable]", "[--pin <tag>]"},
@@ -2257,7 +2272,7 @@ func contextCatalog() map[string]interface{} {
 				"returns":     "node_id",
 			},
 			"trusted": map[string]interface{}{
-				"args":        []string{},
+				"args":        []string{"list"},
 				"description": "List the embedded trusted-agents directory — well-known service agents (list-agents, weather, etc.) auto-approved on first contact. For live trust state use 'trust'",
 				"returns":     "agents [{hostname, node_id}], total",
 			},
@@ -2321,8 +2336,8 @@ func contextCatalog() map[string]interface{} {
 				"returns":     "network_id, status",
 			},
 			"network create": map[string]interface{}{
-				"args":        []string{"<name>", "[--managed]", "[--policy <file>]"},
-				"description": "Create a new network. Use --managed for policy-governed networks",
+				"args":        []string{"--name <name>", "[--join-rule open|token|invite]", "[--token <T>]", "[--enterprise]", "[--rules <json>|--rules-file <path>]"},
+				"description": "Create a new network. Pass --rules/--rules-file for policy-governed (managed) networks",
 				"returns":     "network_id, name, managed (bool)",
 			},
 

--- a/cmd/pilotctl/skills.go
+++ b/cmd/pilotctl/skills.go
@@ -362,7 +362,7 @@ func cmdSkillsDisable(args []string) {
 	} else {
 		fmt.Println()
 		fmt.Println("Opt-out persisted at ~/.pilot/config.json — future ticks are no-ops.")
-		fmt.Println("To re-enable: pilotctl skills enable")
+		fmt.Println("To re-enable: pilotctl skills enable all")
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,7 +16,7 @@ Getting started:
   pilotctl quickstart             3-command getting-started flow
 
 Bootstrap:
-  pilotctl init --registry <addr> [--hostname <name>] [--beacon <addr>]
+  pilotctl init [--registry <addr>] [--hostname <name>] [--beacon <addr>] [--socket <path>]
   pilotctl config [--set key=value]
 
 Daemon lifecycle:
@@ -44,6 +44,7 @@ Communication commands:
   pilotctl recv <port> [--count <n>] [--timeout <dur>]
   pilotctl send-file <address|hostname> <filepath>
   pilotctl send-message <address|hostname> --data <text> [--type text|json|binary] [--count <n>] [--reuse-conn] [--wait <dur>]
+  pilotctl dgram <address|hostname> <port> --data <msg>
   pilotctl subscribe <address|hostname> <topic> [--count <n>] [--timeout <dur>]
   pilotctl publish <address|hostname> <topic> --data <message>
 
@@ -54,7 +55,7 @@ Trust commands:
   pilotctl untrust <node_id>
   pilotctl pending
   pilotctl trust [--search <substr>]                  live trust state (peers you trust)
-  pilotctl trusted                                    embedded directory of auto-approved service agents
+  pilotctl trusted list                               embedded directory of auto-approved service agents
   pilotctl prefer-direct <node_id|address|hostname>   prefer a direct tunnel over the relay (daemon v1.12+)
 
 Identity & recovery:
@@ -83,6 +84,8 @@ Agent tool discovery:
   pilotctl skills [status]            show where the daemon installs SKILL.md per detected agent tool
   pilotctl skills paths               print only the install paths (shell-friendly)
   pilotctl skills check               run one reconcile pass right now
+  pilotctl skills enable|disable all  turn skill injection on/off (only 'all' is implemented)
+  pilotctl skills set-mode auto|manual|disabled   persist the reconcile mode
 
 App store (install + call local capability apps; full help: pilotctl appstore help):
   pilotctl appstore catalogue                         list apps available for one-command install
@@ -98,7 +101,7 @@ Updates:
 
 Operator / admin (run 'pilotctl extras' or 'pilotctl context' for the full list):
   pilotctl extras <cmd>              network / managed / policy / member-tags / enterprise / low-level plumbing
-  pilotctl extras gateway start|stop|map|unmap|list       IP gateway (requires root for ports <1024)
+  pilotctl extras gateway start|stop|map|unmap|list       IP gateway (requires root — creates loopback interface aliases)
 
 Diagnostic commands:
   pilotctl info


### PR DESCRIPTION
The binary's embedded help text has drifted from the implementation in a number of places (the website docs already state the correct behavior — it is the CLI's own `--help` that is stale). This PR fixes the strings only; there is **zero behavior change**. Every item below was verified against the current code on `main` before editing, and each changed string was grepped across the repo (including tests) to confirm nothing depends on it.

1. **`pilotctl quickstart --help`** claimed "it detects whether the daemon is already running and points you to the next action" → `cmdQuickstart` (`cmd/pilotctl/main.go:1983`) is a bare `fmt.Print` of a static banner. New text: prints a fixed 3-step cheat-sheet (DISCOVER, TRUST, TALK) and does not inspect daemon state. The `pilotctl context` catalog entry for `quickstart` repeated the same claim (plus a structured-`returns` shape the command never emits) and was corrected too.
2. **`pilotctl updates --help`**: "`--count <n>` … (default: 5)" → `cmd/pilotctl/updates.go:133` is `flagInt(flags, "count", 10)` (the doc comment above it already says 10). Help now says 10.
3. **`pilotctl init --help`**: showed "`--registry <addr>` registry address (required)" → every flag in `cmdInit` (`cmd/pilotctl/main.go:2010`) is optional with a default (`registry` defaults to `34.71.57.205:9000`), and the accepted `--socket` flag was undocumented. Help now marks flags optional with their defaults and documents `--socket`.
4. **`pilotctl network --help`**: subcommand list omitted `reject` and `role`, both present in the dispatch (`cmd/pilotctl/main.go:1835,1850`). Added.
5. **`network create`**: help showed positional `create <name>` → the command requires `--name` (`cmd/pilotctl/main.go:7044`: `usage: pilotctl network create --name <name> …`). Help aligned. The `pilotctl context` catalog entry additionally advertised nonexistent `--managed` / `--policy <file>` flags — replaced with the real flag set (`--name`, `--join-rule`, `--token`, `--enterprise`, `--rules`/`--rules-file`).
6. **`pilotctl skills --help`**: listed only `status|paths|check` → the dispatch (`cmd/pilotctl/skills.go:37-54`) also handles `set-mode|disable|enable`. `disable`/`enable` require an argument and accept only `all` (`skills.go` explicitly rejects anything else: "only 'all' is supported; per-skill disable is not yet implemented") — now documented. The hardcoded toolchain list "(Claude Code, OpenClaw, PicoClaw)" was replaced with generic wording: the skillinject manifest is fetched at runtime from the pilot-skills repository, so the supported set is not fixed at compile time. Also fixed the `skills disable` success hint, which told users to run `pilotctl skills enable` — a form that errors out (`skill id required`).
7. **`pilotctl trusted --help` / top-level help** showed bare `trusted` → `cmd/pilotctl/trusted.go:12` rejects everything except `trusted list`. Usage fixed to `pilotctl trusted list` (help text, top-level listing, and the context-catalog `args`).
8. **`send-file` help** claimed a "256 MiB" frame cap → `dataexchange.DefaultMaxFrameSize` is `1 << 30` (1 GiB), overridable via `PILOT_DATAEXCHANGE_MAX_FRAME` within [64 KiB, 2 GiB). Help now says 1 GiB and mentions the accepted range.
9. **`bench --help`** claimed timeout "default: 30s" → `cmdBench` (`cmd/pilotctl/main.go`) uses `flagDuration(flags, "timeout", 120*time.Second)`. Help now says 120s. (`traceroute`'s 30s claim was checked and is correct — untouched.)
10. **Gateway help**: "requires root for ports <1024" → pilot-gateway shells out to `ifconfig lo0 alias` (darwin) / `ip addr add` (linux) to create loopback interface aliases (`loopback_darwin.go` / `loopback_linux.go` in pilot-protocol/gateway), which needs root regardless of port. New text: "requires root — creates loopback interface aliases". **Daemon `-dataexchange-b64` flag help** said the base64 field is added "alongside `data`" → the dataexchange service's `if/else` (`service.go:351`) writes `data_b64` **in place of** `data`. Fixed.
11. **Top-level `pilotctl --help`** omitted `dgram`, which exists in the dispatch (`cmd/pilotctl/main.go:1782`) and has its own per-command help. Added to the Communication commands listing.

`docs/cli-reference.md` is regenerated via `scripts/gen-cli-reference.sh` (it is an auto-generated capture of `pilotctl --help` that CI checks for drift); its diff is exactly the top-level-help changes above.

**Verification level:** built locally with Go 1.26.3 — `gofmt -l` clean on touched files, `go build ./cmd/...` succeeds, `go test ./cmd/pilotctl` passes (12.9s, ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142ryqVGEmJN66VZtCC7wFD
