### PR TITLE
fix(webhook): wire HMAC signing secret through daemon CLI flags (PILOT-90)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -94,6 +94,7 @@ func main() {
 	noEventStream := flag.Bool("no-eventstream", false, "disable built-in event stream service (port 1002)")
 	noSkillinject := flag.Bool("no-skillinject", false, "disable built-in skill-injection service (agent context injection). Env: PILOT_NO_SKILLINJECT=1.")
 	webhookURL := flag.String("webhook", "", "HTTP(S) endpoint for event notifications (empty = disabled)")
+	webhookSecret := flag.String("webhook-secret", "", "HMAC-SHA256 pre-shared secret for webhook payload signing (empty = no signature). Env: PILOT_WEBHOOK_SECRET.")
 	adminToken := flag.String("admin-token", "", "admin token for network operations")
 	networks := flag.String("networks", "", "comma-separated network IDs to auto-join at startup")
 	trustAutoApprove := flag.Bool("trust-auto-approve", false, "automatically approve all incoming trust handshakes")
@@ -348,7 +349,7 @@ func main() {
 	// bus, the plugin subscribes and POSTs to the configured URL. URL
 	// hot-swap (IPC's `set-webhook`) routes through SetURL on the
 	// plugin via the daemon's WebhookManager interface.
-	webhookSvc := webhook.NewService(*webhookURL)
+	webhookSvc := webhook.NewService(*webhookURL, webhook.WithSecret(*webhookSecret))
 	if err := rt.Register(webhookSvc); err != nil {
 		log.Fatalf("register webhook: %v", err)
 	}


### PR DESCRIPTION
## Fix: Wire webhook HMAC signing secret through daemon CLI flags

The webhook library already supports `WithSecret` and `X-Pilot-Signature-256` header output — this was implemented and merged in pilot-protocol/webhook#3. However, the daemon's `main.go` never added the `--webhook-secret` flag or threaded it through to `webhook.WithSecret()`, so the signing capability was inaccessible from the running daemon.

### What changed
1. Added `--webhook-secret` flag (env fallback: `PILOT_WEBHOOK_SECRET`) to `cmd/daemon/main.go`
2. Wired it via `webhook.WithSecret(*webhookSecret)` in the `NewService` call

### Verification
- `go build ./cmd/daemon/...` ✅
- `go vet ./cmd/daemon/...` ✅
- Empty secret = no signature header (backward compatible, existing behavior)

Closes [PILOT-90](https://vulturelabs.atlassian.net/browse/PILOT-90)