### PR TITLE
Authenticate confidential managed-node reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pilot-protocol/rendezvous v0.2.8
 	github.com/pilot-protocol/runtime v0.3.2
 	github.com/pilot-protocol/skillinject v0.2.4-0.20260717204101-902f745138da
-	github.com/pilot-protocol/trustedagents v0.2.5
+	github.com/pilot-protocol/trustedagents v0.2.6
 	github.com/pilot-protocol/updater v0.2.4
 	github.com/pilot-protocol/webhook v0.2.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/pilot-protocol/runtime v0.3.2 h1:21lgUfYNvpls0Vd3V2v9lfs13G7mT8pcT3D2
 github.com/pilot-protocol/runtime v0.3.2/go.mod h1:CXEmjKF/HozhIxn9QZxO13Lxdnkok3XKEkYS/jFjQKs=
 github.com/pilot-protocol/skillinject v0.2.4-0.20260717204101-902f745138da h1:supBO6UzykRn5Ta5pCLXjTvAPqTKOgfr2ZpZQugBNuI=
 github.com/pilot-protocol/skillinject v0.2.4-0.20260717204101-902f745138da/go.mod h1:+jEW+uCFkA6TnmZc41Ev5oczXCbOHD0NqVWG8RzjwXQ=
-github.com/pilot-protocol/trustedagents v0.2.5 h1:zdeezxalidXanOkEcdsageyAp6jVbfhAnPumREbEZt0=
-github.com/pilot-protocol/trustedagents v0.2.5/go.mod h1:6P0pBKmjKlfiSsCbl7EAIr96LW/9RnoLzdl+rEqmN5E=
+github.com/pilot-protocol/trustedagents v0.2.6 h1:dFKr6V+lJr947v3iUyR7EflUTusGfKkItAmsqJfWc8g=
+github.com/pilot-protocol/trustedagents v0.2.6/go.mod h1:JAk89O4bg9NeXLnMJh4gUsCQ1R5BIHTQHjrGwNXaqZM=
 github.com/pilot-protocol/updater v0.2.4 h1:TOnmjv7KzzotSK1n4Nf+KB0VXagql+zqUVAURp3qBDo=
 github.com/pilot-protocol/updater v0.2.4/go.mod h1:yA3Qso83bSLNDe5Yg7L/mj/c2dTBzb2VNQc5i8iJNnA=
 github.com/pilot-protocol/webhook v0.2.0 h1:3UFU9X2yBb0iKlPbzVcism+Z6yCrBBaOgdo9+vd4Wf4=

--- a/internal/enterprisecontrol/control.go
+++ b/internal/enterprisecontrol/control.go
@@ -558,6 +558,13 @@ func Load(path string) (*Runtime, error) {
 		if keyErr != nil || !bytes.Equal(publicKey, privateKey.Public().(ed25519.PublicKey)) {
 			return nil, fmt.Errorf("enterprise control: outbound decision seed does not match active agent intent key")
 		}
+		requestSigner, signerErr := authorityhttp.NewAgentRequestSigner(config.OutboundDecisions.AgentID, config.OutboundDecisions.IntentKeyID, privateKey)
+		if signerErr != nil {
+			return nil, fmt.Errorf("enterprise control: configure workflow request signer: %w", signerErr)
+		}
+		if signerErr = client.ConfigureWorkflowAgentRequestSigning(config.TenantID, config.OutboundDecisions.AgentID, requestSigner.Sign); signerErr != nil {
+			return nil, fmt.Errorf("enterprise control: configure authenticated workflow reads: %w", signerErr)
+		}
 		runtime.outboundClient = client
 		runtime.outboundAgentID = config.OutboundDecisions.AgentID
 		runtime.outboundKeyID = config.OutboundDecisions.IntentKeyID
@@ -660,6 +667,9 @@ func Load(path string) (*Runtime, error) {
 		publicKey, keyErr := runtime.trust.IntentKey(context.Background(), config.TenantID, config.Rollout.AgentID, config.Rollout.AcknowledgementKeyID)
 		if keyErr != nil || !bytes.Equal(publicKey, privateKey.Public().(ed25519.PublicKey)) {
 			return nil, fmt.Errorf("enterprise control: rollout acknowledgement seed does not match active agent intent key")
+		}
+		if signErr := client.ConfigureAgentRequestSigning(config.Rollout.AgentID, config.Rollout.AcknowledgementKeyID, privateKey); signErr != nil {
+			return nil, fmt.Errorf("enterprise control: configure authenticated node-plane reads: %w", signErr)
 		}
 		runtime.rolloutClient = client
 		runtime.rolloutAgentID = config.Rollout.AgentID

--- a/internal/managedsdk/authorityhttp/agent_request_sign.go
+++ b/internal/managedsdk/authorityhttp/agent_request_sign.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package authorityhttp
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	agentRequestDomain          = "pilot-agent-request-v1"
+	agentRequestAgentIDHeader   = "X-Pilot-Agent-Id"
+	agentRequestKeyIDHeader     = "X-Pilot-Agent-Key-Id"
+	agentRequestTimestampHeader = "X-Pilot-Agent-Timestamp"
+	agentRequestNonceHeader     = "X-Pilot-Agent-Nonce"
+	agentRequestSignatureHeader = "X-Pilot-Agent-Signature"
+)
+
+var emptyAgentRequestBodyHash = sha256.Sum256(nil)
+
+// AgentRequestSigner proves which enrolled node is fetching account-specific
+// policy or control-plane state. It is intentionally limited to bodyless GETs:
+// node reports already carry their own signed, validated artifacts.
+type AgentRequestSigner struct {
+	agentID    string
+	keyID      string
+	privateKey ed25519.PrivateKey
+	now        func() time.Time
+	random     io.Reader
+}
+
+// NewAgentRequestSigner binds one active agent intent key to node-plane reads.
+func NewAgentRequestSigner(agentID, keyID string, privateKey ed25519.PrivateKey) (*AgentRequestSigner, error) {
+	if !clientIdentifier(agentID) || !clientIdentifier(keyID) || len(privateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("authorityhttp: invalid agent request signing credentials")
+	}
+	return &AgentRequestSigner{
+		agentID: agentID, keyID: keyID,
+		privateKey: append(ed25519.PrivateKey(nil), privateKey...),
+		now:        time.Now,
+		random:     rand.Reader,
+	}, nil
+}
+
+// ConfigureAgentRequestSigning enables authenticated policy, mandate, and
+// fleet reads. Configure the client before concurrent use.
+func (client *Client) ConfigureAgentRequestSigning(agentID, keyID string, privateKey ed25519.PrivateKey) error {
+	if client == nil {
+		return fmt.Errorf("authorityhttp: client is not initialized")
+	}
+	signer, err := NewAgentRequestSigner(agentID, keyID, privateKey)
+	if err != nil {
+		return err
+	}
+	client.agentRequestSigner = signer
+	return nil
+}
+
+// SignAgentRequest signs a bodyless GET for integrations that do not use
+// Client. tenantID and agentID must exactly match the request query.
+func SignAgentRequest(request *http.Request, tenantID, agentID, keyID string, privateKey ed25519.PrivateKey) error {
+	signer, err := NewAgentRequestSigner(agentID, keyID, privateKey)
+	if err != nil {
+		return err
+	}
+	return signer.Sign(request, tenantID, agentID)
+}
+
+func (client *Client) signAgentRequest(request *http.Request, tenantID, agentID string) error {
+	// Optional signing preserves compatibility with older/self-hosted
+	// authorities. Hosted node-plane endpoints require the signature.
+	if client == nil || client.agentRequestSigner == nil {
+		return nil
+	}
+	return client.agentRequestSigner.Sign(request, tenantID, agentID)
+}
+
+// Sign binds the method, normalized path and query, tenant, node identity,
+// delegated key, short-lived timestamp, nonce, and empty-body digest.
+func (signer *AgentRequestSigner) Sign(request *http.Request, tenantID, agentID string) error {
+	if signer == nil || request == nil || request.URL == nil || signer.now == nil || signer.random == nil || len(signer.privateKey) != ed25519.PrivateKeySize {
+		return fmt.Errorf("authorityhttp: agent request signer is not initialized")
+	}
+	if request.Method != http.MethodGet || (request.Body != nil && request.Body != http.NoBody) {
+		return fmt.Errorf("authorityhttp: agent request signing requires a bodyless GET")
+	}
+	if !clientIdentifier(tenantID) || agentID != signer.agentID || !clientIdentifier(agentID) {
+		return fmt.Errorf("authorityhttp: agent request identity mismatch")
+	}
+	query, err := strictAgentRequestQuery(request.URL, tenantID, agentID)
+	if err != nil {
+		return err
+	}
+	nonceBytes := make([]byte, 16)
+	if _, err := io.ReadFull(signer.random, nonceBytes); err != nil {
+		return fmt.Errorf("authorityhttp: generate agent request nonce: %w", err)
+	}
+	timestamp := strconv.FormatInt(signer.now().UTC().Unix(), 10)
+	nonce := hex.EncodeToString(nonceBytes)
+	canonical, err := canonicalAgentRequest(request.Method, request.URL, query, tenantID, agentID, signer.keyID, timestamp, nonce)
+	if err != nil {
+		return err
+	}
+	signature := ed25519.Sign(signer.privateKey, canonical)
+	request.Header.Set(agentRequestAgentIDHeader, agentID)
+	request.Header.Set(agentRequestKeyIDHeader, signer.keyID)
+	request.Header.Set(agentRequestTimestampHeader, timestamp)
+	request.Header.Set(agentRequestNonceHeader, nonce)
+	request.Header.Set(agentRequestSignatureHeader, base64.RawURLEncoding.EncodeToString(signature))
+	return nil
+}
+
+func strictAgentRequestQuery(target *url.URL, tenantID, agentID string) (string, error) {
+	if target == nil {
+		return "", fmt.Errorf("authorityhttp: agent request URL is required")
+	}
+	values, err := url.ParseQuery(target.RawQuery)
+	if err != nil || len(values["tenant_id"]) != 1 || len(values["agent_id"]) != 1 || values.Get("tenant_id") != tenantID || values.Get("agent_id") != agentID {
+		return "", fmt.Errorf("authorityhttp: agent request query identity mismatch")
+	}
+	return values.Encode(), nil
+}
+
+func canonicalAgentRequest(method string, target *url.URL, query, tenantID, agentID, keyID, timestamp, nonce string) ([]byte, error) {
+	path := ""
+	if target != nil {
+		path = target.EscapedPath()
+	}
+	if method != http.MethodGet || path == "" || !strings.HasPrefix(path, "/") || !clientIdentifier(tenantID) || !clientIdentifier(agentID) || !clientIdentifier(keyID) || timestamp == "" || len(nonce) != 32 {
+		return nil, fmt.Errorf("authorityhttp: invalid canonical agent request")
+	}
+	fields := []string{
+		agentRequestDomain,
+		method,
+		path,
+		query,
+		hex.EncodeToString(emptyAgentRequestBodyHash[:]),
+		tenantID,
+		agentID,
+		keyID,
+		timestamp,
+		nonce,
+	}
+	return []byte(strings.Join(fields, "\n")), nil
+}

--- a/internal/managedsdk/authorityhttp/agent_request_sign_test.go
+++ b/internal/managedsdk/authorityhttp/agent_request_sign_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package authorityhttp
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientSignsEveryConfidentialAgentRead(t *testing.T) {
+	t.Parallel()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		agentID := request.Header.Get(agentRequestAgentIDHeader)
+		keyID := request.Header.Get(agentRequestKeyIDHeader)
+		timestamp := request.Header.Get(agentRequestTimestampHeader)
+		nonce := request.Header.Get(agentRequestNonceHeader)
+		query, queryErr := strictAgentRequestQuery(request.URL, "tenant-a", "agent-a")
+		canonical, canonicalErr := canonicalAgentRequest(request.Method, request.URL, query, "tenant-a", agentID, keyID, timestamp, nonce)
+		signature, signatureErr := base64.RawURLEncoding.DecodeString(request.Header.Get(agentRequestSignatureHeader))
+		if queryErr != nil || canonicalErr != nil || signatureErr != nil || agentID != "agent-a" || keyID != "agent-key-a" || !ed25519.Verify(publicKey, canonical, signature) {
+			t.Errorf("invalid authenticated request for %s", request.URL.String())
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		seen[request.URL.Path]++
+		switch request.URL.Path {
+		case "/v1/fleet/commands":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"commands":[]}`))
+		case "/v1/fleet/state/mutations":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"mutations":[]}`))
+		case "/v1/trust-current":
+			writer.WriteHeader(http.StatusNotFound)
+		default:
+			writer.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.ConfigureAgentRequestSigning("agent-a", "agent-key-a", privateKey); err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	if _, _, err := client.CurrentTrust(ctx, "tenant-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := client.Candidate(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := client.CurrentPolicy(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := client.CurrentMandateBundle(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FleetCommands(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := client.FleetStateSnapshot(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FleetStateMutations(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := client.FleetControl(ctx, "tenant-a", "agent-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{
+		"/v1/trust-current", "/v1/policy-candidate", "/v1/policy-current", "/v1/mandates-current",
+		"/v1/fleet/commands", "/v1/fleet/state/current", "/v1/fleet/state/mutations", "/v1/fleet/control",
+	} {
+		if seen[path] != 1 {
+			t.Errorf("%s signed requests = %d", path, seen[path])
+		}
+	}
+}

--- a/internal/managedsdk/authorityhttp/client.go
+++ b/internal/managedsdk/authorityhttp/client.go
@@ -22,8 +22,9 @@ import (
 )
 
 type Client struct {
-	endpoint   *url.URL
-	httpClient *http.Client
+	endpoint           *url.URL
+	httpClient         *http.Client
+	agentRequestSigner *AgentRequestSigner
 }
 
 // TrustPublicationResult is the durable identity returned after the authority
@@ -116,6 +117,9 @@ func (client *Client) Candidate(ctx context.Context, tenantID, agentID string) (
 		return PublicationEnvelope{}, false, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return PublicationEnvelope{}, false, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return PublicationEnvelope{}, false, fmt.Errorf("authorityhttp: candidate: %w", err)
@@ -150,11 +154,20 @@ func (client *Client) CurrentTrust(ctx context.Context, tenantID string) (author
 	if !clientIdentifier(tenantID) {
 		return authority.TrustBundle{}, false, fmt.Errorf("authorityhttp: tenant identifier is required")
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.route("/v1/trust-current", url.Values{"tenant_id": {tenantID}}), nil)
+	query := url.Values{"tenant_id": {tenantID}}
+	if client.agentRequestSigner != nil {
+		query.Set("agent_id", client.agentRequestSigner.agentID)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.route("/v1/trust-current", query), nil)
 	if err != nil {
 		return authority.TrustBundle{}, false, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if client.agentRequestSigner != nil {
+		if err := client.signAgentRequest(request, tenantID, client.agentRequestSigner.agentID); err != nil {
+			return authority.TrustBundle{}, false, err
+		}
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return authority.TrustBundle{}, false, fmt.Errorf("authorityhttp: current trust: %w", err)
@@ -191,6 +204,9 @@ func (client *Client) CurrentPolicy(ctx context.Context, tenantID, agentID strin
 		return ActivePolicyEnvelope{}, false, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return ActivePolicyEnvelope{}, false, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return ActivePolicyEnvelope{}, false, fmt.Errorf("authorityhttp: current policy: %w", err)
@@ -233,6 +249,9 @@ func (client *Client) CurrentMandateBundle(ctx context.Context, tenantID, agentI
 		return decision.MandateBundle{}, false, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return decision.MandateBundle{}, false, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return decision.MandateBundle{}, false, fmt.Errorf("authorityhttp: current mandates: %w", err)

--- a/internal/managedsdk/authorityhttp/fleet_client.go
+++ b/internal/managedsdk/authorityhttp/fleet_client.go
@@ -28,6 +28,9 @@ func (client *Client) FleetCommands(ctx context.Context, tenantID, agentID strin
 		return nil, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return nil, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("authorityhttp: fleet commands: %w", err)
@@ -94,6 +97,9 @@ func (client *Client) FleetStateSnapshot(ctx context.Context, tenantID, agentID 
 		return authority.FleetStateSnapshot{}, false, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return authority.FleetStateSnapshot{}, false, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return authority.FleetStateSnapshot{}, false, fmt.Errorf("authorityhttp: fleet state snapshot: %w", err)
@@ -124,6 +130,9 @@ func (client *Client) FleetStateMutations(ctx context.Context, tenantID, agentID
 		return nil, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return nil, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("authorityhttp: fleet state mutations: %w", err)
@@ -165,6 +174,9 @@ func (client *Client) FleetControl(ctx context.Context, tenantID, agentID string
 		return authority.FleetNodeControl{}, false, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if err := client.signAgentRequest(request, tenantID, agentID); err != nil {
+		return authority.FleetNodeControl{}, false, err
+	}
 	response, err := client.httpClient.Do(request)
 	if err != nil {
 		return authority.FleetNodeControl{}, false, fmt.Errorf("authorityhttp: fleet control: %w", err)

--- a/internal/managedsdk/decisionhttp/client.go
+++ b/internal/managedsdk/decisionhttp/client.go
@@ -30,10 +30,13 @@ const (
 )
 
 type Client struct {
-	endpoint         *url.URL
-	httpClient       *http.Client
-	maxResponseBytes int64
-	bearerToken      string
+	endpoint                   *url.URL
+	httpClient                 *http.Client
+	maxResponseBytes           int64
+	bearerToken                string
+	workflowTenantID           string
+	workflowAgentID            string
+	workflowAgentRequestSigner func(*http.Request, string, string) error
 }
 
 // AuthorizationRequest is the additive authorization wire envelope for a

--- a/internal/managedsdk/decisionhttp/workflow_client.go
+++ b/internal/managedsdk/decisionhttp/workflow_client.go
@@ -93,7 +93,7 @@ func (client *Client) ExecuteWorkflow(ctx context.Context, transactionID string,
 }
 
 func (client *Client) WorkflowStatus(ctx context.Context, transactionID string) (WorkflowRecord, error) {
-	return client.workflowStatus(ctx, "/v1/workflow-status", transactionID)
+	return client.workflowStatus(ctx, "/v1/workflow-status", transactionID, true)
 }
 
 // ManagementWorkflowStatus returns a workflow record through the separately
@@ -101,7 +101,20 @@ func (client *Client) WorkflowStatus(ctx context.Context, transactionID string) 
 // authority's management mTLS identity; it does not grant an uncredentialed
 // caller any management authority itself.
 func (client *Client) ManagementWorkflowStatus(ctx context.Context, transactionID string) (WorkflowRecord, error) {
-	return client.workflowStatus(ctx, "/v1/manage/workflow-status", transactionID)
+	return client.workflowStatus(ctx, "/v1/manage/workflow-status", transactionID, false)
+}
+
+// ConfigureWorkflowAgentRequestSigning authenticates participant status reads
+// without changing the already signed workflow mutation envelopes. Configure
+// the client before concurrent use.
+func (client *Client) ConfigureWorkflowAgentRequestSigning(tenantID, agentID string, signer func(*http.Request, string, string) error) error {
+	if client == nil || !validWorkflowClientIdentifier(tenantID) || !validWorkflowClientIdentifier(agentID) || signer == nil {
+		return fmt.Errorf("decisionhttp: invalid workflow agent request signing configuration")
+	}
+	client.workflowTenantID = tenantID
+	client.workflowAgentID = agentID
+	client.workflowAgentRequestSigner = signer
+	return nil
 }
 
 // ManagementWorkflows retrieves a bounded tenant-scoped list through the
@@ -144,7 +157,7 @@ func (client *Client) ManagementWorkflows(ctx context.Context, tenantID string, 
 	return append([]WorkflowRecord(nil), response.Workflows...), nil
 }
 
-func (client *Client) workflowStatus(ctx context.Context, path, transactionID string) (WorkflowRecord, error) {
+func (client *Client) workflowStatus(ctx context.Context, path, transactionID string, agentEndpoint bool) (WorkflowRecord, error) {
 	if client == nil || client.endpoint == nil || client.httpClient == nil {
 		return WorkflowRecord{}, fmt.Errorf("decisionhttp: client is not initialized")
 	}
@@ -155,12 +168,21 @@ func (client *Client) workflowStatus(ctx context.Context, path, transactionID st
 	endpoint.Path = path
 	query := url.Values{}
 	query.Set("transaction_id", transactionID)
+	if agentEndpoint && client.workflowAgentRequestSigner != nil {
+		query.Set("tenant_id", client.workflowTenantID)
+		query.Set("agent_id", client.workflowAgentID)
+	}
 	endpoint.RawQuery = query.Encode()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return WorkflowRecord{}, err
 	}
 	request.Header.Set("Accept", "application/json")
+	if agentEndpoint && client.workflowAgentRequestSigner != nil {
+		if err := client.workflowAgentRequestSigner(request, client.workflowTenantID, client.workflowAgentID); err != nil {
+			return WorkflowRecord{}, err
+		}
+	}
 	var record WorkflowRecord
 	if err := client.workflowResponse(request, &record); err != nil {
 		return WorkflowRecord{}, err
@@ -169,6 +191,19 @@ func (client *Client) workflowStatus(ctx context.Context, path, transactionID st
 		return WorkflowRecord{}, fmt.Errorf("decisionhttp: invalid workflow record: %w", err)
 	}
 	return record, nil
+}
+
+func validWorkflowClientIdentifier(value string) bool {
+	if len(value) == 0 || len(value) > 128 {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '-' || character == '_' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // CancelWorkflow requests an authority-signed terminal cancellation through

--- a/internal/managedsdk/decisionhttp/workflow_client_test.go
+++ b/internal/managedsdk/decisionhttp/workflow_client_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package decisionhttp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWorkflowStatusUsesConfiguredAgentRequestSigner(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Query().Get("tenant_id") != "tenant-a" || request.URL.Query().Get("agent_id") != "agent-a" || request.Header.Get("X-Test-Agent-Signature") != "present" {
+			t.Errorf("unbound status request: %s headers=%v", request.URL.String(), request.Header)
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	client, err := New(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	if err := client.ConfigureWorkflowAgentRequestSigning("tenant-a", "agent-a", func(request *http.Request, tenantID, agentID string) error {
+		called = true
+		if tenantID != "tenant-a" || agentID != "agent-a" {
+			t.Fatalf("signer identity = %s/%s", tenantID, agentID)
+		}
+		request.Header.Set("X-Test-Agent-Signature", "present")
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = client.WorkflowStatus(context.Background(), "transaction-a")
+	if !called {
+		t.Fatal("configured workflow status signer was not called")
+	}
+}


### PR DESCRIPTION
## Summary
- sign policy, trust, mandate, fleet, and approval-status reads with the enrolled node's delegated Ed25519 key
- bind each signature to method, path, canonical query, tenant, agent, key, timestamp, nonce, and body digest
- configure managed runtimes automatically while preserving unmanaged/local operation
- cover every confidential route and the workflow-status signer in tests

## Verification
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -race ./internal/managedsdk/authorityhttp ./internal/managedsdk/decisionhttp ./internal/enterprisecontrol`