### PR TITLE
fix(managed): ship cross-process receipt export runtime

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - pilot-nightly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4.37.4
         with:
-          languages: ${{ matrix.language }}
+          languages: go
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@v4.37.4
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4.37.4

--- a/.github/workflows/notify-canary.yml
+++ b/.github/workflows/notify-canary.yml
@@ -61,8 +61,8 @@ jobs:
           set -euo pipefail
           echo "Dispatching: component=$COMPONENT  ref=$REF"
           gh api -X POST /repos/pilot-protocol/pilot-canary/dispatches \
-            -f event_type=component-changed \
-            -f client_payload[component]="$COMPONENT" \
-            -f client_payload[ref]="$REF" \
-            -f client_payload[source_repo]="${{ github.repository }}" \
-            -f client_payload[source_sha]="${{ github.sha }}"
+            -f "event_type=component-changed" \
+            -f "client_payload[component]=$COMPONENT" \
+            -f "client_payload[ref]=$REF" \
+            -f "client_payload[source_repo]=${{ github.repository }}" \
+            -f "client_payload[source_sha]=${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags: ['v*', 'managed-runtime-v*']
 
 permissions:
   contents: write
@@ -82,13 +82,13 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
         run: |
-          VERSION=${GITHUB_REF_NAME}
+          VERSION="${GITHUB_REF_NAME}"
           LDFLAGS="-s -w -X main.version=${VERSION}"
           BINS="daemon pilotctl updater"
           mkdir -p dist
           for bin in $BINS; do
             echo "Building $bin for ${{ matrix.goos }}/${{ matrix.goarch }}..."
-            go build -ldflags "$LDFLAGS" -o dist/$bin ./cmd/$bin
+            go build -ldflags "$LDFLAGS" -o "dist/$bin" "./cmd/$bin"
           done
 
       # Ad-hoc codesign + drop quarantine on darwin builds so downloaded
@@ -114,11 +114,15 @@ jobs:
         run: |
           echo "=== Binary smoke tests ==="
           for bin in dist/*; do
-            name=$(basename $bin)
+            name=$(basename "$bin")
             # Verify it's a valid executable
-            file $bin
+            file "$bin"
             # Version flag check (all binaries should accept -h without crashing)
-            timeout 5 $bin -h 2>&1 || true
+            if command -v timeout >/dev/null 2>&1; then
+              timeout 5 "$bin" -h 2>&1 || true
+            else
+              "$bin" -h 2>&1 || true
+            fi
             echo "  ✓ $name"
           done
 
@@ -135,8 +139,8 @@ jobs:
       - name: Package archive
         run: |
           ARCHIVE="pilot-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
-          tar -czf $ARCHIVE -C dist .
-          echo "ARCHIVE=$ARCHIVE" >> $GITHUB_ENV
+          tar -czf "$ARCHIVE" -C dist .
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -165,7 +169,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd release
-          sha256sum *.tar.gz > checksums.txt
+          sha256sum -- *.tar.gz > checksums.txt
           cat checksums.txt
 
       # PILOT-120: SLSA build provenance attestation via Sigstore.
@@ -189,6 +193,10 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') }}
+          # Managed runtimes are authority-pinned artifacts, not the generic
+          # Pilot update channel. Publishing one must not replace vX.Y.Z as
+          # GitHub's /releases/latest target for ordinary installers.
+          make_latest: ${{ startsWith(github.ref_name, 'managed-runtime-') && 'false' || 'true' }}
 
   # ---------------------------------------------------------------------------
   # Downstream fan-out is NO LONGER driven from here.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coder/websocket v1.8.15
 	github.com/pilot-protocol/app-store v1.0.2
 	github.com/pilot-protocol/beacon v0.2.9
-	github.com/pilot-protocol/common v0.5.12
+	github.com/pilot-protocol/common v0.5.13
 	github.com/pilot-protocol/dataexchange v0.2.2
 	github.com/pilot-protocol/eventstream v0.2.4
 	github.com/pilot-protocol/handshake v0.2.8

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/pilot-protocol/app-store v1.0.2 h1:oK7cNl3e/gfxVhhkUFKNLRN256+7sDSBw8
 github.com/pilot-protocol/app-store v1.0.2/go.mod h1:deltPnaQkiTgMcxWU+honz3+Bl2R1cthhuZra4pQ4PI=
 github.com/pilot-protocol/beacon v0.2.9 h1:VqXAtRKl4YhZVkDmJzuNhS1bfpK0n9qbGKOGLfVYSyo=
 github.com/pilot-protocol/beacon v0.2.9/go.mod h1:DE8masXGku/IwfHL8lN/4CUTe5YsxMXFe2fRGJcH7w8=
-github.com/pilot-protocol/common v0.5.12 h1:ZQ7v8oX0VYtEcluraQZvqrYPMvRIxjixSZtNz8Xo5Uc=
-github.com/pilot-protocol/common v0.5.12/go.mod h1:Ybc6f1A37s3ShoEh1nBMVL9DPyYlxvkqPTvtbxaNWg4=
+github.com/pilot-protocol/common v0.5.13 h1:h9NmPh37ZZujktpSAwgq2H2ai7jG240nQTetGNWtZ3U=
+github.com/pilot-protocol/common v0.5.13/go.mod h1:Ybc6f1A37s3ShoEh1nBMVL9DPyYlxvkqPTvtbxaNWg4=
 github.com/pilot-protocol/dataexchange v0.2.2 h1:h1VJFqFCdMDtX1E2E8zxTQPw+9rWnMohXN8b6HpB2R0=
 github.com/pilot-protocol/dataexchange v0.2.2/go.mod h1:TUj2QtNMZ4oMnOag1j5k5qDxz2457S8uaB2FJif1Ulk=
 github.com/pilot-protocol/eventstream v0.2.4 h1:SyB64wqo+Qpz0hIAuzHGkI9Npwk5SFSg1aqNFLueUIQ=


### PR DESCRIPTION
## What changed
- consume `github.com/pilot-protocol/common@v0.5.13`, which makes the daemon discover receipts appended by separate hook processes
- allow the attested release workflow to publish `managed-runtime-v*` authority-pinned builds
- keep managed builds from replacing the ordinary `vX.Y.Z` GitHub latest release
- repair the undefined CodeQL matrix input and pin CodeQL v4.37.4
- quote nested canary-dispatch form keys and make every workflow pass actionlint

## Production failure
The Gemini hook correctly blocked the prohibited shell action and wrote a signed local receipt. The hosted traffic exchange captured the decision and terminal result, but the Evidence link returned no matching object because the daemon exporter had opened the journal before the hook process appended to it.

## Validation
- `go test -count=1 ./...` (including the 286s full tests package)
- `go test -race -count=3 ./cmd/daemon ./cmd/pilotctl ./internal/enterprisecontrol`
- `go vet ./...`
- `govulncheck ./...` (0 reachable/package vulnerabilities)
- `go mod verify`
- `actionlint` (all workflows)