### PR TITLE
Remove app_usage telemetry entirely (re-land of #366)

### DIFF
--- a/cmd/daemon/appstore_adapter.go
+++ b/cmd/daemon/appstore_adapter.go
@@ -15,67 +15,28 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"time"
 
 	"github.com/pilot-protocol/app-store/plugin/appstore"
 	"github.com/pilot-protocol/common/coreapi"
-	"github.com/pilot-protocol/pilotprotocol/pkg/telemetry"
 )
 
 type appstoreAdapter struct {
-	svc          *appstore.Service
-	telemetryURL string
-	identityPath string
-	getNodeID    func() int64 // called at emit time, after daemon has registered
-}
-
-// telemetryEmitter wraps the consent-gated telemetry client to satisfy
-// the appstore.TelemetryEmitter interface. Events are sent as
-// "app_usage" kind with the supervisor-provided fields as payload.
-// Best-effort: send errors are logged but never block the caller.
-type telemetryEmitter struct {
-	client    *telemetry.Client
-	getNodeID func() int64 // called lazily; valid after daemon has registered
-}
-
-func (e *telemetryEmitter) Emit(ev appstore.TelemetryEvent) {
-	if e == nil || e.client == nil {
-		return
-	}
-	payload, err := json.Marshal(ev)
-	if err != nil {
-		return
-	}
-	var nodeID int64
-	if e.getNodeID != nil {
-		nodeID = e.getNodeID()
-	}
-	_ = e.client.Send(telemetry.Event{
-		Kind:    "app_usage",
-		TS:      time.Now().UTC().Format(time.RFC3339),
-		NodeID:  nodeID,
-		Payload: payload,
-	})
+	svc *appstore.Service
 }
 
 func (a *appstoreAdapter) Name() string { return a.svc.Name() }
 func (a *appstoreAdapter) Order() int   { return a.svc.Order() }
 func (a *appstoreAdapter) Start(ctx context.Context, deps coreapi.Deps) error {
-	// Build a consent-gated telemetry client for app-usage events.
-	// When the URL is empty or identity is absent the client is a
-	// permanent no-op — the emitter never sends anything.
-	client := telemetry.NewClientFromIdentity(a.telemetryURL, a.identityPath, 0)
-	emitter := &telemetryEmitter{client: client, getNodeID: a.getNodeID}
-
+	// No Telemetry emitter: app_usage events were removed entirely
+	// (2026-07-10) — what an agent calls is nobody's business. A nil
+	// emitter is documented no-op in the appstore module.
 	return a.svc.Start(ctx, appstore.Deps{
-		Streams:   deps.Streams,
-		Identity:  deps.Identity,
-		Resolver:  deps.Resolver,
-		Events:    deps.Events,
-		Logger:    deps.Logger,
-		Trust:     deps.Trust,
-		Telemetry: emitter,
+		Streams:  deps.Streams,
+		Identity: deps.Identity,
+		Resolver: deps.Resolver,
+		Events:   deps.Events,
+		Logger:   deps.Logger,
+		Trust:    deps.Trust,
 	})
 }
 func (a *appstoreAdapter) Stop(ctx context.Context) error { return a.svc.Stop(ctx) }

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -410,9 +410,6 @@ func main() {
 			// against this before spawning. nil/unpinned => fail closed.
 			CataloguePublisher: cataloguePins.Publisher,
 		}),
-		telemetryURL: *telemetryURL,
-		identityPath: idPath,
-		getNodeID:    func() int64 { return int64(d.NodeID()) },
 	}); err != nil {
 		log.Fatalf("register appstore: %v", err)
 	}

--- a/cmd/pilotctl/appstore.go
+++ b/cmd/pilotctl/appstore.go
@@ -2239,17 +2239,6 @@ func cmdAppStoreCall(args []string) {
 		fatalHint("ipc_error", hint, "%v", err)
 	}
 
-	// Emit app_usage telemetry for a successful call (consent-gated, best-effort).
-	if h, _ := os.UserHomeDir(); consent.GetConsent(h, "telemetry") {
-		turl := os.Getenv("PILOT_TELEMETRY_URL")
-		if turl == "" {
-			turl = telemetry.DefaultEndpoint
-		}
-		payload, _ := json.Marshal(map[string]string{"app_id": appID, "method": method})
-		client := telemetry.NewClientFromIdentity(turl, configDir()+"/identity.json", nodeIDFromDaemon())
-		_ = client.Send(telemetry.Event{Kind: "app_usage", Payload: json.RawMessage(payload)})
-	}
-
 	// A SUCCESSFUL call is where an app is won or lost: the agent has a result
 	// and no idea the flow continues. Resolve the graph now and print it via
 	// defer so it lands after the result on every return path below — and,


### PR DESCRIPTION
Re-lands the app_usage telemetry removal from #366 (its branch was deleted on close). Removes the consent-gated `app_usage` telemetry emitter from the app-store call path (daemon adapter + pilotctl), preserving main's newer `renderNextSteps` logic. Builds + vets clean.

Closes the intent of #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)