### PR TITLE
fix(daemon): wire webhook HMAC signing secret flag (PILOT-90)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -94,6 +94,7 @@ func main() {
 	noEventStream := flag.Bool("no-eventstream", false, "disable built-in event stream service (port 1002)")
 	noSkillinject := flag.Bool("no-skillinject", false, "disable built-in skill-injection service (agent context injection). Env: PILOT_NO_SKILLINJECT=1.")
 	webhookURL := flag.String("webhook", "", "HTTP(S) endpoint for event notifications (empty = disabled)")
+	webhookSecret := flag.String("webhook-secret", "", "HMAC-SHA256 pre-shared secret for webhook payload signing (empty = no signature). Env: PILOT_WEBHOOK_SECRET.")
 	adminToken := flag.String("admin-token", "", "admin token for network operations")
 	networks := flag.String("networks", "", "comma-separated network IDs to auto-join at startup")
 	trustAutoApprove := flag.Bool("trust-auto-approve", false, "automatically approve all incoming trust handshakes")
@@ -348,7 +349,16 @@ func main() {
 	// bus, the plugin subscribes and POSTs to the configured URL. URL
 	// hot-swap (IPC's `set-webhook`) routes through SetURL on the
 	// plugin via the daemon's WebhookManager interface.
-	webhookSvc := webhook.NewService(*webhookURL)
+	// Resolve webhook secret: explicit flag overrides env var
+	webhookSecretVal := *webhookSecret
+	if webhookSecretVal == "" {
+		webhookSecretVal = os.Getenv("PILOT_WEBHOOK_SECRET")
+	}
+	var webhookOpts []webhook.Option
+	if webhookSecretVal != "" {
+		webhookOpts = append(webhookOpts, webhook.WithSecret(webhookSecretVal))
+	}
+	webhookSvc := webhook.NewService(*webhookURL, webhookOpts...)
 	if err := rt.Register(webhookSvc); err != nil {
 		log.Fatalf("register webhook: %v", err)
 	}


### PR DESCRIPTION
## What

The `pilot-protocol/webhook` library (v0.2.0+) already supports HMAC-SHA256 signing of outbound webhook event payloads via `webhook.WithSecret`, but the daemon never exposed or passed a secret — the `-webhook` flag only sets the URL and the signing option was unreachable.

## What this adds

- New `-webhook-secret` CLI flag
- `PILOT_WEBHOOK_SECRET` env var fallback
- Both are wired to `webhook.WithSecret(...)` in the service constructor

## How it works

When a secret is configured, every webhook POST includes an `X-Pilot-Signature-256` header containing the hex-encoded HMAC-SHA256 of the request body. Receivers can verify authenticity and integrity. When no secret is set (default), behavior is identical to before — no signature header, fully backward-compatible.

## Verification

- `go build ./cmd/daemon/` — passes
- `go vet ./cmd/daemon/` — clean
- `github.com/pilot-protocol/webhook` test suite — 5.030s, all green (includes TestWebhookClientHMACSignatureHeader)

## Files changed

1 file, +11/-1 lines (cmd/daemon/main.go)

Closes [PILOT-90](https://vulturelabs.atlassian.net/browse/PILOT-90)