### PR TITLE
chore: bump trustedagents v0.2.5 (fix malformed trusted-agents list)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pilot-protocol/rendezvous v0.2.5
 	github.com/pilot-protocol/runtime v0.3.1
 	github.com/pilot-protocol/skillinject v0.2.4-0.20260717204101-902f745138da
-	github.com/pilot-protocol/trustedagents v0.2.4
+	github.com/pilot-protocol/trustedagents v0.2.5
 	github.com/pilot-protocol/updater v0.2.3
 	github.com/pilot-protocol/webhook v0.2.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/pilot-protocol/runtime v0.3.1 h1:+W9ww0dZY/FgOBtCmIOV3w5L5Z4Upt/RIsrY
 github.com/pilot-protocol/runtime v0.3.1/go.mod h1:GfFEIji0w7H9SSNR9Wl2q72pd2OYN3PHY9Qhcbvyrqk=
 github.com/pilot-protocol/skillinject v0.2.4-0.20260717204101-902f745138da h1:supBO6UzykRn5Ta5pCLXjTvAPqTKOgfr2ZpZQugBNuI=
 github.com/pilot-protocol/skillinject v0.2.4-0.20260717204101-902f745138da/go.mod h1:+jEW+uCFkA6TnmZc41Ev5oczXCbOHD0NqVWG8RzjwXQ=
-github.com/pilot-protocol/trustedagents v0.2.4 h1:NqYjU3eoxBzyzzlhTQY2vV4q0l5+4eaADAhrOD1OkQU=
-github.com/pilot-protocol/trustedagents v0.2.4/go.mod h1:Y3Eq/IOZqAUIbtzVBcxW4epkciaFAFAYkEyu/E7DXe4=
+github.com/pilot-protocol/trustedagents v0.2.5 h1:zdeezxalidXanOkEcdsageyAp6jVbfhAnPumREbEZt0=
+github.com/pilot-protocol/trustedagents v0.2.5/go.mod h1:6P0pBKmjKlfiSsCbl7EAIr96LW/9RnoLzdl+rEqmN5E=
 github.com/pilot-protocol/updater v0.2.3 h1:9+Y2XvyEnfxjbguho8AIKLdEK+Gzj2I7lkad2qIu6JY=
 github.com/pilot-protocol/updater v0.2.3/go.mod h1:wn+HkjgChZ1QCCkOHBolAol42mxyyW/iz7oOFJLciT4=
 github.com/pilot-protocol/webhook v0.2.0 h1:3UFU9X2yBb0iKlPbzVcism+Z6yCrBBaOgdo9+vd4Wf4=


### PR DESCRIPTION
Bumps `trustedagents v0.2.4 → v0.2.5`, which removes the duplicate `node_id 243113` (stale `pilot-director`) that made the embedded list malformed (ERROR on every `pilotctl` run, blocked the daemon release gate). `pilotctl` test now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)